### PR TITLE
fix: select item style

### DIFF
--- a/example/lib/api/avatar.0.dart
+++ b/example/lib/api/avatar.0.dart
@@ -4,11 +4,11 @@ import 'package:remix/remix.dart';
 // Inspired by gov.br design system
 // https://www.gov.br/ds/components/avatar?tab=desenvolvedor
 
-
 void main() {
   runApp(
     const MaterialApp(
       home: Scaffold(
+        backgroundColor: Colors.white,
         body: AvatarExample(),
       ),
     ),

--- a/example/lib/api/badge.0.dart
+++ b/example/lib/api/badge.0.dart
@@ -8,6 +8,7 @@ void main() {
   runApp(
     const MaterialApp(
       home: Scaffold(
+        backgroundColor: Colors.white,
         body: BadgeExample(),
       ),
     ),

--- a/example/lib/api/card.0.dart
+++ b/example/lib/api/card.0.dart
@@ -8,6 +8,7 @@ void main() {
   runApp(
     const MaterialApp(
       home: Scaffold(
+        backgroundColor: Colors.white,
         body: CardExample(),
       ),
     ),

--- a/example/lib/api/checkbox.0.dart
+++ b/example/lib/api/checkbox.0.dart
@@ -8,6 +8,7 @@ void main() {
   runApp(
     const MaterialApp(
       home: Scaffold(
+        backgroundColor: Colors.white,
         body: CheckboxExample(),
       ),
     ),

--- a/example/lib/api/divider.0.dart
+++ b/example/lib/api/divider.0.dart
@@ -8,6 +8,7 @@ void main() {
   runApp(
     const MaterialApp(
       home: Scaffold(
+        backgroundColor: Colors.white,
         body: DividerExample(),
       ),
     ),

--- a/example/lib/api/menu.0.dart
+++ b/example/lib/api/menu.0.dart
@@ -92,29 +92,32 @@ class _MenuExampleState extends State<MenuExample> {
   RemixMenuStyle get menuStyle {
     return RemixMenuStyle()
         .trigger(
-          RemixMenuTriggerStyle(
-            container: FlexBoxStyler(
-              padding: EdgeInsetsMix.symmetric(horizontal: 14),
-              decoration: BoxDecorationMix(
-                color: Colors.white,
-                borderRadius: BorderRadiusMix.all(const Radius.circular(12)),
-                border: BorderMix.all(
-                  BorderSideMix(color: Colors.blueGrey.shade100),
-                ),
-                boxShadow: [
+          RemixMenuTriggerStyle()
+              .padding(EdgeInsetsMix.symmetric(horizontal: 14))
+              .decoration(
+                BoxDecorationMix()
+                    .color(Colors.white)
+                    .borderRadius(
+                        BorderRadiusMix.all(const Radius.circular(12)))
+                    .border(BorderMix.all(
+                        BorderSideMix(color: Colors.blueGrey.shade100)))
+                    .boxShadow([
                   BoxShadowMix(
                     color: Colors.blueGrey.withValues(alpha: 0.1),
                     blurRadius: 3,
                     offset: const Offset(0, 3),
                   ),
-                ],
+                ]),
+              )
+              .constraints(BoxConstraintsMix(minHeight: 40))
+              .label(
+                TextStyler()
+                    .color(Colors.blueGrey.shade700)
+                    .fontWeight(FontWeight.w400),
+              )
+              .onHovered(
+                RemixMenuTriggerStyle().color(Colors.red),
               ),
-              constraints: BoxConstraintsMix(minHeight: 40),
-            ),
-            label: TextStyler()
-                .color(Colors.blueGrey.shade700)
-                .fontWeight(FontWeight.w400),
-          ),
         )
         .overlay(
           FlexBoxStyler(

--- a/example/lib/api/menu.0.dart
+++ b/example/lib/api/menu.0.dart
@@ -39,22 +39,32 @@ class _MenuExampleState extends State<MenuExample> {
           // RemixMenu
           RemixMenu<String>(
             trigger: const RemixMenuTrigger(label: 'Open Remix Menu'),
-            items: const [
+            items: [
               RemixMenuItem(
                 value: 'History',
                 leadingIcon: Icons.history,
                 label: 'History',
+                style: menuItemStyle,
               ),
               RemixMenuItem(
                 value: 'Settings',
                 leadingIcon: Icons.settings,
                 label: 'Settings',
+                style: menuItemStyle,
               ),
-              RemixMenuDivider(),
+              const RemixMenuDivider(),
               RemixMenuItem(
                 value: 'Logout',
                 leadingIcon: Icons.logout,
                 label: 'Logout',
+                style: menuItemStyle.onHovered(
+                  RemixMenuItemStyle()
+                      .color(Colors.redAccent.withValues(alpha: 0.05))
+                      .label(
+                        TextStyler().color(Colors.redAccent),
+                      )
+                      .leadingIcon(IconStyler().color(Colors.redAccent)),
+                ),
               ),
             ],
             positioning: const OverlayPositionConfig(
@@ -138,7 +148,6 @@ class _MenuExampleState extends State<MenuExample> {
             ),
           ),
         )
-        .item(menuItemStyle)
         .divider(
           RemixDividerStyle()
               .color(Colors.blueGrey.shade100)

--- a/example/lib/api/select.0.dart
+++ b/example/lib/api/select.0.dart
@@ -5,7 +5,7 @@ void main() {
   runApp(
     const MaterialApp(
       home: Scaffold(
-        backgroundColor: Colors.white,
+        backgroundColor: Color(0xFFECEFEB),
         body: SelectExample(),
       ),
     ),
@@ -25,19 +25,64 @@ class _SelectExampleState extends State<SelectExample> {
   @override
   Widget build(BuildContext context) {
     return Center(
-      child: RemixSelect(
-        trigger: const RemixSelectTrigger(placeholder: 'Select an option'),
-        items: const [
-          RemixSelectItem(value: 'option1', label: 'Option 1'),
-          RemixSelectItem(value: 'option2', label: 'Option 2'),
-        ],
-        selectedValue: _selectedValue,
-        onChanged: (value) {
-          setState(() {
-            _selectedValue = value;
-          });
-        },
+      child: SizedBox(
+        width: 200,
+        child: RemixSelect(
+          trigger: const RemixSelectTrigger(placeholder: 'Text Value'),
+          items: [
+            RemixSelectItem(
+              value: 'option1',
+              label: 'Option 1',
+              enabled: true,
+              style: itemStyle,
+            ),
+            RemixSelectItem(
+              value: 'option2',
+              label: 'Option 2',
+              enabled: false,
+              style: itemStyle,
+            ),
+          ],
+          selectedValue: _selectedValue,
+          style: style,
+          onChanged: (value) {
+            setState(() {
+              _selectedValue = value;
+            });
+          },
+        ),
       ),
     );
+  }
+
+  RemixSelectMenuItemStyle get itemStyle {
+    return RemixSelectMenuItemStyle()
+        .iconSize(16)
+        .paddingAll(8)
+        .borderRadiusAll(const Radius.circular(8))
+        .onHovered(RemixSelectMenuItemStyle().color(Colors.blueGrey.shade50))
+        .onDisabled(
+          RemixSelectMenuItemStyle().labelColor(Colors.grey.shade300),
+        );
+  }
+
+  RemixSelectStyle get style {
+    return RemixSelectStyle()
+        .trigger(
+          RemixSelectTriggerStyle()
+              .color(Colors.transparent)
+              .borderAll(color: const Color(0xFF898988))
+              .paddingY(10)
+              .paddingX(12)
+              .borderRadiusAll(const Radius.circular(12)),
+        )
+        .menuContainer(
+          FlexBoxStyler()
+              .width(200)
+              .marginY(5)
+              .paddingAll(6)
+              .color(Colors.white)
+              .borderRadiusAll(const Radius.circular(12)),
+        );
   }
 }

--- a/example/lib/api/slider.0.dart
+++ b/example/lib/api/slider.0.dart
@@ -54,8 +54,8 @@ class _SliderExampleState extends State<SliderExample> {
                     .offset(const Offset(0, 2)),
               ),
         )
-        .thumbColor(Colors.white)
-        .thickness(12)
+        .thumbColor(Colors.black)
+        .thickness(2)
         .trackColor(Colors.grey.shade300)
         .rangeColor(Colors.black)
         .onDisabled(

--- a/lib/src/components/menu/menu_widget.dart
+++ b/lib/src/components/menu/menu_widget.dart
@@ -54,6 +54,9 @@ final class RemixMenuItem<T> extends RemixMenuItemData<T> {
   /// Semantic label for accessibility.
   final String? semanticLabel;
 
+  /// The style for the menu item.
+  final RemixMenuItemStyle style;
+
   const RemixMenuItem({
     required this.value,
     this.label,
@@ -62,6 +65,7 @@ final class RemixMenuItem<T> extends RemixMenuItemData<T> {
     this.enabled = true,
     this.closeOnActivate = true,
     this.semanticLabel,
+    this.style = const RemixMenuItemStyle.create(),
   }) : assert(label != null, 'Must provide label for menu item');
 }
 
@@ -198,10 +202,7 @@ class RemixMenu<T> extends StatelessWidget {
               children: items.map((item) {
                 // Pattern matching ensures exhaustiveness
                 return switch (item) {
-                  RemixMenuItem<T>() => _RemixMenuItemWidget<T>(
-                      data: item,
-                      styleSpec: spec.item,
-                    ),
+                  RemixMenuItem<T>() => _RemixMenuItemWidget<T>(data: item),
                   RemixMenuDivider<T>() =>
                     RemixDivider(styleSpec: spec.divider),
                 };
@@ -254,15 +255,12 @@ class RemixMenu<T> extends StatelessWidget {
 ///
 /// Receives styling directly from parent [RemixMenu] via styleSpec parameter.
 class _RemixMenuItemWidget<T> extends StatelessWidget {
-  const _RemixMenuItemWidget({required this.data, required this.styleSpec});
+  const _RemixMenuItemWidget({required this.data});
 
   final RemixMenuItem<T> data;
-  final StyleSpec<RemixMenuItemSpec> styleSpec;
 
   @override
   Widget build(BuildContext context) {
-    final itemSpec = styleSpec.spec;
-
     return NakedMenuItem<T>(
       value: data.value,
       enabled: data.enabled,
@@ -270,22 +268,28 @@ class _RemixMenuItemWidget<T> extends StatelessWidget {
       closeOnActivate: data.closeOnActivate,
       builder: (context, state, _) {
         // Render item with label and icons
-        return FlexBox(
-          styleSpec: itemSpec.container,
-          children: [
-            if (data.leadingIcon != null)
-              StyledIcon(
-                icon: data.leadingIcon!,
-                styleSpec: itemSpec.leadingIcon,
-              ),
-            if (data.label != null)
-              StyledText(data.label!, styleSpec: itemSpec.label),
-            if (data.trailingIcon != null)
-              StyledIcon(
-                icon: data.trailingIcon!,
-                styleSpec: itemSpec.trailingIcon,
-              ),
-          ],
+        return StyleBuilder(
+          style: data.style,
+          controller: NakedState.controllerOf(context),
+          builder: (context, spec) {
+            return FlexBox(
+              styleSpec: spec.container,
+              children: [
+                if (data.leadingIcon != null)
+                  StyledIcon(
+                    icon: data.leadingIcon!,
+                    styleSpec: spec.leadingIcon,
+                  ),
+                if (data.label != null)
+                  StyledText(data.label!, styleSpec: spec.label),
+                if (data.trailingIcon != null)
+                  StyledIcon(
+                    icon: data.trailingIcon!,
+                    styleSpec: spec.trailingIcon,
+                  ),
+              ],
+            );
+          },
         );
       },
     );

--- a/lib/src/components/select/radix_select_styles.dart
+++ b/lib/src/components/select/radix_select_styles.dart
@@ -131,44 +131,44 @@ class FortalSelectStyles {
   // Content (menu) variants
 
   static RemixSelectStyle contentSolid() {
-    return RemixSelectStyle()
-        .menuContainer(
-          FlexBoxStyler()
-              .color(FortalTokens.colorPanelSolid())
-              .borderAll(
-                color: FortalTokens.gray6(),
-                width: FortalTokens.borderWidth1(),
-              )
-              .borderRadiusAll(FortalTokens.radius3())
-              .padding(EdgeInsetsMix.all(8.0)),
-        )
-        .item(
-          RemixSelectMenuItemStyle()
-              .paddingX(8.0)
-              .height(24.0)
-              .text(TextStyler().color(FortalTokens.gray12()))
-              .icon(IconStyler(size: 20.0)),
-        );
+    return RemixSelectStyle().menuContainer(
+      FlexBoxStyler()
+          .color(FortalTokens.colorPanelSolid())
+          .borderAll(
+            color: FortalTokens.gray6(),
+            width: FortalTokens.borderWidth1(),
+          )
+          .borderRadiusAll(FortalTokens.radius3())
+          .padding(EdgeInsetsMix.all(8.0)),
+    );
+  }
+
+  static RemixSelectMenuItemStyle itemSolid() {
+    return RemixSelectMenuItemStyle()
+        .paddingX(8.0)
+        .height(24.0)
+        .text(TextStyler().color(FortalTokens.gray12()))
+        .icon(IconStyler(size: 20.0));
   }
 
   static RemixSelectStyle contentSoft() {
-    return RemixSelectStyle()
-        .menuContainer(
-          FlexBoxStyler()
-              .color(FortalTokens.colorPanelTranslucent())
-              .borderAll(
-                color: FortalTokens.gray6(),
-                width: FortalTokens.borderWidth1(),
-              )
-              .borderRadiusAll(FortalTokens.radius3())
-              .padding(EdgeInsetsMix.all(8.0)),
-        )
-        .item(
-          RemixSelectMenuItemStyle()
-              .paddingX(8.0)
-              .height(24.0)
-              .text(TextStyler().color(FortalTokens.gray12()))
-              .icon(IconStyler(size: 20.0)),
-        );
+    return RemixSelectStyle().menuContainer(
+      FlexBoxStyler()
+          .color(FortalTokens.colorPanelTranslucent())
+          .borderAll(
+            color: FortalTokens.gray6(),
+            width: FortalTokens.borderWidth1(),
+          )
+          .borderRadiusAll(FortalTokens.radius3())
+          .padding(EdgeInsetsMix.all(8.0)),
+    );
+  }
+
+  static RemixSelectMenuItemStyle itemSoft() {
+    return RemixSelectMenuItemStyle()
+        .paddingX(8.0)
+        .height(24.0)
+        .text(TextStyler().color(FortalTokens.gray12()))
+        .icon(IconStyler(size: 20.0));
   }
 }

--- a/lib/src/components/select/select_style.dart
+++ b/lib/src/components/select/select_style.dart
@@ -3,26 +3,22 @@ part of 'select.dart';
 class RemixSelectStyle extends RemixStyle<RemixSelectSpec, RemixSelectStyle> {
   final Prop<StyleSpec<FlexBoxSpec>>? $menuContainer;
   final Prop<StyleSpec<RemixSelectTriggerSpec>>? $trigger;
-  final Prop<StyleSpec<RemixSelectMenuItemSpec>>? $item;
   final Prop<StyleSpec<RemixCompositedTransformFollowerSpec>>? $position;
 
   const RemixSelectStyle.create({
     Prop<StyleSpec<FlexBoxSpec>>? menuContainer,
     Prop<StyleSpec<RemixSelectTriggerSpec>>? trigger,
-    Prop<StyleSpec<RemixSelectMenuItemSpec>>? item,
     Prop<StyleSpec<RemixCompositedTransformFollowerSpec>>? position,
     super.variants,
     super.animation,
     super.modifier,
   })  : $menuContainer = menuContainer,
         $trigger = trigger,
-        $item = item,
         $position = position;
 
   RemixSelectStyle({
     FlexBoxStyler? menuContainer,
     RemixSelectTriggerStyle? trigger,
-    RemixSelectMenuItemStyle? item,
     RemixCompositedTransformFollowerStyle? position,
     AnimationConfig? animation,
     List<VariantStyle<RemixSelectSpec>>? variants,
@@ -30,7 +26,6 @@ class RemixSelectStyle extends RemixStyle<RemixSelectSpec, RemixSelectStyle> {
   }) : this.create(
           menuContainer: Prop.maybeMix(menuContainer),
           trigger: Prop.maybeMix(trigger),
-          item: Prop.maybeMix(item),
           position: Prop.maybeMix(position),
           variants: variants,
           animation: animation,
@@ -45,11 +40,6 @@ class RemixSelectStyle extends RemixStyle<RemixSelectSpec, RemixSelectStyle> {
   /// Sets trigger styling
   RemixSelectStyle trigger(RemixSelectTriggerStyle value) {
     return merge(RemixSelectStyle(trigger: value));
-  }
-
-  /// Sets menu item styling
-  RemixSelectStyle item(RemixSelectMenuItemStyle value) {
-    return merge(RemixSelectStyle(item: value));
   }
 
   /// Sets follower position styling
@@ -112,7 +102,8 @@ class RemixSelectStyle extends RemixStyle<RemixSelectSpec, RemixSelectStyle> {
     AlignmentGeometry alignment = Alignment.center,
   }) {
     return merge(RemixSelectStyle(
-      menuContainer: FlexBoxStyler(transform: value, transformAlignment: alignment),
+      menuContainer:
+          FlexBoxStyler(transform: value, transformAlignment: alignment),
     ));
   }
 
@@ -137,7 +128,6 @@ class RemixSelectStyle extends RemixStyle<RemixSelectSpec, RemixSelectStyle> {
       spec: RemixSelectSpec(
         trigger: MixOps.resolve(context, $trigger),
         menuContainer: MixOps.resolve(context, $menuContainer),
-        item: MixOps.resolve(context, $item),
         position: MixOps.resolve(context, $position),
       ),
       animation: $animation,
@@ -152,7 +142,6 @@ class RemixSelectStyle extends RemixStyle<RemixSelectSpec, RemixSelectStyle> {
     return RemixSelectStyle.create(
       menuContainer: MixOps.merge($menuContainer, other.$menuContainer),
       trigger: MixOps.merge($trigger, other.$trigger),
-      item: MixOps.merge($item, other.$item),
       position: MixOps.merge($position, other.$position),
       variants: MixOps.mergeVariants($variants, other.$variants),
       animation: MixOps.mergeAnimation($animation, other.$animation),
@@ -164,7 +153,6 @@ class RemixSelectStyle extends RemixStyle<RemixSelectSpec, RemixSelectStyle> {
   List<Object?> get props => [
         $menuContainer,
         $trigger,
-        $item,
         $position,
         $variants,
         $animation,

--- a/lib/src/components/select/select_widget.dart
+++ b/lib/src/components/select/select_widget.dart
@@ -33,6 +33,9 @@ class RemixSelectItem<T> {
   /// Whether this option can be selected.
   final bool enabled;
 
+  /// The style for the item.
+  final RemixSelectMenuItemStyle style;
+
   /// Semantic label for accessibility.
   final String? semanticLabel;
 
@@ -40,6 +43,7 @@ class RemixSelectItem<T> {
     required this.value,
     required this.label,
     this.enabled = true,
+    this.style = const RemixSelectMenuItemStyle.create(),
     this.semanticLabel,
   });
 }
@@ -151,10 +155,7 @@ class _RemixSelectState<T> extends State<RemixSelect<T>>
       curve: Curves.easeInOut,
       menuContainer: spec.menuContainer,
       children: widget.items
-          .map((item) => _RemixSelectItemWidget<T>(
-                data: item,
-                styleSpec: spec.item,
-              ))
+          .map((item) => _RemixSelectItemWidget<T>(data: item))
           .toList(),
     );
   }
@@ -321,13 +322,9 @@ class _RemixSelectTriggerWidget extends StatelessWidget {
 
 /// Internal widget for rendering a selectable item.
 class _RemixSelectItemWidget<T> extends StatelessWidget {
-  const _RemixSelectItemWidget({
-    required this.data,
-    required this.styleSpec,
-  });
+  const _RemixSelectItemWidget({required this.data});
 
   final RemixSelectItem<T> data;
-  final StyleSpec<RemixSelectMenuItemSpec> styleSpec;
 
   @override
   Widget build(BuildContext context) {
@@ -336,18 +333,24 @@ class _RemixSelectItemWidget<T> extends StatelessWidget {
       semanticLabel: data.semanticLabel ?? data.label,
       value: data.value,
       builder: (context, states, _) {
-        return StyleSpecBuilder<RemixSelectMenuItemSpec>(
-          styleSpec: styleSpec,
+        return StyleBuilder(
+          style: data.style,
+          controller: NakedState.controllerOf(context),
           builder: (context, spec) {
-            return RowBox(
-              styleSpec: spec.container,
-              children: [
-                Expanded(
-                  child: StyledText(data.label, styleSpec: spec.text),
-                ),
-                if (states.isSelected)
-                  StyledIcon(icon: Icons.check, styleSpec: spec.icon),
-              ],
+            return StyleSpecBuilder<RemixSelectMenuItemSpec>(
+              styleSpec: StyleSpec(spec: spec),
+              builder: (context, spec) {
+                return RowBox(
+                  styleSpec: spec.container,
+                  children: [
+                    Expanded(
+                      child: StyledText(data.label, styleSpec: spec.text),
+                    ),
+                    if (states.isSelected)
+                      StyledIcon(icon: Icons.check, styleSpec: spec.icon),
+                  ],
+                );
+              },
             );
           },
         );


### PR DESCRIPTION
## Description

Refactored select style classes to separate menu and item styles, removing the item property from `RemixSelectStyle`. Updated `FortalSelectStyles` to provide item styles as separate methods. Enhanced `RemixSelectItem` to accept a custom style, and updated the select widget to use per-item styles. Improved select example to demonstrate new styling capabilities and updated background colors for consistency.

---

## Checklist

**Note**: Updating the `pubspec.yaml` and `CHANGELOG.md` is not required. These are handled automatically during the release process.

- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors.
- [x] I have updated or added relevant documentation (doc comments with `///`).
- [x] I am prepared to follow up on review comments in a timely manner.

## Breaking Change

Does this PR require users of the package to manually update their code?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.