### PR TITLE
refactor: Update textfield styles and naked_ui dependency

### DIFF
--- a/demo/pubspec.yaml
+++ b/demo/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
     path: ../
     
   mix: 2.0.0-dev.5
+  naked_ui: 0.2.0-beta.7
 
 dev_dependencies:
   flutter_test:

--- a/example/lib/api/textfield.0.dart
+++ b/example/lib/api/textfield.0.dart
@@ -42,7 +42,7 @@ class _TextfieldExampleState extends State<TextfieldExample> {
 
   RemixTextFieldStyle get style {
     return RemixTextFieldStyle()
-        .color(Colors.blue)
+        .color(Colors.grey.shade800)
         .backgroundColor(Colors.white)
         .borderRadiusAll(const Radius.circular(8.0))
         .height(44)
@@ -61,9 +61,9 @@ class _TextfieldExampleState extends State<TextfieldExample> {
         .hintColor(Colors.blueGrey.shade500)
         .shadow(
           BoxShadowMix()
-              .blurRadius(4)
+              .blurRadius(1)
               .color(Colors.black12)
-              .offset(const Offset(0, 2)),
+              .offset(const Offset(0, 1)),
         )
         .border(
           BoxBorderMix.all(BorderSideMix(color: Colors.grey.shade300)),

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
     path: ../
     
   mix: 2.0.0-dev.5
-  naked_ui: 0.2.0-beta.6
+  naked_ui: 0.2.0-beta.7
 
 dev_dependencies:
   flutter_test:

--- a/lib/src/components/textfield/fortal_textfield_styles.dart
+++ b/lib/src/components/textfield/fortal_textfield_styles.dart
@@ -73,12 +73,12 @@ class FortalTextFieldStyles {
                 .fontWeight(FortalTokens.fontWeightMedium()),
           ),
         )
-        .color(FortalTokens.colorSurface())
         .borderAll(
           color: FortalTokens.gray7(),
           width: FortalTokens.borderWidth1(),
           strokeAlign: BorderSide.strokeAlignOutside,
         )
+        .color(FortalTokens.gray12())
         // Override focus for surface variant (different border color)
         .onFocused(
           RemixTextFieldStyle().borderAll(
@@ -106,7 +106,7 @@ class FortalTextFieldStyles {
         .merge(
           RemixTextFieldStyle(
             text: TextStyler()
-                .color(Colors.red)
+                // .color(Colors.red)
                 .fontWeight(FortalTokens.fontWeightRegular()),
             hintText: TextStyler()
                 .color(FortalTokens.accentA11())
@@ -120,6 +120,7 @@ class FortalTextFieldStyles {
                 .fontWeight(FortalTokens.fontWeightMedium()),
           ),
         )
+        .color(FortalTokens.accent12())
         .wrapIconTheme(IconThemeData(color: FortalTokens.accent10()))
         .backgroundColor(FortalTokens.accent3())
         .borderAll(

--- a/lib/src/components/textfield/textfield_widget.dart
+++ b/lib/src/components/textfield/textfield_widget.dart
@@ -310,7 +310,6 @@ class RemixTextField extends StatelessWidget {
       canRequestFocus: canRequestFocus,
       spellCheckConfiguration: spellCheckConfiguration,
       magnifierConfiguration: magnifierConfiguration,
-      // style: const TextStyle(), // Will be applied in StyleBuilder
       semanticLabel: semanticLabel ?? label,
       semanticHint: semanticHint ?? hintText,
       builder: (BuildContext context, state, Widget editableText) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -406,10 +406,10 @@ packages:
     dependency: "direct main"
     description:
       name: naked_ui
-      sha256: e2b1bfb455df200914af14e8cf83d0a63bcf4c8f3ec7f5bf7f2206a54b88b6be
+      sha256: "7c908f67a5b37d6434183bf261d0adc9cd53a52b62e58dca6f1e2e78929b29f7"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0-beta.6"
+    version: "0.2.0-beta.7"
   package_config:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   flutter:
     sdk: flutter
   mix: ^2.0.0-dev.5
-  naked_ui: ^0.2.0-beta.6
+  naked_ui: ^0.2.0-beta.7
   meta: ^1.15.0
   prism: ^2.0.0
   prism_flutter: ^2.0.0


### PR DESCRIPTION


## Description

Refined textfield color and shadow styles in the example and FortalTextFieldStyles. Updated naked_ui dependency to 0.2.0-beta.7 in all relevant pubspec files. Minor code cleanup in textfield_widget.dart.

## Related Issues

*Link to any relevant issues that this PR addresses. For example: `Closes #456`.*

---

## Checklist

**Note**: Updating the `pubspec.yaml` and `CHANGELOG.md` is not required. These are handled automatically during the release process.

- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors.
- [ ] I have updated or added relevant documentation (doc comments with `///`).
- [ ] I am prepared to follow up on review comments in a timely manner.

## Breaking Change

Does this PR require users of the package to manually update their code?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.