### PR TITLE
feat: Add leading and trailing icon support to RemixButton

### DIFF
--- a/packages/demo/lib/components/button.dart
+++ b/packages/demo/lib/components/button.dart
@@ -37,9 +37,13 @@ Widget buildButtonUseCase(BuildContext context) {
           enabled: context.knobs.boolean(label: 'Enabled', initialValue: true),
           loading: context.knobs.boolean(label: 'Loading', initialValue: false),
           label: context.knobs.string(label: 'label', initialValue: 'Press Me'),
-          icon: context.knobs.iconData(
-            label: 'Icon',
-            initialValue: Icons.touch_app,
+          leadingIcon: context.knobs.iconData(
+            label: 'Leading Icon',
+            initialValue: null,
+          ),
+          trailingIcon: context.knobs.iconData(
+            label: 'Trailing Icon',
+            initialValue: null,
           ),
           style: FortalButtonStyle.create(
             variant: context.knobs.object.dropdown(

--- a/packages/demo/lib/previews/button_preview.dart
+++ b/packages/demo/lib/previews/button_preview.dart
@@ -17,13 +17,13 @@ Widget previewBasicButtons() {
         SizedBox(height: 12),
         RemixButton(
           label: 'Button with Icon',
-          icon: Icons.star,
+          leadingIcon: Icons.star,
           onPressed: null,
         ),
         SizedBox(height: 12),
         RemixButton(
           label: 'Trailing Icon',
-          icon: Icons.arrow_forward,
+          trailingIcon: Icons.arrow_forward,
           onPressed: null,
         ),
       ],
@@ -55,7 +55,7 @@ Widget previewButtonStates() {
         SizedBox(height: 12),
         RemixButton(
           label: 'Icon Loading',
-          icon: Icons.download,
+          leadingIcon: Icons.download,
           loading: true,
           onPressed: null,
         ),
@@ -105,7 +105,7 @@ Widget previewButtonVariations() {
           children: [
             RemixButton(
               label: 'Save',
-              icon: Icons.save,
+              leadingIcon: Icons.save,
               onPressed: null,
             ),
             SizedBox(width: 12),
@@ -118,7 +118,7 @@ Widget previewButtonVariations() {
         SizedBox(height: 16),
         RemixButton(
           label: 'Download File',
-          icon: Icons.download,
+          leadingIcon: Icons.download,
           onPressed: null,
         ),
         SizedBox(height: 16),
@@ -144,7 +144,7 @@ Widget previewButtonVariations() {
         SizedBox(height: 16),
         RemixButton(
           label: 'Processing...',
-          icon: Icons.sync,
+          leadingIcon: Icons.sync,
           loading: true,
           onPressed: null,
         ),

--- a/packages/example/lib/misc/radix_button_comprehensive_test.dart
+++ b/packages/example/lib/misc/radix_button_comprehensive_test.dart
@@ -242,42 +242,42 @@ class _AllVariantsSection extends StatelessWidget {
         // Solid
         _getSizedStyle(() => FortalButtonStyle.solid()).call(
           label: 'Solid',
-          icon: Icons.check_circle,
+          leadingIcon: Icons.check_circle,
           onPressed: () => _showSnackBar(context, 'Solid pressed'),
         ),
 
         // Soft
         _getSizedStyle(() => FortalButtonStyle.soft()).call(
           label: 'Soft',
-          icon: Icons.favorite,
+          leadingIcon: Icons.favorite,
           onPressed: () => _showSnackBar(context, 'Soft pressed'),
         ),
 
         // Surface
         _getSizedStyle(() => FortalButtonStyle.surface()).call(
           label: 'Surface',
-          icon: Icons.layers,
+          leadingIcon: Icons.layers,
           onPressed: () => _showSnackBar(context, 'Surface pressed'),
         ),
 
         // Outline
         _getSizedStyle(() => FortalButtonStyle.outline()).call(
           label: 'Outline',
-          icon: Icons.crop_free,
+          leadingIcon: Icons.crop_free,
           onPressed: () => _showSnackBar(context, 'Outline pressed'),
         ),
 
         // Ghost
         _getSizedStyle(() => FortalButtonStyle.ghost()).call(
           label: 'Ghost',
-          icon: Icons.visibility_off,
+          leadingIcon: Icons.visibility_off,
           onPressed: () => _showSnackBar(context, 'Ghost pressed'),
         ),
 
         // Surface (was Classic)
         _getSizedStyle(() => FortalButtonStyle.surface()).call(
           label: 'Surface',
-          icon: Icons.style,
+          leadingIcon: Icons.style,
           onPressed: () => _showSnackBar(context, 'Surface pressed'),
         ),
       ],

--- a/packages/example/lib/misc/radix_button_example.dart
+++ b/packages/example/lib/misc/radix_button_example.dart
@@ -138,21 +138,21 @@ class _SizeSection extends StatelessWidget {
           children: [
             FortalButtonStyle.solid(size: FortalButtonSize.size1).call(
               label: 'Solid',
-              icon: Icons.check,
+              leadingIcon: Icons.check,
               // ignore: avoid_print
-                onPressed: () => print('Button pressed'),
+              onPressed: () => print('Button pressed'),
             ),
             FortalButtonStyle.soft(size: FortalButtonSize.size1).call(
               label: 'Soft',
-              icon: Icons.star,
+              leadingIcon: Icons.star,
               // ignore: avoid_print
-                onPressed: () => print('Button pressed'),
+              onPressed: () => print('Button pressed'),
             ),
             FortalButtonStyle.outline(size: FortalButtonSize.size1).call(
               label: 'Outline',
-              icon: Icons.favorite,
+              leadingIcon: Icons.favorite,
               // ignore: avoid_print
-                onPressed: () => print('Button pressed'),
+              onPressed: () => print('Button pressed'),
             ),
           ],
         ),
@@ -164,21 +164,21 @@ class _SizeSection extends StatelessWidget {
           children: [
             FortalButtonStyle.solid(size: FortalButtonSize.size2).call(
               label: 'Solid',
-              icon: Icons.check,
+              leadingIcon: Icons.check,
               // ignore: avoid_print
-                onPressed: () => print('Button pressed'),
+              onPressed: () => print('Button pressed'),
             ),
             FortalButtonStyle.soft(size: FortalButtonSize.size2).call(
               label: 'Soft',
-              icon: Icons.star,
+              leadingIcon: Icons.star,
               // ignore: avoid_print
-                onPressed: () => print('Button pressed'),
+              onPressed: () => print('Button pressed'),
             ),
             FortalButtonStyle.outline(size: FortalButtonSize.size2).call(
               label: 'Outline',
-              icon: Icons.favorite,
+              leadingIcon: Icons.favorite,
               // ignore: avoid_print
-                onPressed: () => print('Button pressed'),
+              onPressed: () => print('Button pressed'),
             ),
           ],
         ),
@@ -190,21 +190,21 @@ class _SizeSection extends StatelessWidget {
           children: [
             FortalButtonStyle.solid(size: FortalButtonSize.size3).call(
               label: 'Solid',
-              icon: Icons.check,
+              leadingIcon: Icons.check,
               // ignore: avoid_print
-                onPressed: () => print('Button pressed'),
+              onPressed: () => print('Button pressed'),
             ),
             FortalButtonStyle.soft(size: FortalButtonSize.size3).call(
               label: 'Soft',
-              icon: Icons.star,
+              leadingIcon: Icons.star,
               // ignore: avoid_print
-                onPressed: () => print('Button pressed'),
+              onPressed: () => print('Button pressed'),
             ),
             FortalButtonStyle.outline(size: FortalButtonSize.size3).call(
               label: 'Outline',
-              icon: Icons.favorite,
+              leadingIcon: Icons.favorite,
               // ignore: avoid_print
-                onPressed: () => print('Button pressed'),
+              onPressed: () => print('Button pressed'),
             ),
           ],
         ),
@@ -216,21 +216,21 @@ class _SizeSection extends StatelessWidget {
           children: [
             FortalButtonStyle.solid(size: FortalButtonSize.size4).call(
               label: 'Solid',
-              icon: Icons.check,
+              leadingIcon: Icons.check,
               // ignore: avoid_print
-                onPressed: () => print('Button pressed'),
+              onPressed: () => print('Button pressed'),
             ),
             FortalButtonStyle.soft(size: FortalButtonSize.size4).call(
               label: 'Soft',
-              icon: Icons.star,
+              leadingIcon: Icons.star,
               // ignore: avoid_print
-                onPressed: () => print('Button pressed'),
+              onPressed: () => print('Button pressed'),
             ),
             FortalButtonStyle.outline(size: FortalButtonSize.size4).call(
               label: 'Outline',
-              icon: Icons.favorite,
+              leadingIcon: Icons.favorite,
               // ignore: avoid_print
-                onPressed: () => print('Button pressed'),
+              onPressed: () => print('Button pressed'),
             ),
           ],
         ),
@@ -256,7 +256,7 @@ class _StateSection extends StatelessWidget {
           label: 'Loading',
           loading: true,
           // ignore: avoid_print
-                onPressed: () => print('Button pressed'),
+          onPressed: () => print('Button pressed'),
         ),
 
         // Disabled state
@@ -269,9 +269,9 @@ class _StateSection extends StatelessWidget {
         // With icon
         FortalButtonStyle.solid().call(
           label: 'With Icon',
-          icon: Icons.download,
+          leadingIcon: Icons.download,
           // ignore: avoid_print
-                onPressed: () => print('Button pressed'),
+          onPressed: () => print('Button pressed'),
         ),
       ],
     );

--- a/packages/playground/lib/registry/entries/button_entry.dart
+++ b/packages/playground/lib/registry/entries/button_entry.dart
@@ -40,7 +40,7 @@ Widget buildButtonExample() {
       ),
       RemixButton(
         label: 'With Icon',
-        icon: Icons.star,
+        leadingIcon: Icons.star,
         onPressed: () {},
         style: RemixButtonStyle()
             .paddingX(16)

--- a/packages/remix/lib/src/components/button/button_style.dart
+++ b/packages/remix/lib/src/components/button/button_style.dart
@@ -129,7 +129,8 @@ class RemixButtonStyle
 
   RemixButton call({
     required String label,
-    IconData? icon,
+    IconData? leadingIcon,
+    IconData? trailingIcon,
     bool loading = false,
     bool enabled = true,
     bool enableFeedback = true,
@@ -139,7 +140,8 @@ class RemixButtonStyle
     return RemixButton(
       style: this,
       label: label,
-      icon: icon,
+      leadingIcon: leadingIcon,
+      trailingIcon: trailingIcon,
       loading: loading,
       enabled: enabled,
       enableFeedback: enableFeedback,

--- a/packages/remix/test/components/button/button_style_test.dart
+++ b/packages/remix/test/components/button/button_style_test.dart
@@ -301,7 +301,7 @@ void main() {
 
         final button = style.call(
           label: 'Test Button',
-          icon: Icons.star,
+          leadingIcon: Icons.star,
           loading: true,
           enabled: false,
           enableFeedback: false,
@@ -311,7 +311,7 @@ void main() {
 
         expect(button, isA<RemixButton>());
         expect(button.label, equals('Test Button'));
-        expect(button.icon, equals(Icons.star));
+        expect(button.leadingIcon, equals(Icons.star));
         expect(button.loading, isTrue);
         expect(button.enabled, isFalse);
         expect(button.enableFeedback, isFalse);

--- a/packages/remix/test/components/button/button_widget_test.dart
+++ b/packages/remix/test/components/button/button_widget_test.dart
@@ -25,7 +25,7 @@ void main() {
 
       testWidgets('renders button with label and icon', (tester) async {
         await tester.pumpRemixApp(
-          RemixButton(label: 'Save', icon: Icons.save, onPressed: () {}),
+          RemixButton(label: 'Save', leadingIcon: Icons.save, onPressed: () {}),
         );
 
         await tester.pumpAndSettle();
@@ -95,8 +95,8 @@ void main() {
         await tester.pumpRemixApp(
           RemixButton(
             label: 'Test',
-            icon: Icons.star,
-            iconBuilder: (context, spec, icon) {
+            leadingIcon: Icons.star,
+            leadingIconBuilder: (context, spec, icon) {
               return Container(
                 key: const ValueKey('custom_icon'),
                 child: Icon(icon, color: Colors.red),
@@ -152,13 +152,13 @@ void main() {
         await tester.pumpRemixApp(
           RemixButton(
             label: 'Test Label',
-            icon: Icons.home,
+            leadingIcon: Icons.home,
             loading: true,
             textBuilder: (context, spec, text) {
               receivedTextSpec = spec;
               return Text(text);
             },
-            iconBuilder: (context, spec, icon) {
+            leadingIconBuilder: (context, spec, icon) {
               receivedIconSpec = spec;
               return Icon(icon);
             },
@@ -186,7 +186,7 @@ void main() {
         await tester.pumpRemixApp(
           RemixButton(
             label: 'Loading',
-            icon: Icons.download,
+            leadingIcon: Icons.download,
             loading: true,
             onPressed: () {},
           ),


### PR DESCRIPTION

## Description

Refactor RemixButton to support both leadingIcon and trailingIcon properties, replacing the previous single icon property. Update all usages, previews, tests, and documentation to reflect the new API, allowing buttons to display icons before and after the label.


## Related Issues

*Link to any relevant issues that this PR addresses. For example: `Closes #456`.*

---

## Checklist

**Note**: Updating the `pubspec.yaml` and `CHANGELOG.md` is not required. These are handled automatically during the release process.

- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors.
- [x] I have updated or added relevant documentation (doc comments with `///`).
- [x] I am prepared to follow up on review comments in a timely manner.

## Breaking Change

Does this PR require users of the package to manually update their code?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.