### PR TITLE
fix: add slider min/max validation and export StyledTextStyleMixin

### DIFF
--- a/packages/remix/lib/src/components/callout/callout.dart
+++ b/packages/remix/lib/src/components/callout/callout.dart
@@ -4,7 +4,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:mix/mix.dart';
 
-import '../../style/mixins/styled_text_style_mixin.dart';
 import '../../style/style.dart';
 import '../../utilities/remix_style.dart';
 import '../../fortal/fortal.dart';

--- a/packages/remix/lib/src/components/slider/slider_widget.dart
+++ b/packages/remix/lib/src/components/slider/slider_widget.dart
@@ -32,10 +32,11 @@ class RemixSlider extends StatelessWidget {
     this.focusNode,
     this.autofocus = false,
     this.snapDivisions,
-  }) : assert(
-         value >= min && value <= max,
-         'Slider value must be between min and max values',
-       );
+  })  : assert(min <= max, 'Slider min must be less than or equal to max'),
+        assert(
+          value >= min && value <= max,
+          'Slider value must be between min and max values',
+        );
 
   /// The minimum value the slider can have.
   final double min;

--- a/packages/remix/lib/src/style/style.dart
+++ b/packages/remix/lib/src/style/style.dart
@@ -3,3 +3,4 @@
 export 'mixins/icon_style_mixin.dart';
 export 'mixins/label_style_mixin.dart';
 export 'mixins/spinner_style_mixin.dart';
+export 'mixins/styled_text_style_mixin.dart';

--- a/packages/remix/lib/src/theme/remix_theme.dart
+++ b/packages/remix/lib/src/theme/remix_theme.dart
@@ -33,7 +33,6 @@ Widget createRemixScope({
     );
 
     // Use createFortalScope which provides all the token values
-    // RemixTokens now just references FortalTokens, so this provides everything
     return createFortalScope(
       accent: accent,
       gray: gray,

--- a/packages/remix/test/components/slider/slider_widget_test.dart
+++ b/packages/remix/test/components/slider/slider_widget_test.dart
@@ -122,6 +122,18 @@ void main() {
           throwsA(isA<AssertionError>()),
         );
       });
+
+      test('throws assertion error when min is greater than max', () {
+        expect(
+          () => RemixSlider(
+            value: 0.5,
+            min: 1.0,
+            max: 0.0,
+            onChanged: (value) {},
+          ),
+          throwsA(isA<AssertionError>()),
+        );
+      });
     });
 
     group('Styling', () {


### PR DESCRIPTION
## Summary
- Add assertion to validate `min <= max` in `RemixSlider` constructor
- Export `StyledTextStyleMixin` from `style.dart` barrel file  
- Remove redundant direct import in `callout.dart`
- Add test coverage for min > max assertion error

## Test plan
- [x] All 1620 tests pass
- [x] Analysis passes with no errors