### PR TITLE
chore: fix documentation API references and add error logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ final button = RemixButtonStyle()
         .color(Colors.blue.shade700),
   )
   .onPressed(
-    RemixButtonStyle().wrapScale(x: 0.95, y: 0.95),
+    RemixButtonStyle().wrap(WidgetModifierConfig.scale(x: 0.95, y: 0.95)),
   );
 ```
 
@@ -136,7 +136,7 @@ final style = RemixButtonStyle()
   )
   .onPressed(
     RemixButtonStyle()
-        .wrapScale(x: 0.95, y: 0.95),
+        .wrap(WidgetModifierConfig.scale(x: 0.95, y: 0.95)),
   );
 ```
 
@@ -204,7 +204,7 @@ final style = FortalButtonStyle.solid()
   .borderRadiusAll(const Radius.circular(8))
   .paddingX(32)
   .onHovered(
-    RemixButtonStyle().wrapScale(x: 1.05, y: 1.05),
+    RemixButtonStyle().wrap(WidgetModifierConfig.scale(x: 1.05, y: 1.05)),
   );
 ```
 

--- a/docs/components/button.mdx
+++ b/docs/components/button.mdx
@@ -62,9 +62,9 @@ class ButtonExample extends StatelessWidget {
               .topRight(const Radius.circular(12)),
           side: BorderSideMix.width(1).color(Colors.redAccent),
         )
-        .wrapScale(x: 1, y: 1)
+        .wrap(WidgetModifierConfig.scale(x: 1, y: 1))
         .onPressed(
-          RemixButtonStyle().wrapScale(x: 0.90, y: 0.90),
+          RemixButtonStyle().wrap(WidgetModifierConfig.scale(x: 0.90, y: 0.90)),
         )
         .onHovered(
           RemixButtonStyle()
@@ -172,7 +172,6 @@ const RemixButton({
   bool enabled = true,
   required VoidCallback? onPressed,
   VoidCallback? onLongPress,
-  VoidCallback? onDoubleTap,
   FocusNode? focusNode,
   bool autofocus = false,
   bool enableFeedback = true,
@@ -245,10 +244,6 @@ Optional. Whether to provide feedback when the button is pressed.  Defaults to t
 #### `onLongPress` → `VoidCallback?`
 
 Optional. Callback function called when the button is long pressed.
-
-#### `onDoubleTap` → `VoidCallback?`
-
-Optional. Callback function called when the button is double tapped.
 
 #### `focusNode` → `FocusNode?`
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -116,7 +116,7 @@ final style = RemixButtonStyle()
         .color(Colors.blue.shade700), // [!code ++]
   ) // [!code ++]
   .onPressed( // [!code ++]
-    RemixButtonStyle().wrapScale(x: 0.95, y: 0.95), // [!code ++]
+    RemixButtonStyle().wrap(WidgetModifierConfig.scale(x: 0.95, y: 0.95)), // [!code ++]
   ); // [!code ++]
 ```
 
@@ -137,7 +137,7 @@ final style = RemixButtonStyle()
   )
   .onPressed(
     RemixButtonStyle()
-        .wrapScale(x: 0.95, y: 0.95),
+        .wrap(WidgetModifierConfig.scale(x: 0.95, y: 0.95)),
   );
 ```
 
@@ -205,7 +205,7 @@ final style = FortalButtonStyle.solid()
   .borderRadiusAll(const Radius.circular(8))
   .paddingX(32)
   .onHovered(
-    RemixButtonStyle().wrapScale(x: 1.05, y: 1.05),
+    RemixButtonStyle().wrap(WidgetModifierConfig.scale(x: 1.05, y: 1.05)),
   );
 ```
 

--- a/packages/remix/README.md
+++ b/packages/remix/README.md
@@ -115,7 +115,7 @@ final button = RemixButtonStyle()
         .color(Colors.blue.shade700),
   )
   .onPressed(
-    RemixButtonStyle().wrapScale(x: 0.95, y: 0.95),
+    RemixButtonStyle().wrap(WidgetModifierConfig.scale(x: 0.95, y: 0.95)),
   );
 ```
 
@@ -136,7 +136,7 @@ final style = RemixButtonStyle()
   )
   .onPressed(
     RemixButtonStyle()
-        .wrapScale(x: 0.95, y: 0.95),
+        .wrap(WidgetModifierConfig.scale(x: 0.95, y: 0.95)),
   );
 ```
 
@@ -204,7 +204,7 @@ final style = FortalButtonStyle.solid()
   .borderRadiusAll(const Radius.circular(8))
   .paddingX(32)
   .onHovered(
-    RemixButtonStyle().wrapScale(x: 1.05, y: 1.05),
+    RemixButtonStyle().wrap(WidgetModifierConfig.scale(x: 1.05, y: 1.05)),
   );
 ```
 

--- a/packages/remix/lib/src/components/button/button_widget.dart
+++ b/packages/remix/lib/src/components/button/button_widget.dart
@@ -76,7 +76,7 @@ class RemixButton extends StatelessWidget {
   /// Whether the button is in a loading state.
   ///
   /// When true, the button will display a spinner and become non-interactive.
-  /// The spinner can be customized via [spinnerBuilder].
+  /// The spinner can be customized via [loadingBuilder].
   final bool loading;
 
   /// Whether the button is enabled.

--- a/packages/remix/scripts/generate_style_docs.dart
+++ b/packages/remix/scripts/generate_style_docs.dart
@@ -453,7 +453,9 @@ List<PropertyInfo> _extractWidgetProperties(
     parseResult.unit.visitChildren(visitor);
 
     return visitor.properties;
-  } catch (e) {
+  } catch (e, stackTrace) {
+    print('  ⚠ Error extracting properties from $componentName: $e');
+    print('     Stack trace: $stackTrace');
     return [];
   }
 }
@@ -567,7 +569,9 @@ List<MethodInfo> _extractMethodsFromMixin(String mixinName, String returnType) {
         docComment: method.docComment,
       );
     }).toList();
-  } catch (e) {
+  } catch (e, stackTrace) {
+    print('  ⚠ Error extracting methods from mixin $mixinName: $e');
+    print('     Stack trace: $stackTrace');
     return [];
   }
 }


### PR DESCRIPTION
## Summary

Fixes critical documentation inaccuracies and improves error visibility in tooling:

- Corrects non-existent `wrapScale()` API calls in examples with proper `wrap(WidgetModifierConfig.scale(...))` implementation
- Removes documented `onDoubleTap` parameter that doesn't exist in RemixButton widget
- Fixes incorrect parameter name reference in button widget comment
- Adds error logging to silent catch blocks in documentation generator script

## Test plan

- [x] Documentation examples compile correctly with fixed API calls
- [x] Removed parameter no longer appears in button docs
- [x] Error messages now logged when documentation generator encounters issues