### PR TITLE
feat: add factory constructors and shape to RemixCardStyle

### DIFF
--- a/packages/example/lib/api/card.0.dart
+++ b/packages/example/lib/api/card.0.dart
@@ -36,7 +36,7 @@ class CardExample extends StatelessWidget {
   RemixCardStyle get style {
     return RemixCardStyle()
         .size(300, 200)
-        .textColor(Colors.white)
+        .color(Colors.white)
         .borderRadiusAll(const Radius.circular(4))
         .borderAll(color: Colors.grey.shade300);
   }

--- a/packages/remix/lib/src/components/card/card_style.dart
+++ b/packages/remix/lib/src/components/card/card_style.dart
@@ -27,18 +27,39 @@ class RemixCardStyle extends RemixContainerStyle<RemixCardSpec, RemixCardStyle>
          modifier: modifier,
        );
 
+  // -- Factory constructors for convenience --
+
+  /// Creates a style with the given padding.
+  factory RemixCardStyle.padding(EdgeInsetsGeometryMix value) =>
+      RemixCardStyle().padding(value);
+
+  /// Creates a style with the given margin.
+  factory RemixCardStyle.margin(EdgeInsetsGeometryMix value) =>
+      RemixCardStyle().margin(value);
+
+  /// Creates a style with the given border radius.
+  factory RemixCardStyle.borderRadius(BorderRadiusGeometryMix radius) =>
+      RemixCardStyle().borderRadius(radius);
+
+  /// Creates a style with the given alignment.
+  factory RemixCardStyle.alignment(Alignment value) =>
+      RemixCardStyle().alignment(value);
+
+  /// Creates a style with the given decoration.
+  factory RemixCardStyle.decoration(DecorationMix value) =>
+      RemixCardStyle().decoration(value);
+
+  /// Creates a style with the given constraints.
+  factory RemixCardStyle.constraints(BoxConstraintsMix value) =>
+      RemixCardStyle().constraints(value);
+
+  /// Creates a style with the given shape.
+  factory RemixCardStyle.shape(ShapeBorderMix value) =>
+      RemixCardStyle().shape(value);
+
   /// Sets container padding
   RemixCardStyle padding(EdgeInsetsGeometryMix value) {
     return merge(RemixCardStyle(container: BoxStyler(padding: value)));
-  }
-
-  /// Sets container background color
-  RemixCardStyle textColor(Color value) {
-    return merge(
-      RemixCardStyle(
-        container: BoxStyler(decoration: BoxDecorationMix(color: value)),
-      ),
-    );
   }
 
   /// Sets container border radius
@@ -66,6 +87,15 @@ class RemixCardStyle extends RemixContainerStyle<RemixCardSpec, RemixCardStyle>
   @override
   RemixCardStyle decoration(DecorationMix value) {
     return merge(RemixCardStyle(container: BoxStyler(decoration: value)));
+  }
+
+  /// Sets the shape of the card.
+  RemixCardStyle shape(ShapeBorderMix value) {
+    return merge(
+      RemixCardStyle(
+        container: BoxStyler(decoration: ShapeDecorationMix(shape: value)),
+      ),
+    );
   }
 
   // Abstract method implementations for mixins


### PR DESCRIPTION
## Description

Removes the misnamed `textColor` method from `RemixCardStyle` (it was setting the container background color, not text color) and replaces its usage in the example with the correct `.color()` method. Adds convenience factory constructors (`padding`, `margin`, `borderRadius`, `alignment`, `decoration`, `constraints`, `shape`) following the same pattern as `RemixButtonStyle`. Also adds a new `shape` instance method for setting card shape via `ShapeDecorationMix`.

## Related Issues

N/A

---

## Checklist

- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors.
- [x] I have updated or added relevant documentation (doc comments with `///`).
- [x] I am prepared to follow up on review comments in a timely manner.

## Breaking Change

- [x] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.