### PR TITLE
feat: add backgroundColor, foregroundColor, shape and factory methods to RemixCalloutStyle

### DIFF
--- a/docs/components/callout.mdx
+++ b/docs/components/callout.mdx
@@ -34,7 +34,7 @@ class CalloutExample extends StatelessWidget {
 
   RemixCalloutStyle get style {
     return RemixCalloutStyle()
-        .color(Colors.grey.shade200)
+        .backgroundColor(Colors.grey.shade200)
         .spacing(12)
         .height(60)
         .paddingRight(12)
@@ -148,9 +148,17 @@ Sets container padding
 
 Sets container margin
 
-#### `color(Color value)`
+#### `backgroundColor(Color value)`
 
 Sets container background color
+
+#### `foregroundColor(Color value)`
+
+Sets the foreground color (icon and text) of the callout
+
+#### `shape(ShapeBorderMix value)`
+
+Sets the shape of the callout
 
 #### `borderRadius(BorderRadiusGeometryMix radius)`
 

--- a/packages/example/lib/api/callout.0.dart
+++ b/packages/example/lib/api/callout.0.dart
@@ -28,7 +28,7 @@ class CalloutExample extends StatelessWidget {
 
   RemixCalloutStyle get style {
     return RemixCalloutStyle()
-        .color(Colors.grey.shade200)
+        .backgroundColor(Colors.grey.shade200)
         .spacing(12)
         .height(60)
         .paddingRight(12)

--- a/packages/remix/lib/src/components/callout/callout_style.dart
+++ b/packages/remix/lib/src/components/callout/callout_style.dart
@@ -42,6 +42,60 @@ class RemixCalloutStyle
          modifier: modifier,
        );
 
+  // -- Factory constructors for convenience --
+
+  /// Creates a style with the given background color.
+  factory RemixCalloutStyle.backgroundColor(Color value) =>
+      RemixCalloutStyle().backgroundColor(value);
+
+  /// Creates a style with the given foreground color (icon and text).
+  factory RemixCalloutStyle.foregroundColor(Color value) =>
+      RemixCalloutStyle().foregroundColor(value);
+
+  /// Creates a style with the given padding.
+  factory RemixCalloutStyle.padding(EdgeInsetsGeometryMix value) =>
+      RemixCalloutStyle().padding(value);
+
+  /// Creates a style with the given margin.
+  factory RemixCalloutStyle.margin(EdgeInsetsGeometryMix value) =>
+      RemixCalloutStyle().margin(value);
+
+  /// Creates a style with the given decoration.
+  factory RemixCalloutStyle.decoration(DecorationMix value) =>
+      RemixCalloutStyle().decoration(value);
+
+  /// Creates a style with the given alignment.
+  factory RemixCalloutStyle.alignment(Alignment value) =>
+      RemixCalloutStyle().alignment(value);
+
+  /// Creates a style with the given spacing.
+  factory RemixCalloutStyle.spacing(double value) =>
+      RemixCalloutStyle().spacing(value);
+
+  /// Creates a style with the given constraints.
+  factory RemixCalloutStyle.constraints(BoxConstraintsMix value) =>
+      RemixCalloutStyle().constraints(value);
+
+  /// Creates a style with the given shape.
+  factory RemixCalloutStyle.shape(ShapeBorderMix value) =>
+      RemixCalloutStyle().shape(value);
+
+  /// Creates a style with the given icon color.
+  factory RemixCalloutStyle.iconColor(Color value) =>
+      RemixCalloutStyle().iconColor(value);
+
+  /// Creates a style with the given icon size.
+  factory RemixCalloutStyle.iconSize(double value) =>
+      RemixCalloutStyle().iconSize(value);
+
+  /// Creates a style with the given text color.
+  factory RemixCalloutStyle.textColor(Color value) =>
+      RemixCalloutStyle().textColor(value);
+
+  /// Creates a style with the given text style.
+  factory RemixCalloutStyle.textStyle(TextStyleMix value) =>
+      RemixCalloutStyle().textStyle(value);
+
   /// Sets container padding
   RemixCalloutStyle padding(EdgeInsetsGeometryMix value) {
     return merge(RemixCalloutStyle(container: FlexBoxStyler(padding: value)));
@@ -53,10 +107,24 @@ class RemixCalloutStyle
   }
 
   /// Sets container background color
-  RemixCalloutStyle color(Color value) {
+  RemixCalloutStyle backgroundColor(Color value) {
     return merge(
       RemixCalloutStyle(
         container: FlexBoxStyler(decoration: BoxDecorationMix(color: value)),
+      ),
+    );
+  }
+
+  /// Sets the foreground color (icon and text) of the callout.
+  RemixCalloutStyle foregroundColor(Color value) {
+    return iconColor(value).textColor(value);
+  }
+
+  /// Sets the shape of the callout.
+  RemixCalloutStyle shape(ShapeBorderMix value) {
+    return merge(
+      RemixCalloutStyle(
+        container: FlexBoxStyler(decoration: ShapeDecorationMix(shape: value)),
       ),
     );
   }
@@ -128,6 +196,11 @@ class RemixCalloutStyle
         ),
       ),
     );
+  }
+
+  @override
+  RemixCalloutStyle color(Color value) {
+    return backgroundColor(value);
   }
 
   // FlexStyleMixin implementation

--- a/packages/remix/lib/src/components/callout/fortal_callout_styles.dart
+++ b/packages/remix/lib/src/components/callout/fortal_callout_styles.dart
@@ -45,7 +45,7 @@ class FortalCalloutStyles {
     FortalCalloutSize size = .size2,
   }) {
     return base(size: size)
-        .color(Colors.transparent)
+        .backgroundColor(Colors.transparent)
         .borderAll(
           color: FortalTokens.accent7(),
           width: FortalTokens.borderWidth1(),
@@ -60,7 +60,7 @@ class FortalCalloutStyles {
     FortalCalloutSize size = .size2,
   }) {
     return base(size: size)
-        .color(FortalTokens.accentSurface())
+        .backgroundColor(FortalTokens.accentSurface())
         .borderAll(
           color: FortalTokens.accent6(),
           width: FortalTokens.borderWidth1(),
@@ -75,7 +75,7 @@ class FortalCalloutStyles {
     FortalCalloutSize size = .size2,
   }) {
     return base(size: size)
-        .color(FortalTokens.accent3())
+        .backgroundColor(FortalTokens.accent3())
         .borderRadiusAll(FortalTokens.radius3())
         .textColor(FortalTokens.accent11())
         .iconColor(FortalTokens.accent11());

--- a/packages/remix/test/components/callout/callout_style_test.dart
+++ b/packages/remix/test/components/callout/callout_style_test.dart
@@ -86,9 +86,9 @@ void main() {
       );
 
       styleMethodTest(
-        'color sets container background color',
+        'backgroundColor sets container background color',
         initial: RemixCalloutStyle(),
-        modify: (style) => style.color(Colors.yellow),
+        modify: (style) => style.backgroundColor(Colors.yellow),
         expect: (style) {
           expect(
             style.$container,
@@ -96,6 +96,52 @@ void main() {
               Prop.maybeMix(
                 FlexBoxStyler(
                   decoration: BoxDecorationMix(color: Colors.yellow),
+                ),
+              ),
+            ),
+          );
+        },
+      );
+
+      styleMethodTest(
+        'foregroundColor sets both icon and text color',
+        initial: RemixCalloutStyle(),
+        modify: (style) => style.foregroundColor(Colors.red),
+        expect: (style) {
+          expect(
+            style.$icon,
+            equals(Prop.maybeMix(IconStyler(color: Colors.red))),
+          );
+          expect(
+            style.$text,
+            equals(
+              Prop.maybeMix(
+                TextStyler(style: TextStyleMix(color: Colors.red)),
+              ),
+            ),
+          );
+        },
+      );
+
+      styleMethodTest(
+        'shape sets container shape decoration',
+        initial: RemixCalloutStyle(),
+        modify: (style) => style.shape(
+          RoundedRectangleBorderMix(
+            borderRadius: BorderRadiusGeometryMix.circular(16.0),
+          ),
+        ),
+        expect: (style) {
+          expect(
+            style.$container,
+            equals(
+              Prop.maybeMix(
+                FlexBoxStyler(
+                  decoration: ShapeDecorationMix(
+                    shape: RoundedRectangleBorderMix(
+                      borderRadius: BorderRadiusGeometryMix.circular(16.0),
+                    ),
+                  ),
                 ),
               ),
             ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -109,10 +109,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   charcode:
     dependency: transitive
     description:
@@ -395,18 +395,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   melos:
     dependency: "direct dev"
     description:
@@ -680,10 +680,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.10"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
## Description

Renames `color` to `backgroundColor` for clarity, adds `foregroundColor` (sets both icon and text color), adds `shape` for shape decoration support, and introduces 13 convenience factory constructors (e.g. `RemixCalloutStyle.backgroundColor(...)`) following the same pattern as `RemixButtonStyle`. The `color` override delegates to `backgroundColor` for mixin compatibility.

## Related Issues

N/A

---

## Checklist

- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors.
- [x] I have updated or added relevant documentation (doc comments with `///`).
- [x] I am prepared to follow up on review comments in a timely manner.

## Breaking Change

Does this PR require users of the package to manually update their code?

- [x] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.