### PR TITLE
docs: fix component documentation to match Dart source code

### DIFF
--- a/docs/components/avatar.mdx
+++ b/docs/components/avatar.mdx
@@ -138,13 +138,13 @@ const RemixAvatar({
 ## Properties
 ### Widget Properties
 
-#### `style` → `Key?`
+#### `style` → `RemixAvatarStyle`
 
-Optional. 
+Optional. The style configuration for the avatar. Customize colors, sizing, shape, and state-based styling.
 
-#### `styleSpec` → `Key?`
+#### `styleSpec` → `RemixAvatarSpec?`
 
-Optional. 
+Optional. A pre-resolved style spec that bypasses style resolution. Useful for performance when sharing resolved styles across multiple instances.
 
 #### `key` → `Key?`
 
@@ -243,7 +243,11 @@ Sets the clip behavior for the avatar container.
 
 #### `label(TextStyler value)`
 
+Configures the label text style using a TextStyler.
+
 #### `icon(IconStyler value)`
+
+Configures the icon style using an IconStyler.
 
 #### `size(double width, double height)`
 
@@ -251,9 +255,15 @@ Sets avatar size with width and height
 
 #### `wrap(WidgetModifierConfig value)`
 
+Applies widget modifiers such as clipping, opacity, or scaling.
+
 #### `foregroundDecoration(DecorationMix value)`
 
+Sets a foreground decoration painted on top of the component.
+
 #### `transform(Matrix4 value, AlignmentGeometry alignment = Alignment.center)`
+
+Applies a matrix transformation to the component.
 
 #### `labelTextStyle(TextStyleMix value)`
 

--- a/docs/components/badge.mdx
+++ b/docs/components/badge.mdx
@@ -128,13 +128,13 @@ const RemixBadge({
 ## Properties
 ### Widget Properties
 
-#### `style` → `Key?`
+#### `style` → `RemixBadgeStyle`
 
-Optional. 
+Optional. The style configuration for the badge. Customize colors, sizing, shape, and state-based styling.
 
-#### `styleSpec` → `Key?`
+#### `styleSpec` → `RemixBadgeSpec?`
 
-Optional. 
+Optional. A pre-resolved style spec that bypasses style resolution. Useful for performance when sharing resolved styles across multiple instances.
 
 #### `key` → `Key?`
 
@@ -185,6 +185,8 @@ Sets container alignment
 
 #### `label(TextStyler value)`
 
+Configures the label text style using a TextStyler.
+
 #### `constraints(BoxConstraintsMix value)`
 
 Sets constraints
@@ -195,9 +197,15 @@ Sets animation
 
 #### `wrap(WidgetModifierConfig value)`
 
+Applies widget modifiers such as clipping, opacity, or scaling.
+
 #### `foregroundDecoration(DecorationMix value)`
 
+Sets a foreground decoration painted on top of the component.
+
 #### `transform(Matrix4 value, AlignmentGeometry alignment = Alignment.center)`
+
+Applies a matrix transformation to the component.
 
 #### `labelTextStyle(TextStyleMix value)`
 

--- a/docs/components/button.mdx
+++ b/docs/components/button.mdx
@@ -164,9 +164,11 @@ class FortalButtonExample extends StatelessWidget {
 const RemixButton({
   Key? key,
   required String label,
-  IconData? icon,
+  IconData? leadingIcon,
+  IconData? trailingIcon,
   RemixButtonTextBuilder? textBuilder,
-  RemixButtonIconBuilder? iconBuilder,
+  RemixButtonIconBuilder? leadingIconBuilder,
+  RemixButtonIconBuilder? trailingIconBuilder,
   RemixButtonLoadingBuilder? loadingBuilder,
   bool loading = false,
   bool enabled = true,
@@ -191,11 +193,11 @@ const RemixButton({
 
 #### `style` → `RemixButtonStyle`
 
-Optional. 
+Optional. The style configuration for the button. Customize colors, sizing, spacing, and state-based styling.
 
 #### `styleSpec` → `RemixButtonSpec?`
 
-Optional. 
+Optional. A pre-resolved style spec that bypasses style resolution. Useful for performance when sharing resolved styles across multiple instances.
 
 #### `key` → `Key?`
 
@@ -205,17 +207,25 @@ Optional. Controls how one widget replaces another widget in the tree.
 
 **Required**. The label text to display in the button. If [textBuilder] is provided, this is ignored.
 
-#### `icon` → `IconData?`
+#### `leadingIcon` → `IconData?`
 
-Optional. The icon to display in the button. If [iconBuilder] is provided, this is ignored.
+Optional. The leading icon to display before the label. If [leadingIconBuilder] is provided, this is ignored.
+
+#### `trailingIcon` → `IconData?`
+
+Optional. The trailing icon to display after the label. If [trailingIconBuilder] is provided, this is ignored.
 
 #### `textBuilder` → `RemixButtonTextBuilder?`
 
 Optional. Builder for customizing the text rendering.
 
-#### `iconBuilder` → `RemixButtonIconBuilder?`
+#### `leadingIconBuilder` → `RemixButtonIconBuilder?`
 
-Optional. Builder for customizing the icon rendering.
+Optional. Builder for customizing the leading icon rendering.
+
+#### `trailingIconBuilder` → `RemixButtonIconBuilder?`
+
+Optional. Builder for customizing the trailing icon rendering.
 
 #### `loadingBuilder` → `RemixButtonLoadingBuilder?`
 
@@ -270,9 +280,15 @@ Optional. Cursor when hovering over the button.  Defaults to [SystemMouseCursors
 
 #### `label(TextStyler value)`
 
+Configures the label text style using a TextStyler.
+
 #### `icon(IconStyler value)`
 
+Configures the icon style using an IconStyler.
+
 #### `spinner(RemixSpinnerStyle value)`
+
+Configures the loading spinner style.
 
 #### `padding(EdgeInsetsGeometryMix value)`
 
@@ -300,15 +316,27 @@ Sets constraints
 
 #### `animate(AnimationConfig animation)`
 
+Configures implicit animation for style transitions.
+
 #### `flex(FlexStyler value)`
+
+Configures the flex layout properties.
 
 #### `foregroundDecoration(DecorationMix value)`
 
+Sets a foreground decoration painted on top of the component.
+
 #### `transform(Matrix4 value, AlignmentGeometry alignment = Alignment.center)`
+
+Applies a matrix transformation to the component.
 
 #### `color(Color value)`
 
+Sets background color.
+
 #### `wrap(WidgetModifierConfig value)`
+
+Applies widget modifiers such as clipping, opacity, or scaling.
 
 #### `labelTextStyle(TextStyleMix value)`
 

--- a/docs/components/callout.mdx
+++ b/docs/components/callout.mdx
@@ -101,8 +101,6 @@ const RemixCallout({
   Widget? child,
   String? text,
   IconData? icon,
-  RemixCalloutTextBuilder? textBuilder,
-  RemixCalloutIconBuilder? iconBuilder,
   RemixCalloutStyle style = const RemixCalloutStyle.create(),
   RemixCalloutSpec? styleSpec,
 })
@@ -113,13 +111,13 @@ const RemixCallout({
 ## Properties
 ### Widget Properties
 
-#### `style` → `Key?`
+#### `style` → `RemixCalloutStyle`
 
-Optional. 
+Optional. The style configuration for the callout. Customize colors, sizing, spacing, and state-based styling.
 
-#### `styleSpec` → `Key?`
+#### `styleSpec` → `RemixCalloutSpec?`
 
-Optional. 
+Optional. A pre-resolved style spec that bypasses style resolution. Useful for performance when sharing resolved styles across multiple instances.
 
 #### `key` → `Key?`
 
@@ -136,7 +134,6 @@ Optional. The icon to display in the callout.
 #### `child` → `Widget?`
 
 Optional. Optional custom child content for the callout body.
-
 
 ### Style Methods
 
@@ -186,19 +183,35 @@ Sets text color
 
 #### `wrap(WidgetModifierConfig value)`
 
+Applies widget modifiers such as clipping, opacity, or scaling.
+
 #### `animate(AnimationConfig config)`
+
+Configures implicit animation for style transitions.
 
 #### `constraints(BoxConstraintsMix value)`
 
+Sets size constraints on the component.
+
 #### `foregroundDecoration(DecorationMix value)`
+
+Sets a foreground decoration painted on top of the component.
 
 #### `transform(Matrix4 value, AlignmentGeometry alignment = Alignment.center)`
 
+Applies a matrix transformation to the component.
+
 #### `flex(FlexStyler value)`
+
+Configures the flex layout properties.
 
 #### `icon(IconStyler value)`
 
+Configures the icon style using an IconStyler.
+
 #### `text(TextStyler value)`
+
+Configures the text style using a TextStyler.
 
 #### `iconSize(double value)`
 

--- a/docs/components/card.mdx
+++ b/docs/components/card.mdx
@@ -91,13 +91,13 @@ const RemixCard({
 ## Properties
 ### Widget Properties
 
-#### `style` → `Key?`
+#### `style` → `RemixCardStyle`
 
-Optional. 
+Optional. The style configuration for the card. Customize colors, sizing, borders, and state-based styling.
 
-#### `styleSpec` → `Key?`
+#### `styleSpec` → `RemixCardSpec?`
 
-Optional. 
+Optional. A pre-resolved style spec that bypasses style resolution. Useful for performance when sharing resolved styles across multiple instances.
 
 #### `key` → `Key?`
 
@@ -116,7 +116,7 @@ Sets container padding
 
 #### `textColor(Color value)`
 
-Sets container background color
+Sets text color
 
 #### `borderRadius(BorderRadiusGeometryMix radius)`
 
@@ -136,11 +136,21 @@ Sets container decoration
 
 #### `wrap(WidgetModifierConfig value)`
 
+Applies widget modifiers such as clipping, opacity, or scaling.
+
 #### `animate(AnimationConfig config)`
+
+Configures implicit animation for style transitions.
 
 #### `constraints(BoxConstraintsMix value)`
 
+Sets size constraints on the component.
+
 #### `foregroundDecoration(DecorationMix value)`
 
+Sets a foreground decoration painted on top of the component.
+
 #### `transform(Matrix4 value, AlignmentGeometry alignment = Alignment.center)`
+
+Applies a matrix transformation to the component.
 

--- a/docs/components/checkbox.mdx
+++ b/docs/components/checkbox.mdx
@@ -109,18 +109,20 @@ class _FortalCheckboxExampleState extends State<FortalCheckboxExample> {
 ```dart
 const RemixCheckbox({
   Key? key,
-  required bool selected,
-  required ValueChanged<bool?>? onChanged,
   bool enabled = true,
-  bool? indeterminate,
-  MouseCursor mouseCursor = SystemMouseCursors.click,
-  bool enableFeedback = true,
-  FocusNode? focusNode,
+  required bool? selected,
+  bool tristate = false,
+  ValueChanged<bool?>? onChanged,
   bool autofocus = false,
-  String? semanticLabel,
-  RemixCheckboxIconBuilder? iconBuilder,
+  IconData checkedIcon = Icons.check_rounded,
+  IconData? uncheckedIcon,
+  IconData indeterminateIcon = Icons.horizontal_rule,
+  bool enableFeedback = true,
   RemixCheckboxStyle style = const RemixCheckboxStyle.create(),
   RemixCheckboxSpec? styleSpec,
+  FocusNode? focusNode,
+  String? semanticLabel,
+  MouseCursor mouseCursor = SystemMouseCursors.click,
 })
 ```
 </CodeGroup>
@@ -147,7 +149,7 @@ Optional. Whether the checkbox can be true, false, or null (indeterminate).
 
 #### `onChanged` → `ValueChanged<bool?>?`
 
-Optional. The callback function that is called when the checkbox is tapped. When [tristate] is true, the value can be null.
+Optional. Called when the user toggles the checkbox. When tristate is true, the value can be null.
 
 #### `autofocus` → `bool`
 
@@ -155,7 +157,7 @@ Optional. Whether the checkbox should automatically request focus when it is cre
 
 #### `checkedIcon` → `IconData`
 
-Optional. The icon to display when the checkbox is checked.
+Optional. The icon to display when the checkbox is checked. Defaults to Icons.check_rounded.
 
 #### `uncheckedIcon` → `IconData?`
 
@@ -163,7 +165,7 @@ Optional. The icon to display when the checkbox is unchecked.
 
 #### `indeterminateIcon` → `IconData`
 
-Optional. The icon to display when the checkbox is in indeterminate state (null value).
+Optional. The icon to display when the checkbox is in indeterminate state. Defaults to Icons.horizontal_rule.
 
 #### `enableFeedback` → `bool`
 
@@ -214,7 +216,11 @@ Sets container alignment.
 
 #### `onIndeterminate(RemixCheckboxStyle value)`
 
+Style applied when the checkbox is in the indeterminate state.
+
 #### `icon(IconStyler value)`
+
+Configures the icon style using an IconStyler.
 
 #### `padding(EdgeInsetsGeometryMix value)`
 
@@ -238,15 +244,27 @@ Sets animation configuration.
 
 #### `wrap(WidgetModifierConfig value)`
 
+Applies widget modifiers such as clipping, opacity, or scaling.
+
 #### `constraints(BoxConstraintsMix value)`
+
+Sets size constraints on the component.
 
 #### `decoration(DecorationMix value)`
 
+Sets the container decoration.
+
 #### `margin(EdgeInsetsGeometryMix value)`
+
+Sets the container margin.
 
 #### `foregroundDecoration(DecorationMix value)`
 
+Sets a foreground decoration painted on top of the component.
+
 #### `transform(Matrix4 value, AlignmentGeometry alignment = Alignment.center)`
+
+Applies a matrix transformation to the component.
 
 #### `iconColor(Color value)`
 

--- a/docs/components/divider.mdx
+++ b/docs/components/divider.mdx
@@ -85,13 +85,13 @@ const RemixDivider({
 ## Properties
 ### Widget Properties
 
-#### `style` → `Key?`
+#### `style` → `RemixDividerStyle`
 
-Optional. 
+Optional. The style configuration for the divider. Customize color, thickness, and spacing.
 
-#### `styleSpec` → `Key?`
+#### `styleSpec` → `RemixDividerSpec?`
 
-Optional. 
+Optional. A pre-resolved style spec that bypasses style resolution. Useful for performance when sharing resolved styles across multiple instances.
 
 #### `key` → `Key?`
 
@@ -126,11 +126,21 @@ Sets container decoration
 
 #### `wrap(WidgetModifierConfig value)`
 
+Applies widget modifiers such as clipping, opacity, or scaling.
+
 #### `animate(AnimationConfig config)`
+
+Configures implicit animation for style transitions.
 
 #### `constraints(BoxConstraintsMix value)`
 
+Sets size constraints on the component.
+
 #### `foregroundDecoration(DecorationMix value)`
 
+Sets a foreground decoration painted on top of the component.
+
 #### `transform(Matrix4 value, AlignmentGeometry alignment = Alignment.center)`
+
+Applies a matrix transformation to the component.
 

--- a/docs/components/icon_button.mdx
+++ b/docs/components/icon_button.mdx
@@ -124,13 +124,11 @@ const RemixIconButton({
   RemixIconButtonIconBuilder? iconBuilder,
   RemixIconButtonLoadingBuilder? loadingBuilder,
   bool loading = false,
-  bool enabled = true,
+  bool enableFeedback = true,
   required VoidCallback? onPressed,
   VoidCallback? onLongPress,
-  VoidCallback? onDoubleTap,
   FocusNode? focusNode,
   bool autofocus = false,
-  bool enableFeedback = true,
   String? semanticLabel,
   String? semanticHint,
   bool excludeSemantics = false,
@@ -147,11 +145,11 @@ const RemixIconButton({
 
 #### `style` → `RemixIconButtonStyle`
 
-Optional. 
+Optional. The style configuration for the icon button. Customize colors, sizing, and state-based styling.
 
 #### `styleSpec` → `RemixIconButtonSpec?`
 
-Optional. 
+Optional. A pre-resolved style spec that bypasses style resolution. Useful for performance when sharing resolved styles across multiple instances.
 
 #### `key` → `Key?`
 
@@ -189,10 +187,6 @@ Optional. Whether to provide feedback when the button is pressed.  Defaults to t
 
 Optional. Callback function called when the button is long pressed.
 
-#### `onDoubleTap` → `VoidCallback?`
-
-Optional. Callback function called when the button is double tapped.
-
 #### `focusNode` → `FocusNode?`
 
 Optional. Optional focus node to control the button's focus behavior.
@@ -218,7 +212,11 @@ Optional. Cursor when hovering over the button.  Defaults to [SystemMouseCursors
 
 #### `icon(IconStyler value)`
 
+Configures the icon style using an IconStyler.
+
 #### `spinner(RemixSpinnerStyle value)`
+
+Configures the loading spinner style.
 
 #### `color(Color value)`
 
@@ -274,11 +272,19 @@ Sets height
 
 #### `animate(AnimationConfig animation)`
 
+Configures implicit animation for style transitions.
+
 #### `foregroundDecoration(DecorationMix value)`
+
+Sets a foreground decoration painted on top of the component.
 
 #### `transform(Matrix4 value, AlignmentGeometry alignment = Alignment.center)`
 
+Applies a matrix transformation to the component.
+
 #### `wrap(WidgetModifierConfig value)`
+
+Applies widget modifiers such as clipping, opacity, or scaling.
 
 #### `iconOpacity(double value)`
 

--- a/docs/components/menu.mdx
+++ b/docs/components/menu.mdx
@@ -178,12 +178,20 @@ class FortalMenuExample extends StatelessWidget {
 const RemixMenu({
   Key? key,
   required RemixMenuTrigger trigger,
-  required List<Widget> items,
-  required ValueChanged<T>? onSelected,
+  required List<RemixMenuItemData<T>> items,
   MenuController? controller,
+  ValueChanged<T>? onSelected,
+  VoidCallback? onOpen,
+  VoidCallback? onClose,
+  VoidCallback? onCanceled,
+  RawMenuAnchorOpenRequestedCallback? onOpenRequested,
+  RawMenuAnchorCloseRequestedCallback? onCloseRequested,
+  bool consumeOutsideTaps = true,
+  bool useRootOverlay = false,
+  bool closeOnClickOutside = true,
+  FocusNode? triggerFocusNode,
   OverlayPositionConfig positioning = const OverlayPositionConfig(),
   RemixMenuStyle style = const RemixMenuStyle.create(),
-  RemixMenuSpec? styleSpec,
 })
 ```
 </CodeGroup>
@@ -261,9 +269,15 @@ Optional. The style configuration for the menu.
 
 #### `label(TextStyler value)`
 
+Configures the label text style using a TextStyler.
+
 #### `leadingIcon(IconStyler value)`
 
+Configures the leading icon style.
+
 #### `trailingIcon(IconStyler value)`
+
+Configures the trailing icon style.
 
 #### `alignment(Alignment value)`
 
@@ -271,27 +285,51 @@ Sets container alignment
 
 #### `padding(EdgeInsetsGeometryMix value)`
 
+Sets the container padding.
+
 #### `color(Color value)`
+
+Sets background color.
 
 #### `size(double width, double height)`
 
+Sets the component size.
+
 #### `borderRadius(BorderRadiusGeometryMix radius)`
+
+Sets the border radius.
 
 #### `constraints(BoxConstraintsMix value)`
 
+Sets size constraints on the component.
+
 #### `decoration(DecorationMix value)`
+
+Sets the container decoration.
 
 #### `margin(EdgeInsetsGeometryMix value)`
 
+Sets the container margin.
+
 #### `foregroundDecoration(DecorationMix value)`
+
+Sets a foreground decoration painted on top of the component.
 
 #### `transform(Matrix4 value, AlignmentGeometry alignment = Alignment.center)`
 
+Applies a matrix transformation to the component.
+
 #### `flex(FlexStyler value)`
+
+Configures the flex layout properties.
 
 #### `animate(AnimationConfig animation)`
 
+Configures implicit animation for style transitions.
+
 #### `wrap(WidgetModifierConfig value)`
+
+Applies widget modifiers such as clipping, opacity, or scaling.
 
 #### `labelTextStyle(TextStyleMix value)`
 
@@ -339,7 +377,7 @@ Sets label/text decoration color
 
 #### `icon(IconStyler value)`
 
-Must be implemented by the class using this mixin Should merge the provided IconStyler with the component's icon style
+Configures the icon style using an IconStyler.
 
 #### `iconColor(Color value)`
 

--- a/docs/components/progress.mdx
+++ b/docs/components/progress.mdx
@@ -84,7 +84,7 @@ class FortalProgressExample extends StatelessWidget {
 ```dart
 const RemixProgress({
   Key? key,
-  required double? value,
+  required double value,
   RemixProgressStyle style = const RemixProgressStyle.create(),
   RemixProgressSpec? styleSpec,
 })
@@ -95,13 +95,13 @@ const RemixProgress({
 ## Properties
 ### Widget Properties
 
-#### `style` → `Key?`
+#### `style` → `RemixProgressStyle`
 
-Optional. 
+Optional. The style configuration for the progress indicator. Customize colors, sizing, and track appearance.
 
-#### `styleSpec` → `Key?`
+#### `styleSpec` → `RemixProgressSpec?`
 
-Optional. 
+Optional. A pre-resolved style spec that bypasses style resolution. Useful for performance when sharing resolved styles across multiple instances.
 
 #### `key` → `Key?`
 
@@ -148,17 +148,33 @@ Sets container alignment
 
 #### `wrap(WidgetModifierConfig value)`
 
+Applies widget modifiers such as clipping, opacity, or scaling.
+
 #### `animate(AnimationConfig config)`
+
+Configures implicit animation for style transitions.
 
 #### `constraints(BoxConstraintsMix value)`
 
+Sets size constraints on the component.
+
 #### `decoration(DecorationMix value)`
+
+Sets the container decoration.
 
 #### `margin(EdgeInsetsGeometryMix value)`
 
+Sets the container margin.
+
 #### `padding(EdgeInsetsGeometryMix value)`
+
+Sets the container padding.
 
 #### `foregroundDecoration(DecorationMix value)`
 
+Sets a foreground decoration painted on top of the component.
+
 #### `transform(Matrix4 value, AlignmentGeometry alignment = Alignment.center)`
+
+Applies a matrix transformation to the component.
 

--- a/docs/components/radio.mdx
+++ b/docs/components/radio.mdx
@@ -157,7 +157,7 @@ class _FortalRadioExampleState extends State<FortalRadioExample> {
 const RemixRadioGroup({
   Key? key,
   required T? groupValue,
-  required ValueChanged<T?>? onChanged,
+  required ValueChanged<T?> onChanged,
   required Widget child,
 })
 
@@ -166,11 +166,11 @@ const RemixRadio({
   Key? key,
   required T value,
   bool enabled = true,
-  MouseCursor mouseCursor = SystemMouseCursors.click,
+  bool toggleable = false,
+  MouseCursor? mouseCursor,
   bool enableFeedback = true,
   FocusNode? focusNode,
   bool autofocus = false,
-  String? semanticLabel,
   RemixRadioStyle style = const RemixRadioStyle.create(),
   RemixRadioSpec? styleSpec,
 })
@@ -183,11 +183,11 @@ const RemixRadio({
 
 #### `style` → `RemixRadioStyle`
 
-Optional. 
+Optional. The style configuration for the radio button. Customize colors, borders, and state-based styling.
 
 #### `styleSpec` → `RemixRadioSpec?`
 
-Optional. 
+Optional. A pre-resolved style spec that bypasses style resolution. Useful for performance when sharing resolved styles across multiple instances.
 
 #### `key` → `Key?`
 
@@ -258,11 +258,21 @@ Sets animation configuration.
 
 #### `wrap(WidgetModifierConfig value)`
 
+Applies widget modifiers such as clipping, opacity, or scaling.
+
 #### `constraints(BoxConstraintsMix value)`
+
+Sets size constraints on the component.
 
 #### `decoration(DecorationMix value)`
 
+Sets the container decoration.
+
 #### `foregroundDecoration(DecorationMix value)`
 
+Sets a foreground decoration painted on top of the component.
+
 #### `transform(Matrix4 value, AlignmentGeometry alignment = Alignment.center)`
+
+Applies a matrix transformation to the component.
 

--- a/docs/components/select.mdx
+++ b/docs/components/select.mdx
@@ -149,13 +149,18 @@ class _FortalSelectExampleState extends State<FortalSelectExample> {
 const RemixSelect({
   Key? key,
   required RemixSelectTrigger trigger,
-  required List<RemixSelectItem> items,
-  required T? selectedValue,
+  required List<RemixSelectItem<T>> items,
+  T? selectedValue,
   Alignment? targetAnchor,
   Alignment? followerAnchor,
-  required ValueChanged<T?>? onChanged,
+  ValueChanged<T?>? onChanged,
+  VoidCallback? onOpen,
+  VoidCallback? onClose,
+  bool enabled = true,
+  String? semanticLabel,
+  bool closeOnSelect = true,
+  FocusNode? focusNode,
   RemixSelectStyle style = const RemixSelectStyle.create(),
-  RemixSelectSpec? styleSpec,
 })
 ```
 </CodeGroup>
@@ -233,21 +238,39 @@ Sets label styling (delegates to text for consistency with mixin)
 
 #### `animate(AnimationConfig config)`
 
+Configures implicit animation for style transitions.
+
 #### `constraints(BoxConstraintsMix value)`
+
+Sets size constraints on the component.
 
 #### `decoration(DecorationMix value)`
 
+Sets the container decoration.
+
 #### `margin(EdgeInsetsGeometryMix value)`
+
+Sets the container margin.
 
 #### `padding(EdgeInsetsGeometryMix value)`
 
+Sets the container padding.
+
 #### `wrap(WidgetModifierConfig value)`
+
+Applies widget modifiers such as clipping, opacity, or scaling.
 
 #### `foregroundDecoration(DecorationMix value)`
 
+Sets a foreground decoration painted on top of the component.
+
 #### `transform(Matrix4 value, AlignmentGeometry alignment = Alignment.center)`
 
+Applies a matrix transformation to the component.
+
 #### `flex(FlexStyler value)`
+
+Configures the flex layout properties.
 
 #### `labelTextStyle(TextStyleMix value)`
 

--- a/docs/components/slider.mdx
+++ b/docs/components/slider.mdx
@@ -129,9 +129,10 @@ const RemixSlider({
   double min = 0.0,
   double max = 1.0,
   bool enabled = true,
+  bool enableHapticFeedback = true,
   FocusNode? focusNode,
   bool autofocus = false,
-  String? semanticLabel,
+  int? snapDivisions,
   RemixSliderStyle style = const RemixSliderStyle.create(),
   RemixSliderSpec? styleSpec,
 })
@@ -239,23 +240,45 @@ Sets stroke width for the range only (filled portion).
 
 #### `padding(EdgeInsetsGeometryMix value)`
 
+Sets the container padding.
+
 #### `color(Color value)`
+
+Sets background color.
 
 #### `size(double width, double height)`
 
+Sets the component size.
+
 #### `borderRadius(BorderRadiusGeometryMix radius)`
+
+Sets the border radius.
 
 #### `constraints(BoxConstraintsMix value)`
 
+Sets size constraints on the component.
+
 #### `decoration(DecorationMix value)`
+
+Sets the container decoration.
 
 #### `margin(EdgeInsetsGeometryMix value)`
 
+Sets the container margin.
+
 #### `foregroundDecoration(DecorationMix value)`
+
+Sets a foreground decoration painted on top of the component.
 
 #### `transform(Matrix4 value, AlignmentGeometry alignment = Alignment.center)`
 
+Applies a matrix transformation to the component.
+
 #### `wrap(WidgetModifierConfig value)`
 
+Applies widget modifiers such as clipping, opacity, or scaling.
+
 #### `animate(AnimationConfig animation)`
+
+Configures implicit animation for style transitions.
 

--- a/docs/components/spinner.mdx
+++ b/docs/components/spinner.mdx
@@ -91,11 +91,6 @@ class FortalSpinnerExample extends StatelessWidget {
 ```dart
 const RemixSpinner({
   Key? key,
-  double? size,
-  double? strokeWidth,
-  Color? indicatorColor,
-  Color? trackColor,
-  Duration? duration,
   RemixSpinnerStyle style = const RemixSpinnerStyle.create(),
   RemixSpinnerSpec? styleSpec,
 })
@@ -106,13 +101,13 @@ const RemixSpinner({
 ## Properties
 ### Widget Properties
 
-#### `style` → `Key?`
+#### `style` → `RemixSpinnerStyle`
 
-Optional. 
+Optional. The style configuration for the spinner. Customize colors, sizing, stroke, and animation duration.
 
-#### `styleSpec` → `Key?`
+#### `styleSpec` → `RemixSpinnerSpec?`
 
-Optional. 
+Optional. A pre-resolved style spec that bypasses style resolution. Useful for performance when sharing resolved styles across multiple instances.
 
 #### `key` → `Key?`
 
@@ -123,17 +118,33 @@ Optional. Controls how one widget replaces another widget in the tree.
 
 #### `size(double value)`
 
+Sets the spinner size (width and height).
+
 #### `indicatorColor(Color value)`
+
+Sets the color of the spinning indicator.
 
 #### `trackColor(Color value)`
 
+Sets the color of the track (background ring).
+
 #### `strokeWidth(double value)`
+
+Sets the stroke width of the indicator.
 
 #### `trackStrokeWidth(double value)`
 
+Sets the stroke width of the track.
+
 #### `duration(Duration value)`
+
+Sets the duration of one full rotation.
 
 #### `animate(AnimationConfig animation)`
 
+Configures implicit animation for style transitions.
+
 #### `wrap(WidgetModifierConfig value)`
+
+Applies widget modifiers such as clipping, opacity, or scaling.
 

--- a/docs/components/switch.mdx
+++ b/docs/components/switch.mdx
@@ -206,17 +206,33 @@ Sets container alignment
 
 #### `wrap(WidgetModifierConfig value)`
 
+Applies widget modifiers such as clipping, opacity, or scaling.
+
 #### `animate(AnimationConfig config)`
+
+Configures implicit animation for style transitions.
 
 #### `constraints(BoxConstraintsMix value)`
 
+Sets size constraints on the component.
+
 #### `decoration(DecorationMix value)`
+
+Sets the container decoration.
 
 #### `margin(EdgeInsetsGeometryMix value)`
 
+Sets the container margin.
+
 #### `padding(EdgeInsetsGeometryMix value)`
+
+Sets the container padding.
 
 #### `foregroundDecoration(DecorationMix value)`
 
+Sets a foreground decoration painted on top of the component.
+
 #### `transform(Matrix4 value, AlignmentGeometry alignment = Alignment.center)`
+
+Applies a matrix transformation to the component.
 

--- a/docs/components/tabs.mdx
+++ b/docs/components/tabs.mdx
@@ -172,9 +172,13 @@ class _FortalTabsExampleState extends State<FortalTabsExample> {
 // Tabs Container
 const RemixTabs({
   Key? key,
-  required String selectedTabId,
-  required ValueChanged<String> onChanged,
   required Widget child,
+  NakedTabController? controller,
+  String? selectedTabId,
+  ValueChanged<String>? onChanged,
+  Axis orientation = Axis.horizontal,
+  bool enabled = true,
+  VoidCallback? onEscapePressed,
 })
 
 // Tab Bar
@@ -182,17 +186,26 @@ const RemixTabBar({
   Key? key,
   required Widget child,
   RemixTabBarStyle style = const RemixTabBarStyle.create(),
-  RemixTabBarSpec? styleSpec,
 })
 
 // Individual Tab
 const RemixTab({
   Key? key,
   required String tabId,
+  Widget? child,
   String? label,
   IconData? icon,
+  bool enabled = true,
+  MouseCursor mouseCursor = SystemMouseCursors.click,
+  bool enableFeedback = true,
+  FocusNode? focusNode,
+  bool autofocus = false,
+  ValueChanged<bool>? onFocusChange,
+  ValueChanged<bool>? onHoverChange,
+  ValueChanged<bool>? onPressChange,
+  ValueWidgetBuilder<NakedTabState>? builder,
+  String? semanticLabel,
   RemixTabStyle style = const RemixTabStyle.create(),
-  RemixTabSpec? styleSpec,
 })
 
 // Tab View
@@ -201,7 +214,6 @@ const RemixTabView({
   required String tabId,
   required Widget child,
   RemixTabViewStyle style = const RemixTabViewStyle.create(),
-  RemixTabViewSpec? styleSpec,
 })
 ```
 </CodeGroup>
@@ -251,29 +263,55 @@ Sets container alignment
 
 #### `container(FlexBoxStyler value)`
 
+Configures the container flex box style.
+
 #### `label(TextStyler value)`
+
+Configures the label text style using a TextStyler.
 
 #### `icon(IconStyler value)`
 
+Configures the icon style using an IconStyler.
+
 #### `animate(AnimationConfig animation)`
+
+Configures implicit animation for style transitions.
 
 #### `wrap(WidgetModifierConfig value)`
 
+Applies widget modifiers such as clipping, opacity, or scaling.
+
 #### `flex(FlexStyler value)`
+
+Configures the flex layout properties.
 
 #### `foregroundDecoration(DecorationMix value)`
 
+Sets a foreground decoration painted on top of the component.
+
 #### `transform(Matrix4 value, AlignmentGeometry alignment = Alignment.center)`
+
+Applies a matrix transformation to the component.
 
 #### `color(Color value)`
 
+Sets background color.
+
 #### `constraints(BoxConstraintsMix value)`
+
+Sets size constraints on the component.
 
 #### `decoration(DecorationMix value)`
 
+Sets the container decoration.
+
 #### `margin(EdgeInsetsGeometryMix value)`
 
+Sets the container margin.
+
 #### `padding(EdgeInsetsGeometryMix value)`
+
+Sets the container padding.
 
 #### `labelTextStyle(TextStyleMix value)`
 

--- a/docs/components/textfield.mdx
+++ b/docs/components/textfield.mdx
@@ -145,18 +145,57 @@ const RemixTextField({
   String? label,
   String? hintText,
   String? helperText,
-  String? errorText,
+  bool error = false,
   TextInputType? keyboardType,
   TextInputAction? textInputAction,
+  TextCapitalization textCapitalization = TextCapitalization.none,
+  TextDirection? textDirection,
   bool obscureText = false,
   bool enabled = true,
   bool readOnly = false,
   bool autofocus = false,
   int? maxLines = 1,
+  int? minLines,
+  bool expands = false,
   int? maxLength,
+  MaxLengthEnforcement? maxLengthEnforcement,
   ValueChanged<String>? onChanged,
   VoidCallback? onEditingComplete,
   ValueChanged<String>? onSubmitted,
+  AppPrivateCommandCallback? onAppPrivateCommand,
+  List<TextInputFormatter>? inputFormatters,
+  bool? showCursor,
+  String obscuringCharacter = '•',
+  bool autocorrect = true,
+  bool enableSuggestions = true,
+  SmartDashesType? smartDashesType,
+  SmartQuotesType? smartQuotesType,
+  DragStartBehavior dragStartBehavior = DragStartBehavior.start,
+  bool enableInteractiveSelection = true,
+  TextSelectionControls? selectionControls,
+  TapRegionCallback? onTapOutside,
+  TapRegionUpCallback? onPressUpOutside,
+  bool onTapAlwaysCalled = false,
+  ScrollController? scrollController,
+  ScrollPhysics? scrollPhysics,
+  Iterable<String>? autofillHints,
+  ContentInsertionConfiguration? contentInsertionConfiguration,
+  Clip clipBehavior = Clip.hardEdge,
+  String? restorationId,
+  bool stylusHandwritingEnabled = true,
+  bool enableIMEPersonalizedLearning = true,
+  EditableTextContextMenuBuilder? contextMenuBuilder,
+  SpellCheckConfiguration? spellCheckConfiguration,
+  TextMagnifierConfiguration? magnifierConfiguration,
+  bool canRequestFocus = true,
+  bool? ignorePointers,
+  UndoHistoryController? undoController,
+  Object groupId = EditableText,
+  Widget? leading,
+  Widget? trailing,
+  String? semanticLabel,
+  String? semanticHint,
+  bool excludeSemantics = false,
   RemixTextFieldStyle style = const RemixTextFieldStyle.create(),
   RemixTextFieldSpec? styleSpec,
 })
@@ -387,10 +426,6 @@ Optional. A widget to display at the leading edge of the text field.
 
 Optional. A widget to display at the trailing edge of the text field.
 
-#### `onPressed` → `VoidCallback?`
-
-Optional. Called when the text field is pressed (for tap interactions).
-
 #### `semanticLabel` → `String?`
 
 Optional. The semantic label for the text field.
@@ -452,7 +487,7 @@ Sets hint text color
 
 #### `hintText(TextStyler value)`
 
-Sets hint text color
+Sets hint text style using a TextStyler.
 
 #### `margin(EdgeInsetsGeometryMix value)`
 
@@ -492,11 +527,19 @@ Sets animation
 
 #### `wrap(WidgetModifierConfig value)`
 
+Applies widget modifiers such as clipping, opacity, or scaling.
+
 #### `foregroundDecoration(DecorationMix value)`
+
+Sets a foreground decoration painted on top of the component.
 
 #### `transform(Matrix4 value, AlignmentGeometry alignment = Alignment.center)`
 
+Applies a matrix transformation to the component.
+
 #### `flex(FlexStyler value)`
+
+Configures the flex layout properties.
 
 #### `labelTextStyle(TextStyleMix value)`
 

--- a/docs/components/tooltip.mdx
+++ b/docs/components/tooltip.mdx
@@ -134,8 +134,7 @@ const RemixTooltip({
   Key? key,
   required Widget child,
   required Widget tooltipChild,
-  Duration? waitDuration,
-  Duration? showDuration,
+  String? tooltipSemantics,
   RemixTooltipStyle style = const RemixTooltipStyle.create(),
   RemixTooltipSpec? styleSpec,
 })
@@ -207,11 +206,21 @@ Sets the show duration before hiding tooltip
 
 #### `wrap(WidgetModifierConfig value)`
 
+Applies widget modifiers such as clipping, opacity, or scaling.
+
 #### `animate(AnimationConfig config)`
+
+Configures implicit animation for style transitions.
 
 #### `constraints(BoxConstraintsMix value)`
 
+Sets size constraints on the component.
+
 #### `foregroundDecoration(DecorationMix value)`
 
+Sets a foreground decoration painted on top of the component.
+
 #### `transform(Matrix4 value, AlignmentGeometry alignment = Alignment.center)`
+
+Applies a matrix transformation to the component.
 


### PR DESCRIPTION
## Description

Cross-referenced all 18 component MDX documentation files against their Dart widget source code and fixed every mismatch found. This includes correcting wrong property types (`Key?` instead of actual style types in 7 files), removing phantom properties that don't exist in source (e.g. `textBuilder`/`iconBuilder` on Callout, `enabled`/`onDoubleTap` on IconButton), fixing constructor signatures to match reality (e.g. Button's `icon` → `leadingIcon`/`trailingIcon`), adding missing constructor parameters (Menu, Select, Tabs, TextField), filling in empty descriptions for `style`/`styleSpec` and ~100 undescribed style methods, and correcting required/optional mismatches (Checkbox, Tabs, Menu, Select).

## Related Issues

*No related issues.*

---

## Checklist

- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors.
- [x] I have updated or added relevant documentation (doc comments with `///`).
- [x] I am prepared to follow up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.