### PR TITLE
chore: preview spec migration to mix_generator on btwld/mix#918

### DIFF
--- a/packages/remix/lib/src/components/accordion/accordion.g.dart
+++ b/packages/remix/lib/src/components/accordion/accordion.g.dart
@@ -6,12 +6,15 @@ part of 'accordion.dart';
 // SpecGenerator
 // **************************************************************************
 
-mixin _$RemixAccordionSpecMethods on Spec<RemixAccordionSpec>, Diagnosticable {
+mixin _$RemixAccordionSpec implements Spec<RemixAccordionSpec>, Diagnosticable {
   StyleSpec<FlexBoxSpec> get trigger;
   StyleSpec<IconSpec> get leadingIcon;
   StyleSpec<TextSpec> get title;
   StyleSpec<IconSpec> get trailingIcon;
   StyleSpec<BoxSpec> get content;
+
+  @override
+  Type get type => RemixAccordionSpec;
 
   @override
   RemixAccordionSpec copyWith({
@@ -42,17 +45,6 @@ mixin _$RemixAccordionSpecMethods on Spec<RemixAccordionSpec>, Diagnosticable {
   }
 
   @override
-  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
-    properties
-      ..add(DiagnosticsProperty('trigger', trigger))
-      ..add(DiagnosticsProperty('leadingIcon', leadingIcon))
-      ..add(DiagnosticsProperty('title', title))
-      ..add(DiagnosticsProperty('trailingIcon', trailingIcon))
-      ..add(DiagnosticsProperty('content', content));
-  }
-
-  @override
   List<Object?> get props => [
     trigger,
     leadingIcon,
@@ -60,7 +52,59 @@ mixin _$RemixAccordionSpecMethods on Spec<RemixAccordionSpec>, Diagnosticable {
     trailingIcon,
     content,
   ];
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        other is RemixAccordionSpec &&
+            runtimeType == other.runtimeType &&
+            propsEquals(props, other.props);
+  }
+
+  @override
+  int get hashCode => propsHash(runtimeType, props);
+
+  @override
+  bool get stringify => true;
+
+  @override
+  Map<String, String> getDiff(Equatable other) {
+    if (this == other) return const {};
+
+    return propsDiff(props, other.props);
+  }
+
+  @override
+  String toStringShort() => '$runtimeType';
+
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) =>
+      toDiagnosticsNode(
+        style: DiagnosticsTreeStyle.singleLine,
+      ).toString(minLevel: minLevel);
+
+  @override
+  DiagnosticsNode toDiagnosticsNode({
+    String? name,
+    DiagnosticsTreeStyle? style,
+  }) =>
+      DiagnosticableNode<Diagnosticable>(name: name, value: this, style: style);
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    properties
+      ..add(DiagnosticsProperty('trigger', trigger))
+      ..add(DiagnosticsProperty('leadingIcon', leadingIcon))
+      ..add(DiagnosticsProperty('title', title))
+      ..add(DiagnosticsProperty('trailingIcon', trailingIcon))
+      ..add(DiagnosticsProperty('content', content));
+  }
 }
+
+@Deprecated(
+  'Rename to `_\$RemixAccordionSpec` and migrate the class declaration to `class RemixAccordionSpec with _\$RemixAccordionSpec`. The `_\$RemixAccordionSpecMethods` alias will be removed in mix_generator 3.0.',
+)
+typedef _$RemixAccordionSpecMethods = _$RemixAccordionSpec; // ignore: unused_element
 
 // **************************************************************************
 // StylerGenerator

--- a/packages/remix/lib/src/components/accordion/accordion_spec.dart
+++ b/packages/remix/lib/src/components/accordion/accordion_spec.dart
@@ -1,8 +1,7 @@
 part of 'accordion.dart';
 
 @MixableSpec()
-class RemixAccordionSpec extends Spec<RemixAccordionSpec>
-    with Diagnosticable, _$RemixAccordionSpecMethods {
+class RemixAccordionSpec with _$RemixAccordionSpec {
   @override
   final StyleSpec<FlexBoxSpec> trigger;
   @override

--- a/packages/remix/lib/src/components/avatar/avatar.g.dart
+++ b/packages/remix/lib/src/components/avatar/avatar.g.dart
@@ -6,10 +6,13 @@ part of 'avatar.dart';
 // SpecGenerator
 // **************************************************************************
 
-mixin _$RemixAvatarSpecMethods on Spec<RemixAvatarSpec>, Diagnosticable {
+mixin _$RemixAvatarSpec implements Spec<RemixAvatarSpec>, Diagnosticable {
   StyleSpec<BoxSpec> get container;
   StyleSpec<TextSpec> get text;
   StyleSpec<IconSpec> get icon;
+
+  @override
+  Type get type => RemixAvatarSpec;
 
   @override
   RemixAvatarSpec copyWith({
@@ -34,17 +37,58 @@ mixin _$RemixAvatarSpecMethods on Spec<RemixAvatarSpec>, Diagnosticable {
   }
 
   @override
+  List<Object?> get props => [container, text, icon];
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        other is RemixAvatarSpec &&
+            runtimeType == other.runtimeType &&
+            propsEquals(props, other.props);
+  }
+
+  @override
+  int get hashCode => propsHash(runtimeType, props);
+
+  @override
+  bool get stringify => true;
+
+  @override
+  Map<String, String> getDiff(Equatable other) {
+    if (this == other) return const {};
+
+    return propsDiff(props, other.props);
+  }
+
+  @override
+  String toStringShort() => '$runtimeType';
+
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) =>
+      toDiagnosticsNode(
+        style: DiagnosticsTreeStyle.singleLine,
+      ).toString(minLevel: minLevel);
+
+  @override
+  DiagnosticsNode toDiagnosticsNode({
+    String? name,
+    DiagnosticsTreeStyle? style,
+  }) =>
+      DiagnosticableNode<Diagnosticable>(name: name, value: this, style: style);
+
+  @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
     properties
       ..add(DiagnosticsProperty('container', container))
       ..add(DiagnosticsProperty('text', text))
       ..add(DiagnosticsProperty('icon', icon));
   }
-
-  @override
-  List<Object?> get props => [container, text, icon];
 }
+
+@Deprecated(
+  'Rename to `_\$RemixAvatarSpec` and migrate the class declaration to `class RemixAvatarSpec with _\$RemixAvatarSpec`. The `_\$RemixAvatarSpecMethods` alias will be removed in mix_generator 3.0.',
+)
+typedef _$RemixAvatarSpecMethods = _$RemixAvatarSpec; // ignore: unused_element
 
 // **************************************************************************
 // StylerGenerator

--- a/packages/remix/lib/src/components/avatar/avatar_spec.dart
+++ b/packages/remix/lib/src/components/avatar/avatar_spec.dart
@@ -1,8 +1,7 @@
 part of 'avatar.dart';
 
 @MixableSpec()
-class RemixAvatarSpec extends Spec<RemixAvatarSpec>
-    with Diagnosticable, _$RemixAvatarSpecMethods {
+class RemixAvatarSpec with _$RemixAvatarSpec {
   @override
   final StyleSpec<BoxSpec> container;
   @override

--- a/packages/remix/lib/src/components/badge/badge.g.dart
+++ b/packages/remix/lib/src/components/badge/badge.g.dart
@@ -6,9 +6,12 @@ part of 'badge.dart';
 // SpecGenerator
 // **************************************************************************
 
-mixin _$RemixBadgeSpecMethods on Spec<RemixBadgeSpec>, Diagnosticable {
+mixin _$RemixBadgeSpec implements Spec<RemixBadgeSpec>, Diagnosticable {
   StyleSpec<BoxSpec> get container;
   StyleSpec<TextSpec> get text;
+
+  @override
+  Type get type => RemixBadgeSpec;
 
   @override
   RemixBadgeSpec copyWith({
@@ -30,16 +33,57 @@ mixin _$RemixBadgeSpecMethods on Spec<RemixBadgeSpec>, Diagnosticable {
   }
 
   @override
+  List<Object?> get props => [container, text];
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        other is RemixBadgeSpec &&
+            runtimeType == other.runtimeType &&
+            propsEquals(props, other.props);
+  }
+
+  @override
+  int get hashCode => propsHash(runtimeType, props);
+
+  @override
+  bool get stringify => true;
+
+  @override
+  Map<String, String> getDiff(Equatable other) {
+    if (this == other) return const {};
+
+    return propsDiff(props, other.props);
+  }
+
+  @override
+  String toStringShort() => '$runtimeType';
+
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) =>
+      toDiagnosticsNode(
+        style: DiagnosticsTreeStyle.singleLine,
+      ).toString(minLevel: minLevel);
+
+  @override
+  DiagnosticsNode toDiagnosticsNode({
+    String? name,
+    DiagnosticsTreeStyle? style,
+  }) =>
+      DiagnosticableNode<Diagnosticable>(name: name, value: this, style: style);
+
+  @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
     properties
       ..add(DiagnosticsProperty('container', container))
       ..add(DiagnosticsProperty('text', text));
   }
-
-  @override
-  List<Object?> get props => [container, text];
 }
+
+@Deprecated(
+  'Rename to `_\$RemixBadgeSpec` and migrate the class declaration to `class RemixBadgeSpec with _\$RemixBadgeSpec`. The `_\$RemixBadgeSpecMethods` alias will be removed in mix_generator 3.0.',
+)
+typedef _$RemixBadgeSpecMethods = _$RemixBadgeSpec; // ignore: unused_element
 
 // **************************************************************************
 // StylerGenerator

--- a/packages/remix/lib/src/components/badge/badge_spec.dart
+++ b/packages/remix/lib/src/components/badge/badge_spec.dart
@@ -1,8 +1,7 @@
 part of 'badge.dart';
 
 @MixableSpec()
-class RemixBadgeSpec extends Spec<RemixBadgeSpec>
-    with Diagnosticable, _$RemixBadgeSpecMethods {
+class RemixBadgeSpec with _$RemixBadgeSpec {
   @override
   final StyleSpec<BoxSpec> container;
   @override

--- a/packages/remix/lib/src/components/button/button.g.dart
+++ b/packages/remix/lib/src/components/button/button.g.dart
@@ -6,12 +6,15 @@ part of 'button.dart';
 // SpecGenerator
 // **************************************************************************
 
-mixin _$RemixButtonSpecMethods on Spec<RemixButtonSpec>, Diagnosticable {
+mixin _$RemixButtonSpec implements Spec<RemixButtonSpec>, Diagnosticable {
   StyleSpec<FlexBoxSpec> get container;
   StyleSpec<TextSpec> get label;
   StyleSpec<IconSpec> get icon;
   StyleSpec<RemixSpinnerSpec> get spinner;
   IconAlignment get iconAlignment;
+
+  @override
+  Type get type => RemixButtonSpec;
 
   @override
   RemixButtonSpec copyWith({
@@ -42,8 +45,47 @@ mixin _$RemixButtonSpecMethods on Spec<RemixButtonSpec>, Diagnosticable {
   }
 
   @override
+  List<Object?> get props => [container, label, icon, spinner, iconAlignment];
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        other is RemixButtonSpec &&
+            runtimeType == other.runtimeType &&
+            propsEquals(props, other.props);
+  }
+
+  @override
+  int get hashCode => propsHash(runtimeType, props);
+
+  @override
+  bool get stringify => true;
+
+  @override
+  Map<String, String> getDiff(Equatable other) {
+    if (this == other) return const {};
+
+    return propsDiff(props, other.props);
+  }
+
+  @override
+  String toStringShort() => '$runtimeType';
+
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) =>
+      toDiagnosticsNode(
+        style: DiagnosticsTreeStyle.singleLine,
+      ).toString(minLevel: minLevel);
+
+  @override
+  DiagnosticsNode toDiagnosticsNode({
+    String? name,
+    DiagnosticsTreeStyle? style,
+  }) =>
+      DiagnosticableNode<Diagnosticable>(name: name, value: this, style: style);
+
+  @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
     properties
       ..add(DiagnosticsProperty('container', container))
       ..add(DiagnosticsProperty('label', label))
@@ -51,10 +93,12 @@ mixin _$RemixButtonSpecMethods on Spec<RemixButtonSpec>, Diagnosticable {
       ..add(DiagnosticsProperty('spinner', spinner))
       ..add(DiagnosticsProperty('iconAlignment', iconAlignment));
   }
-
-  @override
-  List<Object?> get props => [container, label, icon, spinner, iconAlignment];
 }
+
+@Deprecated(
+  'Rename to `_\$RemixButtonSpec` and migrate the class declaration to `class RemixButtonSpec with _\$RemixButtonSpec`. The `_\$RemixButtonSpecMethods` alias will be removed in mix_generator 3.0.',
+)
+typedef _$RemixButtonSpecMethods = _$RemixButtonSpec; // ignore: unused_element
 
 // **************************************************************************
 // StylerGenerator

--- a/packages/remix/lib/src/components/button/button_spec.dart
+++ b/packages/remix/lib/src/components/button/button_spec.dart
@@ -50,8 +50,7 @@ part of 'button.dart';
 /// - [RemixButton] for the widget implementation
 /// - [Spec] for the base specification pattern
 @MixableSpec()
-class RemixButtonSpec extends Spec<RemixButtonSpec>
-    with Diagnosticable, _$RemixButtonSpecMethods {
+class RemixButtonSpec with _$RemixButtonSpec {
   /// Styling specification for the button's container.
   ///
   /// Controls the button's layout, background, borders, padding,

--- a/packages/remix/lib/src/components/callout/callout.g.dart
+++ b/packages/remix/lib/src/components/callout/callout.g.dart
@@ -6,10 +6,13 @@ part of 'callout.dart';
 // SpecGenerator
 // **************************************************************************
 
-mixin _$RemixCalloutSpecMethods on Spec<RemixCalloutSpec>, Diagnosticable {
+mixin _$RemixCalloutSpec implements Spec<RemixCalloutSpec>, Diagnosticable {
   StyleSpec<FlexBoxSpec> get container;
   StyleSpec<TextSpec> get text;
   StyleSpec<IconSpec> get icon;
+
+  @override
+  Type get type => RemixCalloutSpec;
 
   @override
   RemixCalloutSpec copyWith({
@@ -34,17 +37,58 @@ mixin _$RemixCalloutSpecMethods on Spec<RemixCalloutSpec>, Diagnosticable {
   }
 
   @override
+  List<Object?> get props => [container, text, icon];
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        other is RemixCalloutSpec &&
+            runtimeType == other.runtimeType &&
+            propsEquals(props, other.props);
+  }
+
+  @override
+  int get hashCode => propsHash(runtimeType, props);
+
+  @override
+  bool get stringify => true;
+
+  @override
+  Map<String, String> getDiff(Equatable other) {
+    if (this == other) return const {};
+
+    return propsDiff(props, other.props);
+  }
+
+  @override
+  String toStringShort() => '$runtimeType';
+
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) =>
+      toDiagnosticsNode(
+        style: DiagnosticsTreeStyle.singleLine,
+      ).toString(minLevel: minLevel);
+
+  @override
+  DiagnosticsNode toDiagnosticsNode({
+    String? name,
+    DiagnosticsTreeStyle? style,
+  }) =>
+      DiagnosticableNode<Diagnosticable>(name: name, value: this, style: style);
+
+  @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
     properties
       ..add(DiagnosticsProperty('container', container))
       ..add(DiagnosticsProperty('text', text))
       ..add(DiagnosticsProperty('icon', icon));
   }
-
-  @override
-  List<Object?> get props => [container, text, icon];
 }
+
+@Deprecated(
+  'Rename to `_\$RemixCalloutSpec` and migrate the class declaration to `class RemixCalloutSpec with _\$RemixCalloutSpec`. The `_\$RemixCalloutSpecMethods` alias will be removed in mix_generator 3.0.',
+)
+typedef _$RemixCalloutSpecMethods = _$RemixCalloutSpec; // ignore: unused_element
 
 // **************************************************************************
 // StylerGenerator

--- a/packages/remix/lib/src/components/callout/callout_spec.dart
+++ b/packages/remix/lib/src/components/callout/callout_spec.dart
@@ -1,8 +1,7 @@
 part of 'callout.dart';
 
 @MixableSpec()
-class RemixCalloutSpec extends Spec<RemixCalloutSpec>
-    with Diagnosticable, _$RemixCalloutSpecMethods {
+class RemixCalloutSpec with _$RemixCalloutSpec {
   @override
   final StyleSpec<FlexBoxSpec> container;
   @override

--- a/packages/remix/lib/src/components/card/card.g.dart
+++ b/packages/remix/lib/src/components/card/card.g.dart
@@ -6,8 +6,11 @@ part of 'card.dart';
 // SpecGenerator
 // **************************************************************************
 
-mixin _$RemixCardSpecMethods on Spec<RemixCardSpec>, Diagnosticable {
+mixin _$RemixCardSpec implements Spec<RemixCardSpec>, Diagnosticable {
   StyleSpec<BoxSpec> get container;
+
+  @override
+  Type get type => RemixCardSpec;
 
   @override
   RemixCardSpec copyWith({StyleSpec<BoxSpec>? container}) {
@@ -20,14 +23,55 @@ mixin _$RemixCardSpecMethods on Spec<RemixCardSpec>, Diagnosticable {
   }
 
   @override
-  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
-    properties..add(DiagnosticsProperty('container', container));
+  List<Object?> get props => [container];
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        other is RemixCardSpec &&
+            runtimeType == other.runtimeType &&
+            propsEquals(props, other.props);
   }
 
   @override
-  List<Object?> get props => [container];
+  int get hashCode => propsHash(runtimeType, props);
+
+  @override
+  bool get stringify => true;
+
+  @override
+  Map<String, String> getDiff(Equatable other) {
+    if (this == other) return const {};
+
+    return propsDiff(props, other.props);
+  }
+
+  @override
+  String toStringShort() => '$runtimeType';
+
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) =>
+      toDiagnosticsNode(
+        style: DiagnosticsTreeStyle.singleLine,
+      ).toString(minLevel: minLevel);
+
+  @override
+  DiagnosticsNode toDiagnosticsNode({
+    String? name,
+    DiagnosticsTreeStyle? style,
+  }) =>
+      DiagnosticableNode<Diagnosticable>(name: name, value: this, style: style);
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    properties..add(DiagnosticsProperty('container', container));
+  }
 }
+
+@Deprecated(
+  'Rename to `_\$RemixCardSpec` and migrate the class declaration to `class RemixCardSpec with _\$RemixCardSpec`. The `_\$RemixCardSpecMethods` alias will be removed in mix_generator 3.0.',
+)
+typedef _$RemixCardSpecMethods = _$RemixCardSpec; // ignore: unused_element
 
 // **************************************************************************
 // StylerGenerator

--- a/packages/remix/lib/src/components/card/card_spec.dart
+++ b/packages/remix/lib/src/components/card/card_spec.dart
@@ -1,8 +1,7 @@
 part of 'card.dart';
 
 @MixableSpec()
-class RemixCardSpec extends Spec<RemixCardSpec>
-    with Diagnosticable, _$RemixCardSpecMethods {
+class RemixCardSpec with _$RemixCardSpec {
   @override
   final StyleSpec<BoxSpec> container;
 

--- a/packages/remix/lib/src/components/checkbox/checkbox.g.dart
+++ b/packages/remix/lib/src/components/checkbox/checkbox.g.dart
@@ -6,9 +6,12 @@ part of 'checkbox.dart';
 // SpecGenerator
 // **************************************************************************
 
-mixin _$RemixCheckboxSpecMethods on Spec<RemixCheckboxSpec>, Diagnosticable {
+mixin _$RemixCheckboxSpec implements Spec<RemixCheckboxSpec>, Diagnosticable {
   StyleSpec<BoxSpec> get container;
   StyleSpec<IconSpec> get indicator;
+
+  @override
+  Type get type => RemixCheckboxSpec;
 
   @override
   RemixCheckboxSpec copyWith({
@@ -30,16 +33,57 @@ mixin _$RemixCheckboxSpecMethods on Spec<RemixCheckboxSpec>, Diagnosticable {
   }
 
   @override
+  List<Object?> get props => [container, indicator];
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        other is RemixCheckboxSpec &&
+            runtimeType == other.runtimeType &&
+            propsEquals(props, other.props);
+  }
+
+  @override
+  int get hashCode => propsHash(runtimeType, props);
+
+  @override
+  bool get stringify => true;
+
+  @override
+  Map<String, String> getDiff(Equatable other) {
+    if (this == other) return const {};
+
+    return propsDiff(props, other.props);
+  }
+
+  @override
+  String toStringShort() => '$runtimeType';
+
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) =>
+      toDiagnosticsNode(
+        style: DiagnosticsTreeStyle.singleLine,
+      ).toString(minLevel: minLevel);
+
+  @override
+  DiagnosticsNode toDiagnosticsNode({
+    String? name,
+    DiagnosticsTreeStyle? style,
+  }) =>
+      DiagnosticableNode<Diagnosticable>(name: name, value: this, style: style);
+
+  @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
     properties
       ..add(DiagnosticsProperty('container', container))
       ..add(DiagnosticsProperty('indicator', indicator));
   }
-
-  @override
-  List<Object?> get props => [container, indicator];
 }
+
+@Deprecated(
+  'Rename to `_\$RemixCheckboxSpec` and migrate the class declaration to `class RemixCheckboxSpec with _\$RemixCheckboxSpec`. The `_\$RemixCheckboxSpecMethods` alias will be removed in mix_generator 3.0.',
+)
+typedef _$RemixCheckboxSpecMethods = _$RemixCheckboxSpec; // ignore: unused_element
 
 // **************************************************************************
 // StylerGenerator

--- a/packages/remix/lib/src/components/checkbox/checkbox_spec.dart
+++ b/packages/remix/lib/src/components/checkbox/checkbox_spec.dart
@@ -54,8 +54,7 @@ part of 'checkbox.dart';
 /// - [RemixCheckbox] for the widget implementation
 /// - [Spec] for the base specification pattern
 @MixableSpec()
-class RemixCheckboxSpec extends Spec<RemixCheckboxSpec>
-    with Diagnosticable, _$RemixCheckboxSpecMethods {
+class RemixCheckboxSpec with _$RemixCheckboxSpec {
   /// Styling specification for the checkbox box container.
   ///
   /// Defines the appearance of the checkbox box itself, including

--- a/packages/remix/lib/src/components/dialog/dialog.g.dart
+++ b/packages/remix/lib/src/components/dialog/dialog.g.dart
@@ -6,12 +6,15 @@ part of 'dialog.dart';
 // SpecGenerator
 // **************************************************************************
 
-mixin _$RemixDialogSpecMethods on Spec<RemixDialogSpec>, Diagnosticable {
+mixin _$RemixDialogSpec implements Spec<RemixDialogSpec>, Diagnosticable {
   StyleSpec<BoxSpec> get container;
   StyleSpec<TextSpec> get title;
   StyleSpec<TextSpec> get description;
   StyleSpec<FlexBoxSpec> get actions;
   StyleSpec<BoxSpec> get overlay;
+
+  @override
+  Type get type => RemixDialogSpec;
 
   @override
   RemixDialogSpec copyWith({
@@ -42,8 +45,47 @@ mixin _$RemixDialogSpecMethods on Spec<RemixDialogSpec>, Diagnosticable {
   }
 
   @override
+  List<Object?> get props => [container, title, description, actions, overlay];
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        other is RemixDialogSpec &&
+            runtimeType == other.runtimeType &&
+            propsEquals(props, other.props);
+  }
+
+  @override
+  int get hashCode => propsHash(runtimeType, props);
+
+  @override
+  bool get stringify => true;
+
+  @override
+  Map<String, String> getDiff(Equatable other) {
+    if (this == other) return const {};
+
+    return propsDiff(props, other.props);
+  }
+
+  @override
+  String toStringShort() => '$runtimeType';
+
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) =>
+      toDiagnosticsNode(
+        style: DiagnosticsTreeStyle.singleLine,
+      ).toString(minLevel: minLevel);
+
+  @override
+  DiagnosticsNode toDiagnosticsNode({
+    String? name,
+    DiagnosticsTreeStyle? style,
+  }) =>
+      DiagnosticableNode<Diagnosticable>(name: name, value: this, style: style);
+
+  @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
     properties
       ..add(DiagnosticsProperty('container', container))
       ..add(DiagnosticsProperty('title', title))
@@ -51,10 +93,12 @@ mixin _$RemixDialogSpecMethods on Spec<RemixDialogSpec>, Diagnosticable {
       ..add(DiagnosticsProperty('actions', actions))
       ..add(DiagnosticsProperty('overlay', overlay));
   }
-
-  @override
-  List<Object?> get props => [container, title, description, actions, overlay];
 }
+
+@Deprecated(
+  'Rename to `_\$RemixDialogSpec` and migrate the class declaration to `class RemixDialogSpec with _\$RemixDialogSpec`. The `_\$RemixDialogSpecMethods` alias will be removed in mix_generator 3.0.',
+)
+typedef _$RemixDialogSpecMethods = _$RemixDialogSpec; // ignore: unused_element
 
 // **************************************************************************
 // StylerGenerator

--- a/packages/remix/lib/src/components/dialog/dialog_spec.dart
+++ b/packages/remix/lib/src/components/dialog/dialog_spec.dart
@@ -1,8 +1,7 @@
 part of 'dialog.dart';
 
 @MixableSpec()
-class RemixDialogSpec extends Spec<RemixDialogSpec>
-    with Diagnosticable, _$RemixDialogSpecMethods {
+class RemixDialogSpec with _$RemixDialogSpec {
   @override
   final StyleSpec<BoxSpec> container;
   @override

--- a/packages/remix/lib/src/components/divider/divider.g.dart
+++ b/packages/remix/lib/src/components/divider/divider.g.dart
@@ -6,8 +6,11 @@ part of 'divider.dart';
 // SpecGenerator
 // **************************************************************************
 
-mixin _$RemixDividerSpecMethods on Spec<RemixDividerSpec>, Diagnosticable {
+mixin _$RemixDividerSpec implements Spec<RemixDividerSpec>, Diagnosticable {
   StyleSpec<BoxSpec> get container;
+
+  @override
+  Type get type => RemixDividerSpec;
 
   @override
   RemixDividerSpec copyWith({StyleSpec<BoxSpec>? container}) {
@@ -20,14 +23,55 @@ mixin _$RemixDividerSpecMethods on Spec<RemixDividerSpec>, Diagnosticable {
   }
 
   @override
-  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
-    properties..add(DiagnosticsProperty('container', container));
+  List<Object?> get props => [container];
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        other is RemixDividerSpec &&
+            runtimeType == other.runtimeType &&
+            propsEquals(props, other.props);
   }
 
   @override
-  List<Object?> get props => [container];
+  int get hashCode => propsHash(runtimeType, props);
+
+  @override
+  bool get stringify => true;
+
+  @override
+  Map<String, String> getDiff(Equatable other) {
+    if (this == other) return const {};
+
+    return propsDiff(props, other.props);
+  }
+
+  @override
+  String toStringShort() => '$runtimeType';
+
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) =>
+      toDiagnosticsNode(
+        style: DiagnosticsTreeStyle.singleLine,
+      ).toString(minLevel: minLevel);
+
+  @override
+  DiagnosticsNode toDiagnosticsNode({
+    String? name,
+    DiagnosticsTreeStyle? style,
+  }) =>
+      DiagnosticableNode<Diagnosticable>(name: name, value: this, style: style);
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    properties..add(DiagnosticsProperty('container', container));
+  }
 }
+
+@Deprecated(
+  'Rename to `_\$RemixDividerSpec` and migrate the class declaration to `class RemixDividerSpec with _\$RemixDividerSpec`. The `_\$RemixDividerSpecMethods` alias will be removed in mix_generator 3.0.',
+)
+typedef _$RemixDividerSpecMethods = _$RemixDividerSpec; // ignore: unused_element
 
 // **************************************************************************
 // StylerGenerator

--- a/packages/remix/lib/src/components/divider/divider_spec.dart
+++ b/packages/remix/lib/src/components/divider/divider_spec.dart
@@ -1,8 +1,7 @@
 part of 'divider.dart';
 
 @MixableSpec()
-class RemixDividerSpec extends Spec<RemixDividerSpec>
-    with Diagnosticable, _$RemixDividerSpecMethods {
+class RemixDividerSpec with _$RemixDividerSpec {
   @override
   final StyleSpec<BoxSpec> container;
 

--- a/packages/remix/lib/src/components/icon_button/icon_button.g.dart
+++ b/packages/remix/lib/src/components/icon_button/icon_button.g.dart
@@ -6,11 +6,14 @@ part of 'icon_button.dart';
 // SpecGenerator
 // **************************************************************************
 
-mixin _$RemixIconButtonSpecMethods
-    on Spec<RemixIconButtonSpec>, Diagnosticable {
+mixin _$RemixIconButtonSpec
+    implements Spec<RemixIconButtonSpec>, Diagnosticable {
   StyleSpec<BoxSpec> get container;
   StyleSpec<IconSpec> get icon;
   StyleSpec<RemixSpinnerSpec> get spinner;
+
+  @override
+  Type get type => RemixIconButtonSpec;
 
   @override
   RemixIconButtonSpec copyWith({
@@ -35,17 +38,58 @@ mixin _$RemixIconButtonSpecMethods
   }
 
   @override
+  List<Object?> get props => [container, icon, spinner];
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        other is RemixIconButtonSpec &&
+            runtimeType == other.runtimeType &&
+            propsEquals(props, other.props);
+  }
+
+  @override
+  int get hashCode => propsHash(runtimeType, props);
+
+  @override
+  bool get stringify => true;
+
+  @override
+  Map<String, String> getDiff(Equatable other) {
+    if (this == other) return const {};
+
+    return propsDiff(props, other.props);
+  }
+
+  @override
+  String toStringShort() => '$runtimeType';
+
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) =>
+      toDiagnosticsNode(
+        style: DiagnosticsTreeStyle.singleLine,
+      ).toString(minLevel: minLevel);
+
+  @override
+  DiagnosticsNode toDiagnosticsNode({
+    String? name,
+    DiagnosticsTreeStyle? style,
+  }) =>
+      DiagnosticableNode<Diagnosticable>(name: name, value: this, style: style);
+
+  @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
     properties
       ..add(DiagnosticsProperty('container', container))
       ..add(DiagnosticsProperty('icon', icon))
       ..add(DiagnosticsProperty('spinner', spinner));
   }
-
-  @override
-  List<Object?> get props => [container, icon, spinner];
 }
+
+@Deprecated(
+  'Rename to `_\$RemixIconButtonSpec` and migrate the class declaration to `class RemixIconButtonSpec with _\$RemixIconButtonSpec`. The `_\$RemixIconButtonSpecMethods` alias will be removed in mix_generator 3.0.',
+)
+typedef _$RemixIconButtonSpecMethods = _$RemixIconButtonSpec; // ignore: unused_element
 
 // **************************************************************************
 // StylerGenerator

--- a/packages/remix/lib/src/components/icon_button/icon_button_spec.dart
+++ b/packages/remix/lib/src/components/icon_button/icon_button_spec.dart
@@ -1,8 +1,7 @@
 part of 'icon_button.dart';
 
 @MixableSpec()
-class RemixIconButtonSpec extends Spec<RemixIconButtonSpec>
-    with Diagnosticable, _$RemixIconButtonSpecMethods {
+class RemixIconButtonSpec with _$RemixIconButtonSpec {
   @override
   final StyleSpec<BoxSpec> container;
   @override

--- a/packages/remix/lib/src/components/menu/menu.g.dart
+++ b/packages/remix/lib/src/components/menu/menu.g.dart
@@ -6,11 +6,14 @@ part of 'menu.dart';
 // SpecGenerator
 // **************************************************************************
 
-mixin _$RemixMenuTriggerSpecMethods
-    on Spec<RemixMenuTriggerSpec>, Diagnosticable {
+mixin _$RemixMenuTriggerSpec
+    implements Spec<RemixMenuTriggerSpec>, Diagnosticable {
   StyleSpec<FlexBoxSpec> get container;
   StyleSpec<TextSpec> get label;
   StyleSpec<IconSpec> get icon;
+
+  @override
+  Type get type => RemixMenuTriggerSpec;
 
   @override
   RemixMenuTriggerSpec copyWith({
@@ -35,23 +38,67 @@ mixin _$RemixMenuTriggerSpecMethods
   }
 
   @override
+  List<Object?> get props => [container, label, icon];
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        other is RemixMenuTriggerSpec &&
+            runtimeType == other.runtimeType &&
+            propsEquals(props, other.props);
+  }
+
+  @override
+  int get hashCode => propsHash(runtimeType, props);
+
+  @override
+  bool get stringify => true;
+
+  @override
+  Map<String, String> getDiff(Equatable other) {
+    if (this == other) return const {};
+
+    return propsDiff(props, other.props);
+  }
+
+  @override
+  String toStringShort() => '$runtimeType';
+
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) =>
+      toDiagnosticsNode(
+        style: DiagnosticsTreeStyle.singleLine,
+      ).toString(minLevel: minLevel);
+
+  @override
+  DiagnosticsNode toDiagnosticsNode({
+    String? name,
+    DiagnosticsTreeStyle? style,
+  }) =>
+      DiagnosticableNode<Diagnosticable>(name: name, value: this, style: style);
+
+  @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
     properties
       ..add(DiagnosticsProperty('container', container))
       ..add(DiagnosticsProperty('label', label))
       ..add(DiagnosticsProperty('icon', icon));
   }
-
-  @override
-  List<Object?> get props => [container, label, icon];
 }
 
-mixin _$RemixMenuSpecMethods on Spec<RemixMenuSpec>, Diagnosticable {
+@Deprecated(
+  'Rename to `_\$RemixMenuTriggerSpec` and migrate the class declaration to `class RemixMenuTriggerSpec with _\$RemixMenuTriggerSpec`. The `_\$RemixMenuTriggerSpecMethods` alias will be removed in mix_generator 3.0.',
+)
+typedef _$RemixMenuTriggerSpecMethods = _$RemixMenuTriggerSpec; // ignore: unused_element
+
+mixin _$RemixMenuSpec implements Spec<RemixMenuSpec>, Diagnosticable {
   StyleSpec<RemixMenuTriggerSpec> get trigger;
   StyleSpec<FlexBoxSpec> get overlay;
   StyleSpec<RemixMenuItemSpec> get item;
   StyleSpec<RemixDividerSpec> get divider;
+
+  @override
+  Type get type => RemixMenuSpec;
 
   @override
   RemixMenuSpec copyWith({
@@ -79,24 +126,68 @@ mixin _$RemixMenuSpecMethods on Spec<RemixMenuSpec>, Diagnosticable {
   }
 
   @override
+  List<Object?> get props => [trigger, overlay, item, divider];
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        other is RemixMenuSpec &&
+            runtimeType == other.runtimeType &&
+            propsEquals(props, other.props);
+  }
+
+  @override
+  int get hashCode => propsHash(runtimeType, props);
+
+  @override
+  bool get stringify => true;
+
+  @override
+  Map<String, String> getDiff(Equatable other) {
+    if (this == other) return const {};
+
+    return propsDiff(props, other.props);
+  }
+
+  @override
+  String toStringShort() => '$runtimeType';
+
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) =>
+      toDiagnosticsNode(
+        style: DiagnosticsTreeStyle.singleLine,
+      ).toString(minLevel: minLevel);
+
+  @override
+  DiagnosticsNode toDiagnosticsNode({
+    String? name,
+    DiagnosticsTreeStyle? style,
+  }) =>
+      DiagnosticableNode<Diagnosticable>(name: name, value: this, style: style);
+
+  @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
     properties
       ..add(DiagnosticsProperty('trigger', trigger))
       ..add(DiagnosticsProperty('overlay', overlay))
       ..add(DiagnosticsProperty('item', item))
       ..add(DiagnosticsProperty('divider', divider));
   }
-
-  @override
-  List<Object?> get props => [trigger, overlay, item, divider];
 }
 
-mixin _$RemixMenuItemSpecMethods on Spec<RemixMenuItemSpec>, Diagnosticable {
+@Deprecated(
+  'Rename to `_\$RemixMenuSpec` and migrate the class declaration to `class RemixMenuSpec with _\$RemixMenuSpec`. The `_\$RemixMenuSpecMethods` alias will be removed in mix_generator 3.0.',
+)
+typedef _$RemixMenuSpecMethods = _$RemixMenuSpec; // ignore: unused_element
+
+mixin _$RemixMenuItemSpec implements Spec<RemixMenuItemSpec>, Diagnosticable {
   StyleSpec<FlexBoxSpec> get container;
   StyleSpec<TextSpec> get label;
   StyleSpec<IconSpec> get leadingIcon;
   StyleSpec<IconSpec> get trailingIcon;
+
+  @override
+  Type get type => RemixMenuItemSpec;
 
   @override
   RemixMenuItemSpec copyWith({
@@ -124,18 +215,59 @@ mixin _$RemixMenuItemSpecMethods on Spec<RemixMenuItemSpec>, Diagnosticable {
   }
 
   @override
+  List<Object?> get props => [container, label, leadingIcon, trailingIcon];
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        other is RemixMenuItemSpec &&
+            runtimeType == other.runtimeType &&
+            propsEquals(props, other.props);
+  }
+
+  @override
+  int get hashCode => propsHash(runtimeType, props);
+
+  @override
+  bool get stringify => true;
+
+  @override
+  Map<String, String> getDiff(Equatable other) {
+    if (this == other) return const {};
+
+    return propsDiff(props, other.props);
+  }
+
+  @override
+  String toStringShort() => '$runtimeType';
+
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) =>
+      toDiagnosticsNode(
+        style: DiagnosticsTreeStyle.singleLine,
+      ).toString(minLevel: minLevel);
+
+  @override
+  DiagnosticsNode toDiagnosticsNode({
+    String? name,
+    DiagnosticsTreeStyle? style,
+  }) =>
+      DiagnosticableNode<Diagnosticable>(name: name, value: this, style: style);
+
+  @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
     properties
       ..add(DiagnosticsProperty('container', container))
       ..add(DiagnosticsProperty('label', label))
       ..add(DiagnosticsProperty('leadingIcon', leadingIcon))
       ..add(DiagnosticsProperty('trailingIcon', trailingIcon));
   }
-
-  @override
-  List<Object?> get props => [container, label, leadingIcon, trailingIcon];
 }
+
+@Deprecated(
+  'Rename to `_\$RemixMenuItemSpec` and migrate the class declaration to `class RemixMenuItemSpec with _\$RemixMenuItemSpec`. The `_\$RemixMenuItemSpecMethods` alias will be removed in mix_generator 3.0.',
+)
+typedef _$RemixMenuItemSpecMethods = _$RemixMenuItemSpec; // ignore: unused_element
 
 // **************************************************************************
 // StylerGenerator

--- a/packages/remix/lib/src/components/menu/menu_spec.dart
+++ b/packages/remix/lib/src/components/menu/menu_spec.dart
@@ -5,8 +5,7 @@ part of 'menu.dart';
 // ============================================================================
 
 @MixableSpec()
-class RemixMenuTriggerSpec extends Spec<RemixMenuTriggerSpec>
-    with Diagnosticable, _$RemixMenuTriggerSpecMethods {
+class RemixMenuTriggerSpec with _$RemixMenuTriggerSpec {
   @override
   final StyleSpec<FlexBoxSpec> container;
   @override
@@ -28,8 +27,7 @@ class RemixMenuTriggerSpec extends Spec<RemixMenuTriggerSpec>
 // ============================================================================
 
 @MixableSpec()
-class RemixMenuSpec extends Spec<RemixMenuSpec>
-    with Diagnosticable, _$RemixMenuSpecMethods {
+class RemixMenuSpec with _$RemixMenuSpec {
   @override
   final StyleSpec<RemixMenuTriggerSpec> trigger;
   @override
@@ -55,8 +53,7 @@ class RemixMenuSpec extends Spec<RemixMenuSpec>
 // ============================================================================
 
 @MixableSpec()
-class RemixMenuItemSpec extends Spec<RemixMenuItemSpec>
-    with Diagnosticable, _$RemixMenuItemSpecMethods {
+class RemixMenuItemSpec with _$RemixMenuItemSpec {
   @override
   final StyleSpec<FlexBoxSpec> container;
   @override

--- a/packages/remix/lib/src/components/progress/progress.g.dart
+++ b/packages/remix/lib/src/components/progress/progress.g.dart
@@ -6,11 +6,14 @@ part of 'progress.dart';
 // SpecGenerator
 // **************************************************************************
 
-mixin _$RemixProgressSpecMethods on Spec<RemixProgressSpec>, Diagnosticable {
+mixin _$RemixProgressSpec implements Spec<RemixProgressSpec>, Diagnosticable {
   StyleSpec<BoxSpec> get container;
   StyleSpec<BoxSpec> get track;
   StyleSpec<BoxSpec> get indicator;
   StyleSpec<BoxSpec> get trackContainer;
+
+  @override
+  Type get type => RemixProgressSpec;
 
   @override
   RemixProgressSpec copyWith({
@@ -38,18 +41,59 @@ mixin _$RemixProgressSpecMethods on Spec<RemixProgressSpec>, Diagnosticable {
   }
 
   @override
+  List<Object?> get props => [container, track, indicator, trackContainer];
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        other is RemixProgressSpec &&
+            runtimeType == other.runtimeType &&
+            propsEquals(props, other.props);
+  }
+
+  @override
+  int get hashCode => propsHash(runtimeType, props);
+
+  @override
+  bool get stringify => true;
+
+  @override
+  Map<String, String> getDiff(Equatable other) {
+    if (this == other) return const {};
+
+    return propsDiff(props, other.props);
+  }
+
+  @override
+  String toStringShort() => '$runtimeType';
+
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) =>
+      toDiagnosticsNode(
+        style: DiagnosticsTreeStyle.singleLine,
+      ).toString(minLevel: minLevel);
+
+  @override
+  DiagnosticsNode toDiagnosticsNode({
+    String? name,
+    DiagnosticsTreeStyle? style,
+  }) =>
+      DiagnosticableNode<Diagnosticable>(name: name, value: this, style: style);
+
+  @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
     properties
       ..add(DiagnosticsProperty('container', container))
       ..add(DiagnosticsProperty('track', track))
       ..add(DiagnosticsProperty('indicator', indicator))
       ..add(DiagnosticsProperty('trackContainer', trackContainer));
   }
-
-  @override
-  List<Object?> get props => [container, track, indicator, trackContainer];
 }
+
+@Deprecated(
+  'Rename to `_\$RemixProgressSpec` and migrate the class declaration to `class RemixProgressSpec with _\$RemixProgressSpec`. The `_\$RemixProgressSpecMethods` alias will be removed in mix_generator 3.0.',
+)
+typedef _$RemixProgressSpecMethods = _$RemixProgressSpec; // ignore: unused_element
 
 // **************************************************************************
 // StylerGenerator

--- a/packages/remix/lib/src/components/progress/progress_spec.dart
+++ b/packages/remix/lib/src/components/progress/progress_spec.dart
@@ -1,8 +1,7 @@
 part of 'progress.dart';
 
 @MixableSpec()
-class RemixProgressSpec extends Spec<RemixProgressSpec>
-    with Diagnosticable, _$RemixProgressSpecMethods {
+class RemixProgressSpec with _$RemixProgressSpec {
   @override
   final StyleSpec<BoxSpec> container;
   @override

--- a/packages/remix/lib/src/components/radio/radio.g.dart
+++ b/packages/remix/lib/src/components/radio/radio.g.dart
@@ -6,9 +6,12 @@ part of 'radio.dart';
 // SpecGenerator
 // **************************************************************************
 
-mixin _$RemixRadioSpecMethods on Spec<RemixRadioSpec>, Diagnosticable {
+mixin _$RemixRadioSpec implements Spec<RemixRadioSpec>, Diagnosticable {
   StyleSpec<BoxSpec> get container;
   StyleSpec<BoxSpec> get indicator;
+
+  @override
+  Type get type => RemixRadioSpec;
 
   @override
   RemixRadioSpec copyWith({
@@ -30,16 +33,57 @@ mixin _$RemixRadioSpecMethods on Spec<RemixRadioSpec>, Diagnosticable {
   }
 
   @override
+  List<Object?> get props => [container, indicator];
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        other is RemixRadioSpec &&
+            runtimeType == other.runtimeType &&
+            propsEquals(props, other.props);
+  }
+
+  @override
+  int get hashCode => propsHash(runtimeType, props);
+
+  @override
+  bool get stringify => true;
+
+  @override
+  Map<String, String> getDiff(Equatable other) {
+    if (this == other) return const {};
+
+    return propsDiff(props, other.props);
+  }
+
+  @override
+  String toStringShort() => '$runtimeType';
+
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) =>
+      toDiagnosticsNode(
+        style: DiagnosticsTreeStyle.singleLine,
+      ).toString(minLevel: minLevel);
+
+  @override
+  DiagnosticsNode toDiagnosticsNode({
+    String? name,
+    DiagnosticsTreeStyle? style,
+  }) =>
+      DiagnosticableNode<Diagnosticable>(name: name, value: this, style: style);
+
+  @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
     properties
       ..add(DiagnosticsProperty('container', container))
       ..add(DiagnosticsProperty('indicator', indicator));
   }
-
-  @override
-  List<Object?> get props => [container, indicator];
 }
+
+@Deprecated(
+  'Rename to `_\$RemixRadioSpec` and migrate the class declaration to `class RemixRadioSpec with _\$RemixRadioSpec`. The `_\$RemixRadioSpecMethods` alias will be removed in mix_generator 3.0.',
+)
+typedef _$RemixRadioSpecMethods = _$RemixRadioSpec; // ignore: unused_element
 
 // **************************************************************************
 // StylerGenerator

--- a/packages/remix/lib/src/components/radio/radio_spec.dart
+++ b/packages/remix/lib/src/components/radio/radio_spec.dart
@@ -6,8 +6,7 @@ part of 'radio.dart';
 /// building the control. It provides two [StyleSpec] segments representing the
 /// container (outer ring) and the indicator fill shown when the radio is selected.
 @MixableSpec()
-class RemixRadioSpec extends Spec<RemixRadioSpec>
-    with Diagnosticable, _$RemixRadioSpecMethods {
+class RemixRadioSpec with _$RemixRadioSpec {
   @override
   final StyleSpec<BoxSpec> container;
   @override

--- a/packages/remix/lib/src/components/select/select.g.dart
+++ b/packages/remix/lib/src/components/select/select.g.dart
@@ -6,10 +6,13 @@ part of 'select.dart';
 // SpecGenerator
 // **************************************************************************
 
-mixin _$RemixSelectSpecMethods on Spec<RemixSelectSpec>, Diagnosticable {
+mixin _$RemixSelectSpec implements Spec<RemixSelectSpec>, Diagnosticable {
   StyleSpec<RemixSelectTriggerSpec> get trigger;
   StyleSpec<FlexBoxSpec> get menuContainer;
   StyleSpec<RemixSelectMenuItemSpec> get item;
+
+  @override
+  Type get type => RemixSelectSpec;
 
   @override
   RemixSelectSpec copyWith({
@@ -34,23 +37,67 @@ mixin _$RemixSelectSpecMethods on Spec<RemixSelectSpec>, Diagnosticable {
   }
 
   @override
+  List<Object?> get props => [trigger, menuContainer, item];
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        other is RemixSelectSpec &&
+            runtimeType == other.runtimeType &&
+            propsEquals(props, other.props);
+  }
+
+  @override
+  int get hashCode => propsHash(runtimeType, props);
+
+  @override
+  bool get stringify => true;
+
+  @override
+  Map<String, String> getDiff(Equatable other) {
+    if (this == other) return const {};
+
+    return propsDiff(props, other.props);
+  }
+
+  @override
+  String toStringShort() => '$runtimeType';
+
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) =>
+      toDiagnosticsNode(
+        style: DiagnosticsTreeStyle.singleLine,
+      ).toString(minLevel: minLevel);
+
+  @override
+  DiagnosticsNode toDiagnosticsNode({
+    String? name,
+    DiagnosticsTreeStyle? style,
+  }) =>
+      DiagnosticableNode<Diagnosticable>(name: name, value: this, style: style);
+
+  @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
     properties
       ..add(DiagnosticsProperty('trigger', trigger))
       ..add(DiagnosticsProperty('menuContainer', menuContainer))
       ..add(DiagnosticsProperty('item', item));
   }
-
-  @override
-  List<Object?> get props => [trigger, menuContainer, item];
 }
 
-mixin _$RemixSelectTriggerSpecMethods
-    on Spec<RemixSelectTriggerSpec>, Diagnosticable {
+@Deprecated(
+  'Rename to `_\$RemixSelectSpec` and migrate the class declaration to `class RemixSelectSpec with _\$RemixSelectSpec`. The `_\$RemixSelectSpecMethods` alias will be removed in mix_generator 3.0.',
+)
+typedef _$RemixSelectSpecMethods = _$RemixSelectSpec; // ignore: unused_element
+
+mixin _$RemixSelectTriggerSpec
+    implements Spec<RemixSelectTriggerSpec>, Diagnosticable {
   StyleSpec<FlexBoxSpec> get container;
   StyleSpec<TextSpec> get label;
   StyleSpec<IconSpec> get icon;
+
+  @override
+  Type get type => RemixSelectTriggerSpec;
 
   @override
   RemixSelectTriggerSpec copyWith({
@@ -75,23 +122,67 @@ mixin _$RemixSelectTriggerSpecMethods
   }
 
   @override
+  List<Object?> get props => [container, label, icon];
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        other is RemixSelectTriggerSpec &&
+            runtimeType == other.runtimeType &&
+            propsEquals(props, other.props);
+  }
+
+  @override
+  int get hashCode => propsHash(runtimeType, props);
+
+  @override
+  bool get stringify => true;
+
+  @override
+  Map<String, String> getDiff(Equatable other) {
+    if (this == other) return const {};
+
+    return propsDiff(props, other.props);
+  }
+
+  @override
+  String toStringShort() => '$runtimeType';
+
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) =>
+      toDiagnosticsNode(
+        style: DiagnosticsTreeStyle.singleLine,
+      ).toString(minLevel: minLevel);
+
+  @override
+  DiagnosticsNode toDiagnosticsNode({
+    String? name,
+    DiagnosticsTreeStyle? style,
+  }) =>
+      DiagnosticableNode<Diagnosticable>(name: name, value: this, style: style);
+
+  @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
     properties
       ..add(DiagnosticsProperty('container', container))
       ..add(DiagnosticsProperty('label', label))
       ..add(DiagnosticsProperty('icon', icon));
   }
-
-  @override
-  List<Object?> get props => [container, label, icon];
 }
 
-mixin _$RemixSelectMenuItemSpecMethods
-    on Spec<RemixSelectMenuItemSpec>, Diagnosticable {
+@Deprecated(
+  'Rename to `_\$RemixSelectTriggerSpec` and migrate the class declaration to `class RemixSelectTriggerSpec with _\$RemixSelectTriggerSpec`. The `_\$RemixSelectTriggerSpecMethods` alias will be removed in mix_generator 3.0.',
+)
+typedef _$RemixSelectTriggerSpecMethods = _$RemixSelectTriggerSpec; // ignore: unused_element
+
+mixin _$RemixSelectMenuItemSpec
+    implements Spec<RemixSelectMenuItemSpec>, Diagnosticable {
   StyleSpec<FlexBoxSpec> get container;
   StyleSpec<TextSpec> get text;
   StyleSpec<IconSpec> get icon;
+
+  @override
+  Type get type => RemixSelectMenuItemSpec;
 
   @override
   RemixSelectMenuItemSpec copyWith({
@@ -116,17 +207,58 @@ mixin _$RemixSelectMenuItemSpecMethods
   }
 
   @override
+  List<Object?> get props => [container, text, icon];
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        other is RemixSelectMenuItemSpec &&
+            runtimeType == other.runtimeType &&
+            propsEquals(props, other.props);
+  }
+
+  @override
+  int get hashCode => propsHash(runtimeType, props);
+
+  @override
+  bool get stringify => true;
+
+  @override
+  Map<String, String> getDiff(Equatable other) {
+    if (this == other) return const {};
+
+    return propsDiff(props, other.props);
+  }
+
+  @override
+  String toStringShort() => '$runtimeType';
+
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) =>
+      toDiagnosticsNode(
+        style: DiagnosticsTreeStyle.singleLine,
+      ).toString(minLevel: minLevel);
+
+  @override
+  DiagnosticsNode toDiagnosticsNode({
+    String? name,
+    DiagnosticsTreeStyle? style,
+  }) =>
+      DiagnosticableNode<Diagnosticable>(name: name, value: this, style: style);
+
+  @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
     properties
       ..add(DiagnosticsProperty('container', container))
       ..add(DiagnosticsProperty('text', text))
       ..add(DiagnosticsProperty('icon', icon));
   }
-
-  @override
-  List<Object?> get props => [container, text, icon];
 }
+
+@Deprecated(
+  'Rename to `_\$RemixSelectMenuItemSpec` and migrate the class declaration to `class RemixSelectMenuItemSpec with _\$RemixSelectMenuItemSpec`. The `_\$RemixSelectMenuItemSpecMethods` alias will be removed in mix_generator 3.0.',
+)
+typedef _$RemixSelectMenuItemSpecMethods = _$RemixSelectMenuItemSpec; // ignore: unused_element
 
 // **************************************************************************
 // StylerGenerator

--- a/packages/remix/lib/src/components/select/select_spec.dart
+++ b/packages/remix/lib/src/components/select/select_spec.dart
@@ -1,8 +1,7 @@
 part of 'select.dart';
 
 @MixableSpec()
-class RemixSelectSpec extends Spec<RemixSelectSpec>
-    with Diagnosticable, _$RemixSelectSpecMethods {
+class RemixSelectSpec with _$RemixSelectSpec {
   @override
   final StyleSpec<RemixSelectTriggerSpec> trigger;
   @override
@@ -20,8 +19,7 @@ class RemixSelectSpec extends Spec<RemixSelectSpec>
 }
 
 @MixableSpec()
-class RemixSelectTriggerSpec extends Spec<RemixSelectTriggerSpec>
-    with Diagnosticable, _$RemixSelectTriggerSpecMethods {
+class RemixSelectTriggerSpec with _$RemixSelectTriggerSpec {
   @override
   final StyleSpec<FlexBoxSpec> container;
   @override
@@ -39,8 +37,7 @@ class RemixSelectTriggerSpec extends Spec<RemixSelectTriggerSpec>
 }
 
 @MixableSpec()
-class RemixSelectMenuItemSpec extends Spec<RemixSelectMenuItemSpec>
-    with Diagnosticable, _$RemixSelectMenuItemSpecMethods {
+class RemixSelectMenuItemSpec with _$RemixSelectMenuItemSpec {
   @override
   final StyleSpec<FlexBoxSpec> container;
   @override

--- a/packages/remix/lib/src/components/slider/slider.g.dart
+++ b/packages/remix/lib/src/components/slider/slider.g.dart
@@ -6,12 +6,15 @@ part of 'slider.dart';
 // SpecGenerator
 // **************************************************************************
 
-mixin _$RemixSliderSpecMethods on Spec<RemixSliderSpec>, Diagnosticable {
+mixin _$RemixSliderSpec implements Spec<RemixSliderSpec>, Diagnosticable {
   StyleSpec<BoxSpec> get thumb;
   Color get trackColor;
   double get trackWidth;
   Color get rangeColor;
   double get rangeWidth;
+
+  @override
+  Type get type => RemixSliderSpec;
 
   @override
   RemixSliderSpec copyWith({
@@ -42,17 +45,6 @@ mixin _$RemixSliderSpecMethods on Spec<RemixSliderSpec>, Diagnosticable {
   }
 
   @override
-  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
-    properties
-      ..add(DiagnosticsProperty('thumb', thumb))
-      ..add(ColorProperty('trackColor', trackColor))
-      ..add(DoubleProperty('trackWidth', trackWidth))
-      ..add(ColorProperty('rangeColor', rangeColor))
-      ..add(DoubleProperty('rangeWidth', rangeWidth));
-  }
-
-  @override
   List<Object?> get props => [
     thumb,
     trackColor,
@@ -60,4 +52,56 @@ mixin _$RemixSliderSpecMethods on Spec<RemixSliderSpec>, Diagnosticable {
     rangeColor,
     rangeWidth,
   ];
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        other is RemixSliderSpec &&
+            runtimeType == other.runtimeType &&
+            propsEquals(props, other.props);
+  }
+
+  @override
+  int get hashCode => propsHash(runtimeType, props);
+
+  @override
+  bool get stringify => true;
+
+  @override
+  Map<String, String> getDiff(Equatable other) {
+    if (this == other) return const {};
+
+    return propsDiff(props, other.props);
+  }
+
+  @override
+  String toStringShort() => '$runtimeType';
+
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) =>
+      toDiagnosticsNode(
+        style: DiagnosticsTreeStyle.singleLine,
+      ).toString(minLevel: minLevel);
+
+  @override
+  DiagnosticsNode toDiagnosticsNode({
+    String? name,
+    DiagnosticsTreeStyle? style,
+  }) =>
+      DiagnosticableNode<Diagnosticable>(name: name, value: this, style: style);
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    properties
+      ..add(DiagnosticsProperty('thumb', thumb))
+      ..add(ColorProperty('trackColor', trackColor))
+      ..add(DoubleProperty('trackWidth', trackWidth))
+      ..add(ColorProperty('rangeColor', rangeColor))
+      ..add(DoubleProperty('rangeWidth', rangeWidth));
+  }
 }
+
+@Deprecated(
+  'Rename to `_\$RemixSliderSpec` and migrate the class declaration to `class RemixSliderSpec with _\$RemixSliderSpec`. The `_\$RemixSliderSpecMethods` alias will be removed in mix_generator 3.0.',
+)
+typedef _$RemixSliderSpecMethods = _$RemixSliderSpec; // ignore: unused_element

--- a/packages/remix/lib/src/components/slider/slider_spec.dart
+++ b/packages/remix/lib/src/components/slider/slider_spec.dart
@@ -8,8 +8,7 @@ const Color _defaultTrackColor = MixColors.grey;
 const Color _defaultRangeColor = MixColors.black;
 
 @MixableSpec()
-class RemixSliderSpec extends Spec<RemixSliderSpec>
-    with Diagnosticable, _$RemixSliderSpecMethods {
+class RemixSliderSpec with _$RemixSliderSpec {
   static const Size defaultThumbSize = _remixSliderDefaultThumbSize;
   static const double defaultTrackStrokeWidth =
       _remixSliderDefaultTrackStrokeWidth;

--- a/packages/remix/lib/src/components/spinner/spinner.g.dart
+++ b/packages/remix/lib/src/components/spinner/spinner.g.dart
@@ -6,13 +6,16 @@ part of 'spinner.dart';
 // SpecGenerator
 // **************************************************************************
 
-mixin _$RemixSpinnerSpecMethods on Spec<RemixSpinnerSpec>, Diagnosticable {
+mixin _$RemixSpinnerSpec implements Spec<RemixSpinnerSpec>, Diagnosticable {
   double? get size;
   double? get strokeWidth;
   Color? get indicatorColor;
   Color? get trackColor;
   double? get trackStrokeWidth;
   Duration? get duration;
+
+  @override
+  Type get type => RemixSpinnerSpec;
 
   @override
   RemixSpinnerSpec copyWith({
@@ -50,18 +53,6 @@ mixin _$RemixSpinnerSpecMethods on Spec<RemixSpinnerSpec>, Diagnosticable {
   }
 
   @override
-  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
-    properties
-      ..add(DoubleProperty('size', size))
-      ..add(DoubleProperty('strokeWidth', strokeWidth))
-      ..add(ColorProperty('indicatorColor', indicatorColor))
-      ..add(ColorProperty('trackColor', trackColor))
-      ..add(DoubleProperty('trackStrokeWidth', trackStrokeWidth))
-      ..add(DiagnosticsProperty('duration', duration));
-  }
-
-  @override
   List<Object?> get props => [
     size,
     strokeWidth,
@@ -70,7 +61,60 @@ mixin _$RemixSpinnerSpecMethods on Spec<RemixSpinnerSpec>, Diagnosticable {
     trackStrokeWidth,
     duration,
   ];
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        other is RemixSpinnerSpec &&
+            runtimeType == other.runtimeType &&
+            propsEquals(props, other.props);
+  }
+
+  @override
+  int get hashCode => propsHash(runtimeType, props);
+
+  @override
+  bool get stringify => true;
+
+  @override
+  Map<String, String> getDiff(Equatable other) {
+    if (this == other) return const {};
+
+    return propsDiff(props, other.props);
+  }
+
+  @override
+  String toStringShort() => '$runtimeType';
+
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) =>
+      toDiagnosticsNode(
+        style: DiagnosticsTreeStyle.singleLine,
+      ).toString(minLevel: minLevel);
+
+  @override
+  DiagnosticsNode toDiagnosticsNode({
+    String? name,
+    DiagnosticsTreeStyle? style,
+  }) =>
+      DiagnosticableNode<Diagnosticable>(name: name, value: this, style: style);
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    properties
+      ..add(DoubleProperty('size', size))
+      ..add(DoubleProperty('strokeWidth', strokeWidth))
+      ..add(ColorProperty('indicatorColor', indicatorColor))
+      ..add(ColorProperty('trackColor', trackColor))
+      ..add(DoubleProperty('trackStrokeWidth', trackStrokeWidth))
+      ..add(DiagnosticsProperty('duration', duration));
+  }
 }
+
+@Deprecated(
+  'Rename to `_\$RemixSpinnerSpec` and migrate the class declaration to `class RemixSpinnerSpec with _\$RemixSpinnerSpec`. The `_\$RemixSpinnerSpecMethods` alias will be removed in mix_generator 3.0.',
+)
+typedef _$RemixSpinnerSpecMethods = _$RemixSpinnerSpec; // ignore: unused_element
 
 // **************************************************************************
 // StylerGenerator

--- a/packages/remix/lib/src/components/spinner/spinner_spec.dart
+++ b/packages/remix/lib/src/components/spinner/spinner_spec.dart
@@ -1,8 +1,7 @@
 part of 'spinner.dart';
 
 @MixableSpec()
-class RemixSpinnerSpec extends Spec<RemixSpinnerSpec>
-    with Diagnosticable, _$RemixSpinnerSpecMethods {
+class RemixSpinnerSpec with _$RemixSpinnerSpec {
   @override
   final double? size;
   @override

--- a/packages/remix/lib/src/components/switch/switch.g.dart
+++ b/packages/remix/lib/src/components/switch/switch.g.dart
@@ -6,9 +6,12 @@ part of 'switch.dart';
 // SpecGenerator
 // **************************************************************************
 
-mixin _$RemixSwitchSpecMethods on Spec<RemixSwitchSpec>, Diagnosticable {
+mixin _$RemixSwitchSpec implements Spec<RemixSwitchSpec>, Diagnosticable {
   StyleSpec<BoxSpec> get container;
   StyleSpec<BoxSpec> get thumb;
+
+  @override
+  Type get type => RemixSwitchSpec;
 
   @override
   RemixSwitchSpec copyWith({
@@ -30,16 +33,57 @@ mixin _$RemixSwitchSpecMethods on Spec<RemixSwitchSpec>, Diagnosticable {
   }
 
   @override
+  List<Object?> get props => [container, thumb];
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        other is RemixSwitchSpec &&
+            runtimeType == other.runtimeType &&
+            propsEquals(props, other.props);
+  }
+
+  @override
+  int get hashCode => propsHash(runtimeType, props);
+
+  @override
+  bool get stringify => true;
+
+  @override
+  Map<String, String> getDiff(Equatable other) {
+    if (this == other) return const {};
+
+    return propsDiff(props, other.props);
+  }
+
+  @override
+  String toStringShort() => '$runtimeType';
+
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) =>
+      toDiagnosticsNode(
+        style: DiagnosticsTreeStyle.singleLine,
+      ).toString(minLevel: minLevel);
+
+  @override
+  DiagnosticsNode toDiagnosticsNode({
+    String? name,
+    DiagnosticsTreeStyle? style,
+  }) =>
+      DiagnosticableNode<Diagnosticable>(name: name, value: this, style: style);
+
+  @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
     properties
       ..add(DiagnosticsProperty('container', container))
       ..add(DiagnosticsProperty('thumb', thumb));
   }
-
-  @override
-  List<Object?> get props => [container, thumb];
 }
+
+@Deprecated(
+  'Rename to `_\$RemixSwitchSpec` and migrate the class declaration to `class RemixSwitchSpec with _\$RemixSwitchSpec`. The `_\$RemixSwitchSpecMethods` alias will be removed in mix_generator 3.0.',
+)
+typedef _$RemixSwitchSpecMethods = _$RemixSwitchSpec; // ignore: unused_element
 
 // **************************************************************************
 // StylerGenerator

--- a/packages/remix/lib/src/components/switch/switch_spec.dart
+++ b/packages/remix/lib/src/components/switch/switch_spec.dart
@@ -1,8 +1,7 @@
 part of 'switch.dart';
 
 @MixableSpec()
-class RemixSwitchSpec extends Spec<RemixSwitchSpec>
-    with Diagnosticable, _$RemixSwitchSpecMethods {
+class RemixSwitchSpec with _$RemixSwitchSpec {
   @override
   final StyleSpec<BoxSpec> container;
   @override

--- a/packages/remix/lib/src/components/tabs/tabs.g.dart
+++ b/packages/remix/lib/src/components/tabs/tabs.g.dart
@@ -6,8 +6,11 @@ part of 'tabs.dart';
 // SpecGenerator
 // **************************************************************************
 
-mixin _$RemixTabBarSpecMethods on Spec<RemixTabBarSpec>, Diagnosticable {
+mixin _$RemixTabBarSpec implements Spec<RemixTabBarSpec>, Diagnosticable {
   StyleSpec<FlexBoxSpec> get container;
+
+  @override
+  Type get type => RemixTabBarSpec;
 
   @override
   RemixTabBarSpec copyWith({StyleSpec<FlexBoxSpec>? container}) {
@@ -20,19 +23,63 @@ mixin _$RemixTabBarSpecMethods on Spec<RemixTabBarSpec>, Diagnosticable {
   }
 
   @override
-  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
-    properties..add(DiagnosticsProperty('container', container));
+  List<Object?> get props => [container];
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        other is RemixTabBarSpec &&
+            runtimeType == other.runtimeType &&
+            propsEquals(props, other.props);
   }
 
   @override
-  List<Object?> get props => [container];
+  int get hashCode => propsHash(runtimeType, props);
+
+  @override
+  bool get stringify => true;
+
+  @override
+  Map<String, String> getDiff(Equatable other) {
+    if (this == other) return const {};
+
+    return propsDiff(props, other.props);
+  }
+
+  @override
+  String toStringShort() => '$runtimeType';
+
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) =>
+      toDiagnosticsNode(
+        style: DiagnosticsTreeStyle.singleLine,
+      ).toString(minLevel: minLevel);
+
+  @override
+  DiagnosticsNode toDiagnosticsNode({
+    String? name,
+    DiagnosticsTreeStyle? style,
+  }) =>
+      DiagnosticableNode<Diagnosticable>(name: name, value: this, style: style);
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    properties..add(DiagnosticsProperty('container', container));
+  }
 }
 
-mixin _$RemixTabSpecMethods on Spec<RemixTabSpec>, Diagnosticable {
+@Deprecated(
+  'Rename to `_\$RemixTabBarSpec` and migrate the class declaration to `class RemixTabBarSpec with _\$RemixTabBarSpec`. The `_\$RemixTabBarSpecMethods` alias will be removed in mix_generator 3.0.',
+)
+typedef _$RemixTabBarSpecMethods = _$RemixTabBarSpec; // ignore: unused_element
+
+mixin _$RemixTabSpec implements Spec<RemixTabSpec>, Diagnosticable {
   StyleSpec<FlexBoxSpec> get container;
   StyleSpec<TextSpec> get label;
   StyleSpec<IconSpec> get icon;
+
+  @override
+  Type get type => RemixTabSpec;
 
   @override
   RemixTabSpec copyWith({
@@ -57,20 +104,64 @@ mixin _$RemixTabSpecMethods on Spec<RemixTabSpec>, Diagnosticable {
   }
 
   @override
+  List<Object?> get props => [container, label, icon];
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        other is RemixTabSpec &&
+            runtimeType == other.runtimeType &&
+            propsEquals(props, other.props);
+  }
+
+  @override
+  int get hashCode => propsHash(runtimeType, props);
+
+  @override
+  bool get stringify => true;
+
+  @override
+  Map<String, String> getDiff(Equatable other) {
+    if (this == other) return const {};
+
+    return propsDiff(props, other.props);
+  }
+
+  @override
+  String toStringShort() => '$runtimeType';
+
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) =>
+      toDiagnosticsNode(
+        style: DiagnosticsTreeStyle.singleLine,
+      ).toString(minLevel: minLevel);
+
+  @override
+  DiagnosticsNode toDiagnosticsNode({
+    String? name,
+    DiagnosticsTreeStyle? style,
+  }) =>
+      DiagnosticableNode<Diagnosticable>(name: name, value: this, style: style);
+
+  @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
     properties
       ..add(DiagnosticsProperty('container', container))
       ..add(DiagnosticsProperty('label', label))
       ..add(DiagnosticsProperty('icon', icon));
   }
-
-  @override
-  List<Object?> get props => [container, label, icon];
 }
 
-mixin _$RemixTabViewSpecMethods on Spec<RemixTabViewSpec>, Diagnosticable {
+@Deprecated(
+  'Rename to `_\$RemixTabSpec` and migrate the class declaration to `class RemixTabSpec with _\$RemixTabSpec`. The `_\$RemixTabSpecMethods` alias will be removed in mix_generator 3.0.',
+)
+typedef _$RemixTabSpecMethods = _$RemixTabSpec; // ignore: unused_element
+
+mixin _$RemixTabViewSpec implements Spec<RemixTabViewSpec>, Diagnosticable {
   StyleSpec<BoxSpec> get container;
+
+  @override
+  Type get type => RemixTabViewSpec;
 
   @override
   RemixTabViewSpec copyWith({StyleSpec<BoxSpec>? container}) {
@@ -83,14 +174,55 @@ mixin _$RemixTabViewSpecMethods on Spec<RemixTabViewSpec>, Diagnosticable {
   }
 
   @override
-  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
-    properties..add(DiagnosticsProperty('container', container));
+  List<Object?> get props => [container];
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        other is RemixTabViewSpec &&
+            runtimeType == other.runtimeType &&
+            propsEquals(props, other.props);
   }
 
   @override
-  List<Object?> get props => [container];
+  int get hashCode => propsHash(runtimeType, props);
+
+  @override
+  bool get stringify => true;
+
+  @override
+  Map<String, String> getDiff(Equatable other) {
+    if (this == other) return const {};
+
+    return propsDiff(props, other.props);
+  }
+
+  @override
+  String toStringShort() => '$runtimeType';
+
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) =>
+      toDiagnosticsNode(
+        style: DiagnosticsTreeStyle.singleLine,
+      ).toString(minLevel: minLevel);
+
+  @override
+  DiagnosticsNode toDiagnosticsNode({
+    String? name,
+    DiagnosticsTreeStyle? style,
+  }) =>
+      DiagnosticableNode<Diagnosticable>(name: name, value: this, style: style);
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    properties..add(DiagnosticsProperty('container', container));
+  }
 }
+
+@Deprecated(
+  'Rename to `_\$RemixTabViewSpec` and migrate the class declaration to `class RemixTabViewSpec with _\$RemixTabViewSpec`. The `_\$RemixTabViewSpecMethods` alias will be removed in mix_generator 3.0.',
+)
+typedef _$RemixTabViewSpecMethods = _$RemixTabViewSpec; // ignore: unused_element
 
 // **************************************************************************
 // StylerGenerator

--- a/packages/remix/lib/src/components/tabs/tabs_spec.dart
+++ b/packages/remix/lib/src/components/tabs/tabs_spec.dart
@@ -1,8 +1,7 @@
 part of 'tabs.dart';
 
 @MixableSpec()
-class RemixTabBarSpec extends Spec<RemixTabBarSpec>
-    with Diagnosticable, _$RemixTabBarSpecMethods {
+class RemixTabBarSpec with _$RemixTabBarSpec {
   @override
   final StyleSpec<FlexBoxSpec> container;
 
@@ -11,8 +10,7 @@ class RemixTabBarSpec extends Spec<RemixTabBarSpec>
 }
 
 @MixableSpec()
-class RemixTabSpec extends Spec<RemixTabSpec>
-    with Diagnosticable, _$RemixTabSpecMethods {
+class RemixTabSpec with _$RemixTabSpec {
   @override
   final StyleSpec<FlexBoxSpec> container;
   @override
@@ -30,8 +28,7 @@ class RemixTabSpec extends Spec<RemixTabSpec>
 }
 
 @MixableSpec()
-class RemixTabViewSpec extends Spec<RemixTabViewSpec>
-    with Diagnosticable, _$RemixTabViewSpecMethods {
+class RemixTabViewSpec with _$RemixTabViewSpec {
   @override
   final StyleSpec<BoxSpec> container;
 

--- a/packages/remix/lib/src/components/textfield/textfield.g.dart
+++ b/packages/remix/lib/src/components/textfield/textfield.g.dart
@@ -6,7 +6,7 @@ part of 'textfield.dart';
 // SpecGenerator
 // **************************************************************************
 
-mixin _$RemixTextFieldSpecMethods on Spec<RemixTextFieldSpec>, Diagnosticable {
+mixin _$RemixTextFieldSpec implements Spec<RemixTextFieldSpec>, Diagnosticable {
   StyleSpec<TextSpec> get text;
   StyleSpec<TextSpec> get hintText;
   TextAlign? get textAlign;
@@ -24,6 +24,9 @@ mixin _$RemixTextFieldSpecMethods on Spec<RemixTextFieldSpec>, Diagnosticable {
   StyleSpec<FlexBoxSpec> get container;
   StyleSpec<TextSpec> get helperText;
   StyleSpec<TextSpec> get label;
+
+  @override
+  Type get type => RemixTextFieldSpec;
 
   @override
   RemixTextFieldSpec copyWith({
@@ -107,29 +110,6 @@ mixin _$RemixTextFieldSpecMethods on Spec<RemixTextFieldSpec>, Diagnosticable {
   }
 
   @override
-  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
-    properties
-      ..add(DiagnosticsProperty('text', text))
-      ..add(DiagnosticsProperty('hintText', hintText))
-      ..add(EnumProperty<TextAlign>('textAlign', textAlign))
-      ..add(DoubleProperty('cursorWidth', cursorWidth))
-      ..add(DoubleProperty('cursorHeight', cursorHeight))
-      ..add(DiagnosticsProperty('cursorRadius', cursorRadius))
-      ..add(ColorProperty('cursorColor', cursorColor))
-      ..add(DiagnosticsProperty('cursorOffset', cursorOffset))
-      ..add(DiagnosticsProperty('selectionHeightStyle', selectionHeightStyle))
-      ..add(DiagnosticsProperty('selectionWidthStyle', selectionWidthStyle))
-      ..add(DiagnosticsProperty('scrollPadding', scrollPadding))
-      ..add(DiagnosticsProperty('keyboardAppearance', keyboardAppearance))
-      ..add(DiagnosticsProperty('cursorOpacityAnimates', cursorOpacityAnimates))
-      ..add(DoubleProperty('spacing', spacing))
-      ..add(DiagnosticsProperty('container', container))
-      ..add(DiagnosticsProperty('helperText', helperText))
-      ..add(DiagnosticsProperty('label', label));
-  }
-
-  @override
   List<Object?> get props => [
     text,
     hintText,
@@ -149,7 +129,71 @@ mixin _$RemixTextFieldSpecMethods on Spec<RemixTextFieldSpec>, Diagnosticable {
     helperText,
     label,
   ];
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        other is RemixTextFieldSpec &&
+            runtimeType == other.runtimeType &&
+            propsEquals(props, other.props);
+  }
+
+  @override
+  int get hashCode => propsHash(runtimeType, props);
+
+  @override
+  bool get stringify => true;
+
+  @override
+  Map<String, String> getDiff(Equatable other) {
+    if (this == other) return const {};
+
+    return propsDiff(props, other.props);
+  }
+
+  @override
+  String toStringShort() => '$runtimeType';
+
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) =>
+      toDiagnosticsNode(
+        style: DiagnosticsTreeStyle.singleLine,
+      ).toString(minLevel: minLevel);
+
+  @override
+  DiagnosticsNode toDiagnosticsNode({
+    String? name,
+    DiagnosticsTreeStyle? style,
+  }) =>
+      DiagnosticableNode<Diagnosticable>(name: name, value: this, style: style);
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    properties
+      ..add(DiagnosticsProperty('text', text))
+      ..add(DiagnosticsProperty('hintText', hintText))
+      ..add(EnumProperty<TextAlign>('textAlign', textAlign))
+      ..add(DoubleProperty('cursorWidth', cursorWidth))
+      ..add(DoubleProperty('cursorHeight', cursorHeight))
+      ..add(DiagnosticsProperty('cursorRadius', cursorRadius))
+      ..add(ColorProperty('cursorColor', cursorColor))
+      ..add(DiagnosticsProperty('cursorOffset', cursorOffset))
+      ..add(DiagnosticsProperty('selectionHeightStyle', selectionHeightStyle))
+      ..add(DiagnosticsProperty('selectionWidthStyle', selectionWidthStyle))
+      ..add(DiagnosticsProperty('scrollPadding', scrollPadding))
+      ..add(DiagnosticsProperty('keyboardAppearance', keyboardAppearance))
+      ..add(DiagnosticsProperty('cursorOpacityAnimates', cursorOpacityAnimates))
+      ..add(DoubleProperty('spacing', spacing))
+      ..add(DiagnosticsProperty('container', container))
+      ..add(DiagnosticsProperty('helperText', helperText))
+      ..add(DiagnosticsProperty('label', label));
+  }
 }
+
+@Deprecated(
+  'Rename to `_\$RemixTextFieldSpec` and migrate the class declaration to `class RemixTextFieldSpec with _\$RemixTextFieldSpec`. The `_\$RemixTextFieldSpecMethods` alias will be removed in mix_generator 3.0.',
+)
+typedef _$RemixTextFieldSpecMethods = _$RemixTextFieldSpec; // ignore: unused_element
 
 // **************************************************************************
 // StylerGenerator

--- a/packages/remix/lib/src/components/textfield/textfield_spec.dart
+++ b/packages/remix/lib/src/components/textfield/textfield_spec.dart
@@ -50,8 +50,7 @@ part of 'textfield.dart';
 /// - [RemixTextField] for the widget implementation
 /// - [Spec] for the base specification pattern
 @MixableSpec()
-class RemixTextFieldSpec extends Spec<RemixTextFieldSpec>
-    with Diagnosticable, _$RemixTextFieldSpecMethods {
+class RemixTextFieldSpec with _$RemixTextFieldSpec {
   /// Styling specification for the input text.
   ///
   /// Controls typography, color, and text-specific properties

--- a/packages/remix/lib/src/components/toggle/toggle.g.dart
+++ b/packages/remix/lib/src/components/toggle/toggle.g.dart
@@ -6,10 +6,13 @@ part of 'toggle.dart';
 // SpecGenerator
 // **************************************************************************
 
-mixin _$RemixToggleSpecMethods on Spec<RemixToggleSpec>, Diagnosticable {
+mixin _$RemixToggleSpec implements Spec<RemixToggleSpec>, Diagnosticable {
   StyleSpec<FlexBoxSpec> get container;
   StyleSpec<TextSpec> get label;
   StyleSpec<IconSpec> get icon;
+
+  @override
+  Type get type => RemixToggleSpec;
 
   @override
   RemixToggleSpec copyWith({
@@ -34,17 +37,58 @@ mixin _$RemixToggleSpecMethods on Spec<RemixToggleSpec>, Diagnosticable {
   }
 
   @override
+  List<Object?> get props => [container, label, icon];
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        other is RemixToggleSpec &&
+            runtimeType == other.runtimeType &&
+            propsEquals(props, other.props);
+  }
+
+  @override
+  int get hashCode => propsHash(runtimeType, props);
+
+  @override
+  bool get stringify => true;
+
+  @override
+  Map<String, String> getDiff(Equatable other) {
+    if (this == other) return const {};
+
+    return propsDiff(props, other.props);
+  }
+
+  @override
+  String toStringShort() => '$runtimeType';
+
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) =>
+      toDiagnosticsNode(
+        style: DiagnosticsTreeStyle.singleLine,
+      ).toString(minLevel: minLevel);
+
+  @override
+  DiagnosticsNode toDiagnosticsNode({
+    String? name,
+    DiagnosticsTreeStyle? style,
+  }) =>
+      DiagnosticableNode<Diagnosticable>(name: name, value: this, style: style);
+
+  @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
     properties
       ..add(DiagnosticsProperty('container', container))
       ..add(DiagnosticsProperty('label', label))
       ..add(DiagnosticsProperty('icon', icon));
   }
-
-  @override
-  List<Object?> get props => [container, label, icon];
 }
+
+@Deprecated(
+  'Rename to `_\$RemixToggleSpec` and migrate the class declaration to `class RemixToggleSpec with _\$RemixToggleSpec`. The `_\$RemixToggleSpecMethods` alias will be removed in mix_generator 3.0.',
+)
+typedef _$RemixToggleSpecMethods = _$RemixToggleSpec; // ignore: unused_element
 
 // **************************************************************************
 // StylerGenerator

--- a/packages/remix/lib/src/components/toggle/toggle_spec.dart
+++ b/packages/remix/lib/src/components/toggle/toggle_spec.dart
@@ -1,8 +1,7 @@
 part of 'toggle.dart';
 
 @MixableSpec()
-class RemixToggleSpec extends Spec<RemixToggleSpec>
-    with Diagnosticable, _$RemixToggleSpecMethods {
+class RemixToggleSpec with _$RemixToggleSpec {
   @override
   final StyleSpec<FlexBoxSpec> container;
   @override

--- a/packages/remix/lib/src/components/tooltip/tooltip.g.dart
+++ b/packages/remix/lib/src/components/tooltip/tooltip.g.dart
@@ -6,11 +6,14 @@ part of 'tooltip.dart';
 // SpecGenerator
 // **************************************************************************
 
-mixin _$RemixTooltipSpecMethods on Spec<RemixTooltipSpec>, Diagnosticable {
+mixin _$RemixTooltipSpec implements Spec<RemixTooltipSpec>, Diagnosticable {
   StyleSpec<BoxSpec> get container;
   StyleSpec<TextSpec> get label;
   Duration? get waitDuration;
   Duration? get showDuration;
+
+  @override
+  Type get type => RemixTooltipSpec;
 
   @override
   RemixTooltipSpec copyWith({
@@ -38,18 +41,59 @@ mixin _$RemixTooltipSpecMethods on Spec<RemixTooltipSpec>, Diagnosticable {
   }
 
   @override
+  List<Object?> get props => [container, label, waitDuration, showDuration];
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        other is RemixTooltipSpec &&
+            runtimeType == other.runtimeType &&
+            propsEquals(props, other.props);
+  }
+
+  @override
+  int get hashCode => propsHash(runtimeType, props);
+
+  @override
+  bool get stringify => true;
+
+  @override
+  Map<String, String> getDiff(Equatable other) {
+    if (this == other) return const {};
+
+    return propsDiff(props, other.props);
+  }
+
+  @override
+  String toStringShort() => '$runtimeType';
+
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) =>
+      toDiagnosticsNode(
+        style: DiagnosticsTreeStyle.singleLine,
+      ).toString(minLevel: minLevel);
+
+  @override
+  DiagnosticsNode toDiagnosticsNode({
+    String? name,
+    DiagnosticsTreeStyle? style,
+  }) =>
+      DiagnosticableNode<Diagnosticable>(name: name, value: this, style: style);
+
+  @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
     properties
       ..add(DiagnosticsProperty('container', container))
       ..add(DiagnosticsProperty('label', label))
       ..add(DiagnosticsProperty('waitDuration', waitDuration))
       ..add(DiagnosticsProperty('showDuration', showDuration));
   }
-
-  @override
-  List<Object?> get props => [container, label, waitDuration, showDuration];
 }
+
+@Deprecated(
+  'Rename to `_\$RemixTooltipSpec` and migrate the class declaration to `class RemixTooltipSpec with _\$RemixTooltipSpec`. The `_\$RemixTooltipSpecMethods` alias will be removed in mix_generator 3.0.',
+)
+typedef _$RemixTooltipSpecMethods = _$RemixTooltipSpec; // ignore: unused_element
 
 // **************************************************************************
 // StylerGenerator

--- a/packages/remix/lib/src/components/tooltip/tooltip_spec.dart
+++ b/packages/remix/lib/src/components/tooltip/tooltip_spec.dart
@@ -1,8 +1,7 @@
 part of 'tooltip.dart';
 
 @MixableSpec()
-class RemixTooltipSpec extends Spec<RemixTooltipSpec>
-    with Diagnosticable, _$RemixTooltipSpecMethods {
+class RemixTooltipSpec with _$RemixTooltipSpec {
   @override
   final StyleSpec<BoxSpec> container;
   @override


### PR DESCRIPTION
## Description

Preview-only PR to show the team what remix looks like after migrating to the new mix_generator emitted by btwld/mix#918.

- All 23 `*_spec.dart` classes drop `extends Spec<FooSpec> with Diagnosticable, _$FooSpecMethods` in favor of the new self-contained `with _\$FooSpec` mixin.
- All 21 `*.g.dart` files are regenerated against PR #918's `chore/code-generation-clean-up` branch — the new mixin owns `==`, `hashCode`, `props`, `toString`, `toDiagnosticsNode`, `debugFillProperties`, `getDiff`, etc. directly instead of inheriting from `Spec`.

Local verification: `dart run build_runner build` succeeds, `flutter analyze` reports no issues, and all 1722 tests pass when `mix`/`mix_annotations`/`mix_generator` are overridden to PR #918.

## Related Issues

Depends on btwld/mix#918 — do **not** merge until that PR is published. `packages/remix/build.yaml` still references the now-removed `mix_generator:spec` / `mix_generator:property` builder ids and will need cleanup as a follow-up.

---

## Checklist

- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors. (existing test suite covers, 1722/1722 pass)
- [ ] I have updated or added relevant documentation (doc comments with \`///\`).
- [x] I am prepared to follow up on review comments in a timely manner.

## Breaking Change

- [x] Yes, this is a breaking change. (requires mix_generator ≥ 2.0.3 from btwld/mix#918)
- [ ] No, this is *not* a breaking change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)