### PR TITLE
chore: update Mix to 2.1.0 and add mix_lint

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,18 @@
+# Workspace-level analyzer config.
+#
+# `plugins:` must be declared at the root of the pub workspace (the analyzer
+# rejects it inside member packages). mix_lint adds Mix-specific diagnostics on
+# top of each package's own analysis_options.yaml.
+#
+# See https://www.fluttermix.com/documentation/mix/ecosystem/mix-lint
+plugins:
+  mix_lint:
+    diagnostics:
+      mix_avoid_defining_tokens_within_style: true
+      mix_avoid_defining_tokens_within_scope: true
+      mix_avoid_token_ref_outside_mix: true
+      mix_avoid_empty_variants: true
+      mix_max_number_of_attributes_per_style: true
+      mix_variants_last: true
+      mix_mixable_styler_has_create: true
+      mix_prefer_dot_shorthands: true

--- a/packages/remix/lib/src/components/accordion/accordion.g.dart
+++ b/packages/remix/lib/src/components/accordion/accordion.g.dart
@@ -111,15 +111,15 @@ typedef _$RemixAccordionSpecMethods = _$RemixAccordionSpec; // ignore: unused_el
 // **************************************************************************
 
 mixin _$RemixAccordionStyleMixin on Style<RemixAccordionSpec>, Diagnosticable {
-  Prop<StyleSpec<BoxSpec>>? get $content;
+  Prop<StyleSpec<FlexBoxSpec>>? get $trigger;
   Prop<StyleSpec<IconSpec>>? get $leadingIcon;
   Prop<StyleSpec<TextSpec>>? get $title;
   Prop<StyleSpec<IconSpec>>? get $trailingIcon;
-  Prop<StyleSpec<FlexBoxSpec>>? get $trigger;
+  Prop<StyleSpec<BoxSpec>>? get $content;
 
-  /// Sets the content.
-  RemixAccordionStyle content(BoxStyler value) {
-    return merge(RemixAccordionStyle(content: value));
+  /// Sets the trigger.
+  RemixAccordionStyle trigger(FlexBoxStyler value) {
+    return merge(RemixAccordionStyle(trigger: value));
   }
 
   /// Sets the leadingIcon.
@@ -137,9 +137,9 @@ mixin _$RemixAccordionStyleMixin on Style<RemixAccordionSpec>, Diagnosticable {
     return merge(RemixAccordionStyle(trailingIcon: value));
   }
 
-  /// Sets the trigger.
-  RemixAccordionStyle trigger(FlexBoxStyler value) {
-    return merge(RemixAccordionStyle(trigger: value));
+  /// Sets the content.
+  RemixAccordionStyle content(BoxStyler value) {
+    return merge(RemixAccordionStyle(content: value));
   }
 
   /// Sets the animation configuration.
@@ -157,15 +157,20 @@ mixin _$RemixAccordionStyleMixin on Style<RemixAccordionSpec>, Diagnosticable {
     return merge(RemixAccordionStyle(modifier: value));
   }
 
+  /// Sets the widget modifier.
+  RemixAccordionStyle modifier(WidgetModifierConfig value) {
+    return merge(RemixAccordionStyle(modifier: value));
+  }
+
   /// Merges with another [RemixAccordionStyle].
   @override
   RemixAccordionStyle merge(RemixAccordionStyle? other) {
     return RemixAccordionStyle.create(
-      content: MixOps.merge($content, other?.$content),
+      trigger: MixOps.merge($trigger, other?.$trigger),
       leadingIcon: MixOps.merge($leadingIcon, other?.$leadingIcon),
       title: MixOps.merge($title, other?.$title),
       trailingIcon: MixOps.merge($trailingIcon, other?.$trailingIcon),
-      trigger: MixOps.merge($trigger, other?.$trigger),
+      content: MixOps.merge($content, other?.$content),
       variants: MixOps.mergeVariants($variants, other?.$variants),
       modifier: MixOps.mergeModifier($modifier, other?.$modifier),
       animation: MixOps.mergeAnimation($animation, other?.$animation),
@@ -176,11 +181,11 @@ mixin _$RemixAccordionStyleMixin on Style<RemixAccordionSpec>, Diagnosticable {
   @override
   StyleSpec<RemixAccordionSpec> resolve(BuildContext context) {
     final spec = RemixAccordionSpec(
-      content: MixOps.resolve(context, $content),
+      trigger: MixOps.resolve(context, $trigger),
       leadingIcon: MixOps.resolve(context, $leadingIcon),
       title: MixOps.resolve(context, $title),
       trailingIcon: MixOps.resolve(context, $trailingIcon),
-      trigger: MixOps.resolve(context, $trigger),
+      content: MixOps.resolve(context, $content),
     );
 
     return StyleSpec(
@@ -194,20 +199,20 @@ mixin _$RemixAccordionStyleMixin on Style<RemixAccordionSpec>, Diagnosticable {
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties
-      ..add(DiagnosticsProperty('content', $content))
+      ..add(DiagnosticsProperty('trigger', $trigger))
       ..add(DiagnosticsProperty('leadingIcon', $leadingIcon))
       ..add(DiagnosticsProperty('title', $title))
       ..add(DiagnosticsProperty('trailingIcon', $trailingIcon))
-      ..add(DiagnosticsProperty('trigger', $trigger));
+      ..add(DiagnosticsProperty('content', $content));
   }
 
   @override
   List<Object?> get props => [
-    $content,
+    $trigger,
     $leadingIcon,
     $title,
     $trailingIcon,
-    $trigger,
+    $content,
     $animation,
     $modifier,
     $variants,

--- a/packages/remix/lib/src/components/avatar/avatar.g.dart
+++ b/packages/remix/lib/src/components/avatar/avatar.g.dart
@@ -96,22 +96,22 @@ typedef _$RemixAvatarSpecMethods = _$RemixAvatarSpec; // ignore: unused_element
 
 mixin _$RemixAvatarStyleMixin on Style<RemixAvatarSpec>, Diagnosticable {
   Prop<StyleSpec<BoxSpec>>? get $container;
-  Prop<StyleSpec<IconSpec>>? get $icon;
   Prop<StyleSpec<TextSpec>>? get $text;
+  Prop<StyleSpec<IconSpec>>? get $icon;
 
   /// Sets the container.
   RemixAvatarStyle container(BoxStyler value) {
     return merge(RemixAvatarStyle(container: value));
   }
 
-  /// Sets the icon.
-  RemixAvatarStyle icon(IconStyler value) {
-    return merge(RemixAvatarStyle(icon: value));
-  }
-
   /// Sets the text.
   RemixAvatarStyle text(TextStyler value) {
     return merge(RemixAvatarStyle(text: value));
+  }
+
+  /// Sets the icon.
+  RemixAvatarStyle icon(IconStyler value) {
+    return merge(RemixAvatarStyle(icon: value));
   }
 
   /// Sets the animation configuration.
@@ -129,13 +129,18 @@ mixin _$RemixAvatarStyleMixin on Style<RemixAvatarSpec>, Diagnosticable {
     return merge(RemixAvatarStyle(modifier: value));
   }
 
+  /// Sets the widget modifier.
+  RemixAvatarStyle modifier(WidgetModifierConfig value) {
+    return merge(RemixAvatarStyle(modifier: value));
+  }
+
   /// Merges with another [RemixAvatarStyle].
   @override
   RemixAvatarStyle merge(RemixAvatarStyle? other) {
     return RemixAvatarStyle.create(
       container: MixOps.merge($container, other?.$container),
-      icon: MixOps.merge($icon, other?.$icon),
       text: MixOps.merge($text, other?.$text),
+      icon: MixOps.merge($icon, other?.$icon),
       variants: MixOps.mergeVariants($variants, other?.$variants),
       modifier: MixOps.mergeModifier($modifier, other?.$modifier),
       animation: MixOps.mergeAnimation($animation, other?.$animation),
@@ -147,8 +152,8 @@ mixin _$RemixAvatarStyleMixin on Style<RemixAvatarSpec>, Diagnosticable {
   StyleSpec<RemixAvatarSpec> resolve(BuildContext context) {
     final spec = RemixAvatarSpec(
       container: MixOps.resolve(context, $container),
-      icon: MixOps.resolve(context, $icon),
       text: MixOps.resolve(context, $text),
+      icon: MixOps.resolve(context, $icon),
     );
 
     return StyleSpec(
@@ -163,15 +168,15 @@ mixin _$RemixAvatarStyleMixin on Style<RemixAvatarSpec>, Diagnosticable {
     super.debugFillProperties(properties);
     properties
       ..add(DiagnosticsProperty('container', $container))
-      ..add(DiagnosticsProperty('icon', $icon))
-      ..add(DiagnosticsProperty('text', $text));
+      ..add(DiagnosticsProperty('text', $text))
+      ..add(DiagnosticsProperty('icon', $icon));
   }
 
   @override
   List<Object?> get props => [
     $container,
-    $icon,
     $text,
+    $icon,
     $animation,
     $modifier,
     $variants,

--- a/packages/remix/lib/src/components/badge/badge.g.dart
+++ b/packages/remix/lib/src/components/badge/badge.g.dart
@@ -118,6 +118,11 @@ mixin _$RemixBadgeStyleMixin on Style<RemixBadgeSpec>, Diagnosticable {
     return merge(RemixBadgeStyle(modifier: value));
   }
 
+  /// Sets the widget modifier.
+  RemixBadgeStyle modifier(WidgetModifierConfig value) {
+    return merge(RemixBadgeStyle(modifier: value));
+  }
+
   /// Merges with another [RemixBadgeStyle].
   @override
   RemixBadgeStyle merge(RemixBadgeStyle? other) {

--- a/packages/remix/lib/src/components/callout/callout.g.dart
+++ b/packages/remix/lib/src/components/callout/callout.g.dart
@@ -96,22 +96,22 @@ typedef _$RemixCalloutSpecMethods = _$RemixCalloutSpec; // ignore: unused_elemen
 
 mixin _$RemixCalloutStyleMixin on Style<RemixCalloutSpec>, Diagnosticable {
   Prop<StyleSpec<FlexBoxSpec>>? get $container;
-  Prop<StyleSpec<IconSpec>>? get $icon;
   Prop<StyleSpec<TextSpec>>? get $text;
+  Prop<StyleSpec<IconSpec>>? get $icon;
 
   /// Sets the container.
   RemixCalloutStyle container(FlexBoxStyler value) {
     return merge(RemixCalloutStyle(container: value));
   }
 
-  /// Sets the icon.
-  RemixCalloutStyle icon(IconStyler value) {
-    return merge(RemixCalloutStyle(icon: value));
-  }
-
   /// Sets the text.
   RemixCalloutStyle text(TextStyler value) {
     return merge(RemixCalloutStyle(text: value));
+  }
+
+  /// Sets the icon.
+  RemixCalloutStyle icon(IconStyler value) {
+    return merge(RemixCalloutStyle(icon: value));
   }
 
   /// Sets the animation configuration.
@@ -129,13 +129,18 @@ mixin _$RemixCalloutStyleMixin on Style<RemixCalloutSpec>, Diagnosticable {
     return merge(RemixCalloutStyle(modifier: value));
   }
 
+  /// Sets the widget modifier.
+  RemixCalloutStyle modifier(WidgetModifierConfig value) {
+    return merge(RemixCalloutStyle(modifier: value));
+  }
+
   /// Merges with another [RemixCalloutStyle].
   @override
   RemixCalloutStyle merge(RemixCalloutStyle? other) {
     return RemixCalloutStyle.create(
       container: MixOps.merge($container, other?.$container),
-      icon: MixOps.merge($icon, other?.$icon),
       text: MixOps.merge($text, other?.$text),
+      icon: MixOps.merge($icon, other?.$icon),
       variants: MixOps.mergeVariants($variants, other?.$variants),
       modifier: MixOps.mergeModifier($modifier, other?.$modifier),
       animation: MixOps.mergeAnimation($animation, other?.$animation),
@@ -147,8 +152,8 @@ mixin _$RemixCalloutStyleMixin on Style<RemixCalloutSpec>, Diagnosticable {
   StyleSpec<RemixCalloutSpec> resolve(BuildContext context) {
     final spec = RemixCalloutSpec(
       container: MixOps.resolve(context, $container),
-      icon: MixOps.resolve(context, $icon),
       text: MixOps.resolve(context, $text),
+      icon: MixOps.resolve(context, $icon),
     );
 
     return StyleSpec(
@@ -163,15 +168,15 @@ mixin _$RemixCalloutStyleMixin on Style<RemixCalloutSpec>, Diagnosticable {
     super.debugFillProperties(properties);
     properties
       ..add(DiagnosticsProperty('container', $container))
-      ..add(DiagnosticsProperty('icon', $icon))
-      ..add(DiagnosticsProperty('text', $text));
+      ..add(DiagnosticsProperty('text', $text))
+      ..add(DiagnosticsProperty('icon', $icon));
   }
 
   @override
   List<Object?> get props => [
     $container,
-    $icon,
     $text,
+    $icon,
     $animation,
     $modifier,
     $variants,

--- a/packages/remix/lib/src/components/card/card.g.dart
+++ b/packages/remix/lib/src/components/card/card.g.dart
@@ -64,7 +64,7 @@ mixin _$RemixCardSpec implements Spec<RemixCardSpec>, Diagnosticable {
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    properties..add(DiagnosticsProperty('container', container));
+    properties.add(DiagnosticsProperty('container', container));
   }
 }
 
@@ -100,6 +100,11 @@ mixin _$RemixCardStyleMixin on Style<RemixCardSpec>, Diagnosticable {
     return merge(RemixCardStyle(modifier: value));
   }
 
+  /// Sets the widget modifier.
+  RemixCardStyle modifier(WidgetModifierConfig value) {
+    return merge(RemixCardStyle(modifier: value));
+  }
+
   /// Merges with another [RemixCardStyle].
   @override
   RemixCardStyle merge(RemixCardStyle? other) {
@@ -126,7 +131,7 @@ mixin _$RemixCardStyleMixin on Style<RemixCardSpec>, Diagnosticable {
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
-    properties..add(DiagnosticsProperty('container', $container));
+    properties.add(DiagnosticsProperty('container', $container));
   }
 
   @override

--- a/packages/remix/lib/src/components/checkbox/checkbox.g.dart
+++ b/packages/remix/lib/src/components/checkbox/checkbox.g.dart
@@ -188,6 +188,11 @@ mixin _$RemixCheckboxStyleMixin on Style<RemixCheckboxSpec>, Diagnosticable {
     return merge(RemixCheckboxStyle(modifier: value));
   }
 
+  /// Sets the widget modifier.
+  RemixCheckboxStyle modifier(WidgetModifierConfig value) {
+    return merge(RemixCheckboxStyle(modifier: value));
+  }
+
   /// Merges with another [RemixCheckboxStyle].
   @override
   RemixCheckboxStyle merge(RemixCheckboxStyle? other) {

--- a/packages/remix/lib/src/components/dialog/dialog.g.dart
+++ b/packages/remix/lib/src/components/dialog/dialog.g.dart
@@ -105,20 +105,20 @@ typedef _$RemixDialogSpecMethods = _$RemixDialogSpec; // ignore: unused_element
 // **************************************************************************
 
 mixin _$RemixDialogStyleMixin on Style<RemixDialogSpec>, Diagnosticable {
-  Prop<StyleSpec<FlexBoxSpec>>? get $actions;
   Prop<StyleSpec<BoxSpec>>? get $container;
-  Prop<StyleSpec<TextSpec>>? get $description;
-  Prop<StyleSpec<BoxSpec>>? get $overlay;
   Prop<StyleSpec<TextSpec>>? get $title;
-
-  /// Sets the actions.
-  RemixDialogStyle actions(FlexBoxStyler value) {
-    return merge(RemixDialogStyle(actions: value));
-  }
+  Prop<StyleSpec<TextSpec>>? get $description;
+  Prop<StyleSpec<FlexBoxSpec>>? get $actions;
+  Prop<StyleSpec<BoxSpec>>? get $overlay;
 
   /// Sets the container.
   RemixDialogStyle container(BoxStyler value) {
     return merge(RemixDialogStyle(container: value));
+  }
+
+  /// Sets the title.
+  RemixDialogStyle title(TextStyler value) {
+    return merge(RemixDialogStyle(title: value));
   }
 
   /// Sets the description.
@@ -126,14 +126,14 @@ mixin _$RemixDialogStyleMixin on Style<RemixDialogSpec>, Diagnosticable {
     return merge(RemixDialogStyle(description: value));
   }
 
+  /// Sets the actions.
+  RemixDialogStyle actions(FlexBoxStyler value) {
+    return merge(RemixDialogStyle(actions: value));
+  }
+
   /// Sets the overlay.
   RemixDialogStyle overlay(BoxStyler value) {
     return merge(RemixDialogStyle(overlay: value));
-  }
-
-  /// Sets the title.
-  RemixDialogStyle title(TextStyler value) {
-    return merge(RemixDialogStyle(title: value));
   }
 
   /// Sets the animation configuration.
@@ -151,15 +151,20 @@ mixin _$RemixDialogStyleMixin on Style<RemixDialogSpec>, Diagnosticable {
     return merge(RemixDialogStyle(modifier: value));
   }
 
+  /// Sets the widget modifier.
+  RemixDialogStyle modifier(WidgetModifierConfig value) {
+    return merge(RemixDialogStyle(modifier: value));
+  }
+
   /// Merges with another [RemixDialogStyle].
   @override
   RemixDialogStyle merge(RemixDialogStyle? other) {
     return RemixDialogStyle.create(
-      actions: MixOps.merge($actions, other?.$actions),
       container: MixOps.merge($container, other?.$container),
-      description: MixOps.merge($description, other?.$description),
-      overlay: MixOps.merge($overlay, other?.$overlay),
       title: MixOps.merge($title, other?.$title),
+      description: MixOps.merge($description, other?.$description),
+      actions: MixOps.merge($actions, other?.$actions),
+      overlay: MixOps.merge($overlay, other?.$overlay),
       variants: MixOps.mergeVariants($variants, other?.$variants),
       modifier: MixOps.mergeModifier($modifier, other?.$modifier),
       animation: MixOps.mergeAnimation($animation, other?.$animation),
@@ -170,11 +175,11 @@ mixin _$RemixDialogStyleMixin on Style<RemixDialogSpec>, Diagnosticable {
   @override
   StyleSpec<RemixDialogSpec> resolve(BuildContext context) {
     final spec = RemixDialogSpec(
-      actions: MixOps.resolve(context, $actions),
       container: MixOps.resolve(context, $container),
-      description: MixOps.resolve(context, $description),
-      overlay: MixOps.resolve(context, $overlay),
       title: MixOps.resolve(context, $title),
+      description: MixOps.resolve(context, $description),
+      actions: MixOps.resolve(context, $actions),
+      overlay: MixOps.resolve(context, $overlay),
     );
 
     return StyleSpec(
@@ -188,20 +193,20 @@ mixin _$RemixDialogStyleMixin on Style<RemixDialogSpec>, Diagnosticable {
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties
-      ..add(DiagnosticsProperty('actions', $actions))
       ..add(DiagnosticsProperty('container', $container))
+      ..add(DiagnosticsProperty('title', $title))
       ..add(DiagnosticsProperty('description', $description))
-      ..add(DiagnosticsProperty('overlay', $overlay))
-      ..add(DiagnosticsProperty('title', $title));
+      ..add(DiagnosticsProperty('actions', $actions))
+      ..add(DiagnosticsProperty('overlay', $overlay));
   }
 
   @override
   List<Object?> get props => [
-    $actions,
     $container,
-    $description,
-    $overlay,
     $title,
+    $description,
+    $actions,
+    $overlay,
     $animation,
     $modifier,
     $variants,

--- a/packages/remix/lib/src/components/divider/divider.g.dart
+++ b/packages/remix/lib/src/components/divider/divider.g.dart
@@ -64,7 +64,7 @@ mixin _$RemixDividerSpec implements Spec<RemixDividerSpec>, Diagnosticable {
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    properties..add(DiagnosticsProperty('container', container));
+    properties.add(DiagnosticsProperty('container', container));
   }
 }
 
@@ -100,6 +100,11 @@ mixin _$RemixDividerStyleMixin on Style<RemixDividerSpec>, Diagnosticable {
     return merge(RemixDividerStyle(modifier: value));
   }
 
+  /// Sets the widget modifier.
+  RemixDividerStyle modifier(WidgetModifierConfig value) {
+    return merge(RemixDividerStyle(modifier: value));
+  }
+
   /// Merges with another [RemixDividerStyle].
   @override
   RemixDividerStyle merge(RemixDividerStyle? other) {
@@ -128,7 +133,7 @@ mixin _$RemixDividerStyleMixin on Style<RemixDividerSpec>, Diagnosticable {
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
-    properties..add(DiagnosticsProperty('container', $container));
+    properties.add(DiagnosticsProperty('container', $container));
   }
 
   @override

--- a/packages/remix/lib/src/components/icon_button/icon_button.g.dart
+++ b/packages/remix/lib/src/components/icon_button/icon_button.g.dart
@@ -173,6 +173,11 @@ mixin _$RemixIconButtonStyleMixin
     return merge(RemixIconButtonStyle(modifier: value));
   }
 
+  /// Sets the widget modifier.
+  RemixIconButtonStyle modifier(WidgetModifierConfig value) {
+    return merge(RemixIconButtonStyle(modifier: value));
+  }
+
   /// Merges with another [RemixIconButtonStyle].
   @override
   RemixIconButtonStyle merge(RemixIconButtonStyle? other) {

--- a/packages/remix/lib/src/components/menu/menu.g.dart
+++ b/packages/remix/lib/src/components/menu/menu.g.dart
@@ -276,22 +276,22 @@ typedef _$RemixMenuItemSpecMethods = _$RemixMenuItemSpec; // ignore: unused_elem
 mixin _$RemixMenuTriggerStyleMixin
     on Style<RemixMenuTriggerSpec>, Diagnosticable {
   Prop<StyleSpec<FlexBoxSpec>>? get $container;
-  Prop<StyleSpec<IconSpec>>? get $icon;
   Prop<StyleSpec<TextSpec>>? get $label;
+  Prop<StyleSpec<IconSpec>>? get $icon;
 
   /// Sets the container.
   RemixMenuTriggerStyle container(FlexBoxStyler value) {
     return merge(RemixMenuTriggerStyle(container: value));
   }
 
-  /// Sets the icon.
-  RemixMenuTriggerStyle icon(IconStyler value) {
-    return merge(RemixMenuTriggerStyle(icon: value));
-  }
-
   /// Sets the label.
   RemixMenuTriggerStyle label(TextStyler value) {
     return merge(RemixMenuTriggerStyle(label: value));
+  }
+
+  /// Sets the icon.
+  RemixMenuTriggerStyle icon(IconStyler value) {
+    return merge(RemixMenuTriggerStyle(icon: value));
   }
 
   /// Sets the animation configuration.
@@ -311,13 +311,18 @@ mixin _$RemixMenuTriggerStyleMixin
     return merge(RemixMenuTriggerStyle(modifier: value));
   }
 
+  /// Sets the widget modifier.
+  RemixMenuTriggerStyle modifier(WidgetModifierConfig value) {
+    return merge(RemixMenuTriggerStyle(modifier: value));
+  }
+
   /// Merges with another [RemixMenuTriggerStyle].
   @override
   RemixMenuTriggerStyle merge(RemixMenuTriggerStyle? other) {
     return RemixMenuTriggerStyle.create(
       container: MixOps.merge($container, other?.$container),
-      icon: MixOps.merge($icon, other?.$icon),
       label: MixOps.merge($label, other?.$label),
+      icon: MixOps.merge($icon, other?.$icon),
       variants: MixOps.mergeVariants($variants, other?.$variants),
       modifier: MixOps.mergeModifier($modifier, other?.$modifier),
       animation: MixOps.mergeAnimation($animation, other?.$animation),
@@ -329,8 +334,8 @@ mixin _$RemixMenuTriggerStyleMixin
   StyleSpec<RemixMenuTriggerSpec> resolve(BuildContext context) {
     final spec = RemixMenuTriggerSpec(
       container: MixOps.resolve(context, $container),
-      icon: MixOps.resolve(context, $icon),
       label: MixOps.resolve(context, $label),
+      icon: MixOps.resolve(context, $icon),
     );
 
     return StyleSpec(
@@ -345,15 +350,15 @@ mixin _$RemixMenuTriggerStyleMixin
     super.debugFillProperties(properties);
     properties
       ..add(DiagnosticsProperty('container', $container))
-      ..add(DiagnosticsProperty('icon', $icon))
-      ..add(DiagnosticsProperty('label', $label));
+      ..add(DiagnosticsProperty('label', $label))
+      ..add(DiagnosticsProperty('icon', $icon));
   }
 
   @override
   List<Object?> get props => [
     $container,
-    $icon,
     $label,
+    $icon,
     $animation,
     $modifier,
     $variants,
@@ -361,19 +366,14 @@ mixin _$RemixMenuTriggerStyleMixin
 }
 
 mixin _$RemixMenuStyleMixin on Style<RemixMenuSpec>, Diagnosticable {
-  Prop<StyleSpec<RemixDividerSpec>>? get $divider;
-  Prop<StyleSpec<RemixMenuItemSpec>>? get $item;
-  Prop<StyleSpec<FlexBoxSpec>>? get $overlay;
   Prop<StyleSpec<RemixMenuTriggerSpec>>? get $trigger;
+  Prop<StyleSpec<FlexBoxSpec>>? get $overlay;
+  Prop<StyleSpec<RemixMenuItemSpec>>? get $item;
+  Prop<StyleSpec<RemixDividerSpec>>? get $divider;
 
-  /// Sets the divider.
-  RemixMenuStyle divider(RemixDividerStyle value) {
-    return merge(RemixMenuStyle(divider: value));
-  }
-
-  /// Sets the item.
-  RemixMenuStyle item(RemixMenuItemStyle value) {
-    return merge(RemixMenuStyle(item: value));
+  /// Sets the trigger.
+  RemixMenuStyle trigger(RemixMenuTriggerStyle value) {
+    return merge(RemixMenuStyle(trigger: value));
   }
 
   /// Sets the overlay.
@@ -381,9 +381,14 @@ mixin _$RemixMenuStyleMixin on Style<RemixMenuSpec>, Diagnosticable {
     return merge(RemixMenuStyle(overlay: value));
   }
 
-  /// Sets the trigger.
-  RemixMenuStyle trigger(RemixMenuTriggerStyle value) {
-    return merge(RemixMenuStyle(trigger: value));
+  /// Sets the item.
+  RemixMenuStyle item(RemixMenuItemStyle value) {
+    return merge(RemixMenuStyle(item: value));
+  }
+
+  /// Sets the divider.
+  RemixMenuStyle divider(RemixDividerStyle value) {
+    return merge(RemixMenuStyle(divider: value));
   }
 
   /// Sets the animation configuration.
@@ -401,14 +406,19 @@ mixin _$RemixMenuStyleMixin on Style<RemixMenuSpec>, Diagnosticable {
     return merge(RemixMenuStyle(modifier: value));
   }
 
+  /// Sets the widget modifier.
+  RemixMenuStyle modifier(WidgetModifierConfig value) {
+    return merge(RemixMenuStyle(modifier: value));
+  }
+
   /// Merges with another [RemixMenuStyle].
   @override
   RemixMenuStyle merge(RemixMenuStyle? other) {
     return RemixMenuStyle.create(
-      divider: MixOps.merge($divider, other?.$divider),
-      item: MixOps.merge($item, other?.$item),
-      overlay: MixOps.merge($overlay, other?.$overlay),
       trigger: MixOps.merge($trigger, other?.$trigger),
+      overlay: MixOps.merge($overlay, other?.$overlay),
+      item: MixOps.merge($item, other?.$item),
+      divider: MixOps.merge($divider, other?.$divider),
       variants: MixOps.mergeVariants($variants, other?.$variants),
       modifier: MixOps.mergeModifier($modifier, other?.$modifier),
       animation: MixOps.mergeAnimation($animation, other?.$animation),
@@ -419,10 +429,10 @@ mixin _$RemixMenuStyleMixin on Style<RemixMenuSpec>, Diagnosticable {
   @override
   StyleSpec<RemixMenuSpec> resolve(BuildContext context) {
     final spec = RemixMenuSpec(
-      divider: MixOps.resolve(context, $divider),
-      item: MixOps.resolve(context, $item),
-      overlay: MixOps.resolve(context, $overlay),
       trigger: MixOps.resolve(context, $trigger),
+      overlay: MixOps.resolve(context, $overlay),
+      item: MixOps.resolve(context, $item),
+      divider: MixOps.resolve(context, $divider),
     );
 
     return StyleSpec(
@@ -436,18 +446,18 @@ mixin _$RemixMenuStyleMixin on Style<RemixMenuSpec>, Diagnosticable {
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties
-      ..add(DiagnosticsProperty('divider', $divider))
-      ..add(DiagnosticsProperty('item', $item))
+      ..add(DiagnosticsProperty('trigger', $trigger))
       ..add(DiagnosticsProperty('overlay', $overlay))
-      ..add(DiagnosticsProperty('trigger', $trigger));
+      ..add(DiagnosticsProperty('item', $item))
+      ..add(DiagnosticsProperty('divider', $divider));
   }
 
   @override
   List<Object?> get props => [
-    $divider,
-    $item,
-    $overlay,
     $trigger,
+    $overlay,
+    $item,
+    $divider,
     $animation,
     $modifier,
     $variants,
@@ -492,6 +502,11 @@ mixin _$RemixMenuItemStyleMixin on Style<RemixMenuItemSpec>, Diagnosticable {
 
   /// Wraps with a widget modifier.
   RemixMenuItemStyle wrap(WidgetModifierConfig value) {
+    return merge(RemixMenuItemStyle(modifier: value));
+  }
+
+  /// Sets the widget modifier.
+  RemixMenuItemStyle modifier(WidgetModifierConfig value) {
     return merge(RemixMenuItemStyle(modifier: value));
   }
 

--- a/packages/remix/lib/src/components/progress/progress.g.dart
+++ b/packages/remix/lib/src/components/progress/progress.g.dart
@@ -101,8 +101,8 @@ typedef _$RemixProgressSpecMethods = _$RemixProgressSpec; // ignore: unused_elem
 
 mixin _$RemixProgressStyleMixin on Style<RemixProgressSpec>, Diagnosticable {
   Prop<StyleSpec<BoxSpec>>? get $container;
-  Prop<StyleSpec<BoxSpec>>? get $indicator;
   Prop<StyleSpec<BoxSpec>>? get $track;
+  Prop<StyleSpec<BoxSpec>>? get $indicator;
   Prop<StyleSpec<BoxSpec>>? get $trackContainer;
 
   /// Sets the container.
@@ -110,14 +110,14 @@ mixin _$RemixProgressStyleMixin on Style<RemixProgressSpec>, Diagnosticable {
     return merge(RemixProgressStyle(container: value));
   }
 
-  /// Sets the indicator.
-  RemixProgressStyle indicator(BoxStyler value) {
-    return merge(RemixProgressStyle(indicator: value));
-  }
-
   /// Sets the track.
   RemixProgressStyle track(BoxStyler value) {
     return merge(RemixProgressStyle(track: value));
+  }
+
+  /// Sets the indicator.
+  RemixProgressStyle indicator(BoxStyler value) {
+    return merge(RemixProgressStyle(indicator: value));
   }
 
   /// Sets the trackContainer.
@@ -140,13 +140,18 @@ mixin _$RemixProgressStyleMixin on Style<RemixProgressSpec>, Diagnosticable {
     return merge(RemixProgressStyle(modifier: value));
   }
 
+  /// Sets the widget modifier.
+  RemixProgressStyle modifier(WidgetModifierConfig value) {
+    return merge(RemixProgressStyle(modifier: value));
+  }
+
   /// Merges with another [RemixProgressStyle].
   @override
   RemixProgressStyle merge(RemixProgressStyle? other) {
     return RemixProgressStyle.create(
       container: MixOps.merge($container, other?.$container),
-      indicator: MixOps.merge($indicator, other?.$indicator),
       track: MixOps.merge($track, other?.$track),
+      indicator: MixOps.merge($indicator, other?.$indicator),
       trackContainer: MixOps.merge($trackContainer, other?.$trackContainer),
       variants: MixOps.mergeVariants($variants, other?.$variants),
       modifier: MixOps.mergeModifier($modifier, other?.$modifier),
@@ -159,8 +164,8 @@ mixin _$RemixProgressStyleMixin on Style<RemixProgressSpec>, Diagnosticable {
   StyleSpec<RemixProgressSpec> resolve(BuildContext context) {
     final spec = RemixProgressSpec(
       container: MixOps.resolve(context, $container),
-      indicator: MixOps.resolve(context, $indicator),
       track: MixOps.resolve(context, $track),
+      indicator: MixOps.resolve(context, $indicator),
       trackContainer: MixOps.resolve(context, $trackContainer),
     );
 
@@ -176,16 +181,16 @@ mixin _$RemixProgressStyleMixin on Style<RemixProgressSpec>, Diagnosticable {
     super.debugFillProperties(properties);
     properties
       ..add(DiagnosticsProperty('container', $container))
-      ..add(DiagnosticsProperty('indicator', $indicator))
       ..add(DiagnosticsProperty('track', $track))
+      ..add(DiagnosticsProperty('indicator', $indicator))
       ..add(DiagnosticsProperty('trackContainer', $trackContainer));
   }
 
   @override
   List<Object?> get props => [
     $container,
-    $indicator,
     $track,
+    $indicator,
     $trackContainer,
     $animation,
     $modifier,

--- a/packages/remix/lib/src/components/radio/radio.g.dart
+++ b/packages/remix/lib/src/components/radio/radio.g.dart
@@ -118,6 +118,11 @@ mixin _$RemixRadioStyleMixin on Style<RemixRadioSpec>, Diagnosticable {
     return merge(RemixRadioStyle(modifier: value));
   }
 
+  /// Sets the widget modifier.
+  RemixRadioStyle modifier(WidgetModifierConfig value) {
+    return merge(RemixRadioStyle(modifier: value));
+  }
+
   /// Merges with another [RemixRadioStyle].
   @override
   RemixRadioStyle merge(RemixRadioStyle? other) {

--- a/packages/remix/lib/src/components/select/select.g.dart
+++ b/packages/remix/lib/src/components/select/select.g.dart
@@ -293,6 +293,11 @@ mixin _$RemixSelectStyleMixin on Style<RemixSelectSpec>, Diagnosticable {
     return merge(RemixSelectStyle(modifier: value));
   }
 
+  /// Sets the widget modifier.
+  RemixSelectStyle modifier(WidgetModifierConfig value) {
+    return merge(RemixSelectStyle(modifier: value));
+  }
+
   /// Merges with another [RemixSelectStyle].
   @override
   RemixSelectStyle merge(RemixSelectStyle? other) {
@@ -341,22 +346,22 @@ mixin _$RemixSelectStyleMixin on Style<RemixSelectSpec>, Diagnosticable {
 mixin _$RemixSelectTriggerStyleMixin
     on Style<RemixSelectTriggerSpec>, Diagnosticable {
   Prop<StyleSpec<FlexBoxSpec>>? get $container;
-  Prop<StyleSpec<IconSpec>>? get $icon;
   Prop<StyleSpec<TextSpec>>? get $label;
+  Prop<StyleSpec<IconSpec>>? get $icon;
 
   /// Sets the container.
   RemixSelectTriggerStyle container(FlexBoxStyler value) {
     return merge(RemixSelectTriggerStyle(container: value));
   }
 
-  /// Sets the icon.
-  RemixSelectTriggerStyle icon(IconStyler value) {
-    return merge(RemixSelectTriggerStyle(icon: value));
-  }
-
   /// Sets the label.
   RemixSelectTriggerStyle label(TextStyler value) {
     return merge(RemixSelectTriggerStyle(label: value));
+  }
+
+  /// Sets the icon.
+  RemixSelectTriggerStyle icon(IconStyler value) {
+    return merge(RemixSelectTriggerStyle(icon: value));
   }
 
   /// Sets the animation configuration.
@@ -376,13 +381,18 @@ mixin _$RemixSelectTriggerStyleMixin
     return merge(RemixSelectTriggerStyle(modifier: value));
   }
 
+  /// Sets the widget modifier.
+  RemixSelectTriggerStyle modifier(WidgetModifierConfig value) {
+    return merge(RemixSelectTriggerStyle(modifier: value));
+  }
+
   /// Merges with another [RemixSelectTriggerStyle].
   @override
   RemixSelectTriggerStyle merge(RemixSelectTriggerStyle? other) {
     return RemixSelectTriggerStyle.create(
       container: MixOps.merge($container, other?.$container),
-      icon: MixOps.merge($icon, other?.$icon),
       label: MixOps.merge($label, other?.$label),
+      icon: MixOps.merge($icon, other?.$icon),
       variants: MixOps.mergeVariants($variants, other?.$variants),
       modifier: MixOps.mergeModifier($modifier, other?.$modifier),
       animation: MixOps.mergeAnimation($animation, other?.$animation),
@@ -394,8 +404,8 @@ mixin _$RemixSelectTriggerStyleMixin
   StyleSpec<RemixSelectTriggerSpec> resolve(BuildContext context) {
     final spec = RemixSelectTriggerSpec(
       container: MixOps.resolve(context, $container),
-      icon: MixOps.resolve(context, $icon),
       label: MixOps.resolve(context, $label),
+      icon: MixOps.resolve(context, $icon),
     );
 
     return StyleSpec(
@@ -410,15 +420,15 @@ mixin _$RemixSelectTriggerStyleMixin
     super.debugFillProperties(properties);
     properties
       ..add(DiagnosticsProperty('container', $container))
-      ..add(DiagnosticsProperty('icon', $icon))
-      ..add(DiagnosticsProperty('label', $label));
+      ..add(DiagnosticsProperty('label', $label))
+      ..add(DiagnosticsProperty('icon', $icon));
   }
 
   @override
   List<Object?> get props => [
     $container,
-    $icon,
     $label,
+    $icon,
     $animation,
     $modifier,
     $variants,
@@ -428,22 +438,22 @@ mixin _$RemixSelectTriggerStyleMixin
 mixin _$RemixSelectMenuItemStyleMixin
     on Style<RemixSelectMenuItemSpec>, Diagnosticable {
   Prop<StyleSpec<FlexBoxSpec>>? get $container;
-  Prop<StyleSpec<IconSpec>>? get $icon;
   Prop<StyleSpec<TextSpec>>? get $text;
+  Prop<StyleSpec<IconSpec>>? get $icon;
 
   /// Sets the container.
   RemixSelectMenuItemStyle container(FlexBoxStyler value) {
     return merge(RemixSelectMenuItemStyle(container: value));
   }
 
-  /// Sets the icon.
-  RemixSelectMenuItemStyle icon(IconStyler value) {
-    return merge(RemixSelectMenuItemStyle(icon: value));
-  }
-
   /// Sets the text.
   RemixSelectMenuItemStyle text(TextStyler value) {
     return merge(RemixSelectMenuItemStyle(text: value));
+  }
+
+  /// Sets the icon.
+  RemixSelectMenuItemStyle icon(IconStyler value) {
+    return merge(RemixSelectMenuItemStyle(icon: value));
   }
 
   /// Sets the animation configuration.
@@ -463,13 +473,18 @@ mixin _$RemixSelectMenuItemStyleMixin
     return merge(RemixSelectMenuItemStyle(modifier: value));
   }
 
+  /// Sets the widget modifier.
+  RemixSelectMenuItemStyle modifier(WidgetModifierConfig value) {
+    return merge(RemixSelectMenuItemStyle(modifier: value));
+  }
+
   /// Merges with another [RemixSelectMenuItemStyle].
   @override
   RemixSelectMenuItemStyle merge(RemixSelectMenuItemStyle? other) {
     return RemixSelectMenuItemStyle.create(
       container: MixOps.merge($container, other?.$container),
-      icon: MixOps.merge($icon, other?.$icon),
       text: MixOps.merge($text, other?.$text),
+      icon: MixOps.merge($icon, other?.$icon),
       variants: MixOps.mergeVariants($variants, other?.$variants),
       modifier: MixOps.mergeModifier($modifier, other?.$modifier),
       animation: MixOps.mergeAnimation($animation, other?.$animation),
@@ -481,8 +496,8 @@ mixin _$RemixSelectMenuItemStyleMixin
   StyleSpec<RemixSelectMenuItemSpec> resolve(BuildContext context) {
     final spec = RemixSelectMenuItemSpec(
       container: MixOps.resolve(context, $container),
-      icon: MixOps.resolve(context, $icon),
       text: MixOps.resolve(context, $text),
+      icon: MixOps.resolve(context, $icon),
     );
 
     return StyleSpec(
@@ -497,15 +512,15 @@ mixin _$RemixSelectMenuItemStyleMixin
     super.debugFillProperties(properties);
     properties
       ..add(DiagnosticsProperty('container', $container))
-      ..add(DiagnosticsProperty('icon', $icon))
-      ..add(DiagnosticsProperty('text', $text));
+      ..add(DiagnosticsProperty('text', $text))
+      ..add(DiagnosticsProperty('icon', $icon));
   }
 
   @override
   List<Object?> get props => [
     $container,
-    $icon,
     $text,
+    $icon,
     $animation,
     $modifier,
     $variants,

--- a/packages/remix/lib/src/components/slider/slider.g.dart
+++ b/packages/remix/lib/src/components/slider/slider.g.dart
@@ -177,21 +177,11 @@ class FortalSlider extends StatelessWidget {
 // **************************************************************************
 
 mixin _$RemixSliderStyleMixin on Style<RemixSliderSpec>, Diagnosticable {
-  Prop<Color>? get $rangeColor;
-  Prop<double>? get $rangeWidth;
   Prop<StyleSpec<BoxSpec>>? get $thumb;
   Prop<Color>? get $trackColor;
   Prop<double>? get $trackWidth;
-
-  /// Sets the rangeColor.
-  RemixSliderStyle rangeColor(Color value) {
-    return merge(RemixSliderStyle(rangeColor: value));
-  }
-
-  /// Sets the rangeWidth.
-  RemixSliderStyle rangeWidth(double value) {
-    return merge(RemixSliderStyle(rangeWidth: value));
-  }
+  Prop<Color>? get $rangeColor;
+  Prop<double>? get $rangeWidth;
 
   /// Sets the thumb.
   RemixSliderStyle thumb(BoxStyler value) {
@@ -206,6 +196,16 @@ mixin _$RemixSliderStyleMixin on Style<RemixSliderSpec>, Diagnosticable {
   /// Sets the trackWidth.
   RemixSliderStyle trackWidth(double value) {
     return merge(RemixSliderStyle(trackWidth: value));
+  }
+
+  /// Sets the rangeColor.
+  RemixSliderStyle rangeColor(Color value) {
+    return merge(RemixSliderStyle(rangeColor: value));
+  }
+
+  /// Sets the rangeWidth.
+  RemixSliderStyle rangeWidth(double value) {
+    return merge(RemixSliderStyle(rangeWidth: value));
   }
 
   /// Sets the animation configuration.
@@ -223,15 +223,20 @@ mixin _$RemixSliderStyleMixin on Style<RemixSliderSpec>, Diagnosticable {
     return merge(RemixSliderStyle(modifier: value));
   }
 
+  /// Sets the widget modifier.
+  RemixSliderStyle modifier(WidgetModifierConfig value) {
+    return merge(RemixSliderStyle(modifier: value));
+  }
+
   /// Merges with another [RemixSliderStyle].
   @override
   RemixSliderStyle merge(RemixSliderStyle? other) {
     return RemixSliderStyle.create(
-      rangeColor: MixOps.merge($rangeColor, other?.$rangeColor),
-      rangeWidth: MixOps.merge($rangeWidth, other?.$rangeWidth),
       thumb: MixOps.merge($thumb, other?.$thumb),
       trackColor: MixOps.merge($trackColor, other?.$trackColor),
       trackWidth: MixOps.merge($trackWidth, other?.$trackWidth),
+      rangeColor: MixOps.merge($rangeColor, other?.$rangeColor),
+      rangeWidth: MixOps.merge($rangeWidth, other?.$rangeWidth),
       variants: MixOps.mergeVariants($variants, other?.$variants),
       modifier: MixOps.mergeModifier($modifier, other?.$modifier),
       animation: MixOps.mergeAnimation($animation, other?.$animation),
@@ -242,11 +247,11 @@ mixin _$RemixSliderStyleMixin on Style<RemixSliderSpec>, Diagnosticable {
   @override
   StyleSpec<RemixSliderSpec> resolve(BuildContext context) {
     final spec = RemixSliderSpec(
-      rangeColor: MixOps.resolve(context, $rangeColor),
-      rangeWidth: MixOps.resolve(context, $rangeWidth),
       thumb: MixOps.resolve(context, $thumb),
       trackColor: MixOps.resolve(context, $trackColor),
       trackWidth: MixOps.resolve(context, $trackWidth),
+      rangeColor: MixOps.resolve(context, $rangeColor),
+      rangeWidth: MixOps.resolve(context, $rangeWidth),
     );
 
     return StyleSpec(
@@ -260,20 +265,20 @@ mixin _$RemixSliderStyleMixin on Style<RemixSliderSpec>, Diagnosticable {
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties
-      ..add(DiagnosticsProperty('rangeColor', $rangeColor))
-      ..add(DiagnosticsProperty('rangeWidth', $rangeWidth))
       ..add(DiagnosticsProperty('thumb', $thumb))
       ..add(DiagnosticsProperty('trackColor', $trackColor))
-      ..add(DiagnosticsProperty('trackWidth', $trackWidth));
+      ..add(DiagnosticsProperty('trackWidth', $trackWidth))
+      ..add(DiagnosticsProperty('rangeColor', $rangeColor))
+      ..add(DiagnosticsProperty('rangeWidth', $rangeWidth));
   }
 
   @override
   List<Object?> get props => [
-    $rangeColor,
-    $rangeWidth,
     $thumb,
     $trackColor,
     $trackWidth,
+    $rangeColor,
+    $rangeWidth,
     $animation,
     $modifier,
     $variants,

--- a/packages/remix/lib/src/components/spinner/spinner.g.dart
+++ b/packages/remix/lib/src/components/spinner/spinner.g.dart
@@ -136,22 +136,12 @@ class FortalSpinner extends StatelessWidget {
 // **************************************************************************
 
 mixin _$RemixSpinnerStyleMixin on Style<RemixSpinnerSpec>, Diagnosticable {
-  Prop<Duration>? get $duration;
-  Prop<Color>? get $indicatorColor;
   Prop<double>? get $size;
   Prop<double>? get $strokeWidth;
+  Prop<Color>? get $indicatorColor;
   Prop<Color>? get $trackColor;
   Prop<double>? get $trackStrokeWidth;
-
-  /// Sets the duration.
-  RemixSpinnerStyle duration(Duration value) {
-    return merge(RemixSpinnerStyle(duration: value));
-  }
-
-  /// Sets the indicatorColor.
-  RemixSpinnerStyle indicatorColor(Color value) {
-    return merge(RemixSpinnerStyle(indicatorColor: value));
-  }
+  Prop<Duration>? get $duration;
 
   /// Sets the size.
   RemixSpinnerStyle size(double value) {
@@ -163,6 +153,11 @@ mixin _$RemixSpinnerStyleMixin on Style<RemixSpinnerSpec>, Diagnosticable {
     return merge(RemixSpinnerStyle(strokeWidth: value));
   }
 
+  /// Sets the indicatorColor.
+  RemixSpinnerStyle indicatorColor(Color value) {
+    return merge(RemixSpinnerStyle(indicatorColor: value));
+  }
+
   /// Sets the trackColor.
   RemixSpinnerStyle trackColor(Color value) {
     return merge(RemixSpinnerStyle(trackColor: value));
@@ -171,6 +166,11 @@ mixin _$RemixSpinnerStyleMixin on Style<RemixSpinnerSpec>, Diagnosticable {
   /// Sets the trackStrokeWidth.
   RemixSpinnerStyle trackStrokeWidth(double value) {
     return merge(RemixSpinnerStyle(trackStrokeWidth: value));
+  }
+
+  /// Sets the duration.
+  RemixSpinnerStyle duration(Duration value) {
+    return merge(RemixSpinnerStyle(duration: value));
   }
 
   /// Sets the animation configuration.
@@ -188,19 +188,24 @@ mixin _$RemixSpinnerStyleMixin on Style<RemixSpinnerSpec>, Diagnosticable {
     return merge(RemixSpinnerStyle(modifier: value));
   }
 
+  /// Sets the widget modifier.
+  RemixSpinnerStyle modifier(WidgetModifierConfig value) {
+    return merge(RemixSpinnerStyle(modifier: value));
+  }
+
   /// Merges with another [RemixSpinnerStyle].
   @override
   RemixSpinnerStyle merge(RemixSpinnerStyle? other) {
     return RemixSpinnerStyle.create(
-      duration: MixOps.merge($duration, other?.$duration),
-      indicatorColor: MixOps.merge($indicatorColor, other?.$indicatorColor),
       size: MixOps.merge($size, other?.$size),
       strokeWidth: MixOps.merge($strokeWidth, other?.$strokeWidth),
+      indicatorColor: MixOps.merge($indicatorColor, other?.$indicatorColor),
       trackColor: MixOps.merge($trackColor, other?.$trackColor),
       trackStrokeWidth: MixOps.merge(
         $trackStrokeWidth,
         other?.$trackStrokeWidth,
       ),
+      duration: MixOps.merge($duration, other?.$duration),
       variants: MixOps.mergeVariants($variants, other?.$variants),
       modifier: MixOps.mergeModifier($modifier, other?.$modifier),
       animation: MixOps.mergeAnimation($animation, other?.$animation),
@@ -211,12 +216,12 @@ mixin _$RemixSpinnerStyleMixin on Style<RemixSpinnerSpec>, Diagnosticable {
   @override
   StyleSpec<RemixSpinnerSpec> resolve(BuildContext context) {
     final spec = RemixSpinnerSpec(
-      duration: MixOps.resolve(context, $duration),
-      indicatorColor: MixOps.resolve(context, $indicatorColor),
       size: MixOps.resolve(context, $size),
       strokeWidth: MixOps.resolve(context, $strokeWidth),
+      indicatorColor: MixOps.resolve(context, $indicatorColor),
       trackColor: MixOps.resolve(context, $trackColor),
       trackStrokeWidth: MixOps.resolve(context, $trackStrokeWidth),
+      duration: MixOps.resolve(context, $duration),
     );
 
     return StyleSpec(
@@ -230,22 +235,22 @@ mixin _$RemixSpinnerStyleMixin on Style<RemixSpinnerSpec>, Diagnosticable {
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties
-      ..add(DiagnosticsProperty('duration', $duration))
-      ..add(DiagnosticsProperty('indicatorColor', $indicatorColor))
       ..add(DiagnosticsProperty('size', $size))
       ..add(DiagnosticsProperty('strokeWidth', $strokeWidth))
+      ..add(DiagnosticsProperty('indicatorColor', $indicatorColor))
       ..add(DiagnosticsProperty('trackColor', $trackColor))
-      ..add(DiagnosticsProperty('trackStrokeWidth', $trackStrokeWidth));
+      ..add(DiagnosticsProperty('trackStrokeWidth', $trackStrokeWidth))
+      ..add(DiagnosticsProperty('duration', $duration));
   }
 
   @override
   List<Object?> get props => [
-    $duration,
-    $indicatorColor,
     $size,
     $strokeWidth,
+    $indicatorColor,
     $trackColor,
     $trackStrokeWidth,
+    $duration,
     $animation,
     $modifier,
     $variants,

--- a/packages/remix/lib/src/components/switch/switch.g.dart
+++ b/packages/remix/lib/src/components/switch/switch.g.dart
@@ -172,6 +172,11 @@ mixin _$RemixSwitchStyleMixin on Style<RemixSwitchSpec>, Diagnosticable {
     return merge(RemixSwitchStyle(modifier: value));
   }
 
+  /// Sets the widget modifier.
+  RemixSwitchStyle modifier(WidgetModifierConfig value) {
+    return merge(RemixSwitchStyle(modifier: value));
+  }
+
   /// Merges with another [RemixSwitchStyle].
   @override
   RemixSwitchStyle merge(RemixSwitchStyle? other) {

--- a/packages/remix/lib/src/components/tabs/tabs.g.dart
+++ b/packages/remix/lib/src/components/tabs/tabs.g.dart
@@ -64,7 +64,7 @@ mixin _$RemixTabBarSpec implements Spec<RemixTabBarSpec>, Diagnosticable {
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    properties..add(DiagnosticsProperty('container', container));
+    properties.add(DiagnosticsProperty('container', container));
   }
 }
 
@@ -215,7 +215,7 @@ mixin _$RemixTabViewSpec implements Spec<RemixTabViewSpec>, Diagnosticable {
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    properties..add(DiagnosticsProperty('container', container));
+    properties.add(DiagnosticsProperty('container', container));
   }
 }
 
@@ -251,6 +251,11 @@ mixin _$RemixTabBarStyleMixin on Style<RemixTabBarSpec>, Diagnosticable {
     return merge(RemixTabBarStyle(modifier: value));
   }
 
+  /// Sets the widget modifier.
+  RemixTabBarStyle modifier(WidgetModifierConfig value) {
+    return merge(RemixTabBarStyle(modifier: value));
+  }
+
   /// Merges with another [RemixTabBarStyle].
   @override
   RemixTabBarStyle merge(RemixTabBarStyle? other) {
@@ -279,7 +284,7 @@ mixin _$RemixTabBarStyleMixin on Style<RemixTabBarSpec>, Diagnosticable {
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
-    properties..add(DiagnosticsProperty('container', $container));
+    properties.add(DiagnosticsProperty('container', $container));
   }
 
   @override
@@ -306,6 +311,11 @@ mixin _$RemixTabViewStyleMixin on Style<RemixTabViewSpec>, Diagnosticable {
 
   /// Wraps with a widget modifier.
   RemixTabViewStyle wrap(WidgetModifierConfig value) {
+    return merge(RemixTabViewStyle(modifier: value));
+  }
+
+  /// Sets the widget modifier.
+  RemixTabViewStyle modifier(WidgetModifierConfig value) {
     return merge(RemixTabViewStyle(modifier: value));
   }
 
@@ -337,7 +347,7 @@ mixin _$RemixTabViewStyleMixin on Style<RemixTabViewSpec>, Diagnosticable {
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
-    properties..add(DiagnosticsProperty('container', $container));
+    properties.add(DiagnosticsProperty('container', $container));
   }
 
   @override
@@ -346,22 +356,22 @@ mixin _$RemixTabViewStyleMixin on Style<RemixTabViewSpec>, Diagnosticable {
 
 mixin _$RemixTabStyleMixin on Style<RemixTabSpec>, Diagnosticable {
   Prop<StyleSpec<FlexBoxSpec>>? get $container;
-  Prop<StyleSpec<IconSpec>>? get $icon;
   Prop<StyleSpec<TextSpec>>? get $label;
+  Prop<StyleSpec<IconSpec>>? get $icon;
 
   /// Sets the container.
   RemixTabStyle container(FlexBoxStyler value) {
     return merge(RemixTabStyle(container: value));
   }
 
-  /// Sets the icon.
-  RemixTabStyle icon(IconStyler value) {
-    return merge(RemixTabStyle(icon: value));
-  }
-
   /// Sets the label.
   RemixTabStyle label(TextStyler value) {
     return merge(RemixTabStyle(label: value));
+  }
+
+  /// Sets the icon.
+  RemixTabStyle icon(IconStyler value) {
+    return merge(RemixTabStyle(icon: value));
   }
 
   /// Sets the animation configuration.
@@ -379,13 +389,18 @@ mixin _$RemixTabStyleMixin on Style<RemixTabSpec>, Diagnosticable {
     return merge(RemixTabStyle(modifier: value));
   }
 
+  /// Sets the widget modifier.
+  RemixTabStyle modifier(WidgetModifierConfig value) {
+    return merge(RemixTabStyle(modifier: value));
+  }
+
   /// Merges with another [RemixTabStyle].
   @override
   RemixTabStyle merge(RemixTabStyle? other) {
     return RemixTabStyle.create(
       container: MixOps.merge($container, other?.$container),
-      icon: MixOps.merge($icon, other?.$icon),
       label: MixOps.merge($label, other?.$label),
+      icon: MixOps.merge($icon, other?.$icon),
       variants: MixOps.mergeVariants($variants, other?.$variants),
       modifier: MixOps.mergeModifier($modifier, other?.$modifier),
       animation: MixOps.mergeAnimation($animation, other?.$animation),
@@ -397,8 +412,8 @@ mixin _$RemixTabStyleMixin on Style<RemixTabSpec>, Diagnosticable {
   StyleSpec<RemixTabSpec> resolve(BuildContext context) {
     final spec = RemixTabSpec(
       container: MixOps.resolve(context, $container),
-      icon: MixOps.resolve(context, $icon),
       label: MixOps.resolve(context, $label),
+      icon: MixOps.resolve(context, $icon),
     );
 
     return StyleSpec(
@@ -413,15 +428,15 @@ mixin _$RemixTabStyleMixin on Style<RemixTabSpec>, Diagnosticable {
     super.debugFillProperties(properties);
     properties
       ..add(DiagnosticsProperty('container', $container))
-      ..add(DiagnosticsProperty('icon', $icon))
-      ..add(DiagnosticsProperty('label', $label));
+      ..add(DiagnosticsProperty('label', $label))
+      ..add(DiagnosticsProperty('icon', $icon));
   }
 
   @override
   List<Object?> get props => [
     $container,
-    $icon,
     $label,
+    $icon,
     $animation,
     $modifier,
     $variants,

--- a/packages/remix/lib/src/components/textfield/textfield.g.dart
+++ b/packages/remix/lib/src/components/textfield/textfield.g.dart
@@ -446,37 +446,57 @@ class FortalTextField extends StatelessWidget {
 // **************************************************************************
 
 mixin _$RemixTextFieldStyleMixin on Style<RemixTextFieldSpec>, Diagnosticable {
-  Prop<StyleSpec<FlexBoxSpec>>? get $container;
-  Prop<Color>? get $cursorColor;
+  Prop<StyleSpec<TextSpec>>? get $text;
+  Prop<StyleSpec<TextSpec>>? get $hintText;
+  Prop<TextAlign>? get $textAlign;
+  Prop<double>? get $cursorWidth;
   Prop<double>? get $cursorHeight;
+  Prop<Radius>? get $cursorRadius;
+  Prop<Color>? get $cursorColor;
   Prop<Offset>? get $cursorOffset;
   Prop<bool>? get $cursorOpacityAnimates;
-  Prop<Radius>? get $cursorRadius;
-  Prop<double>? get $cursorWidth;
-  Prop<StyleSpec<TextSpec>>? get $helperText;
-  Prop<StyleSpec<TextSpec>>? get $hintText;
-  Prop<Brightness>? get $keyboardAppearance;
-  Prop<StyleSpec<TextSpec>>? get $label;
-  Prop<EdgeInsets>? get $scrollPadding;
   Prop<BoxHeightStyle>? get $selectionHeightStyle;
   Prop<BoxWidthStyle>? get $selectionWidthStyle;
+  Prop<EdgeInsets>? get $scrollPadding;
+  Prop<Brightness>? get $keyboardAppearance;
   Prop<double>? get $spacing;
-  Prop<StyleSpec<TextSpec>>? get $text;
-  Prop<TextAlign>? get $textAlign;
+  Prop<StyleSpec<FlexBoxSpec>>? get $container;
+  Prop<StyleSpec<TextSpec>>? get $helperText;
+  Prop<StyleSpec<TextSpec>>? get $label;
 
-  /// Sets the container.
-  RemixTextFieldStyle container(FlexBoxStyler value) {
-    return merge(RemixTextFieldStyle(container: value));
+  /// Sets the text.
+  RemixTextFieldStyle text(TextStyler value) {
+    return merge(RemixTextFieldStyle(text: value));
   }
 
-  /// Sets the cursorColor.
-  RemixTextFieldStyle cursorColor(Color value) {
-    return merge(RemixTextFieldStyle(cursorColor: value));
+  /// Sets the hintText.
+  RemixTextFieldStyle hintText(TextStyler value) {
+    return merge(RemixTextFieldStyle(hintText: value));
+  }
+
+  /// Sets the textAlign.
+  RemixTextFieldStyle textAlign(TextAlign value) {
+    return merge(RemixTextFieldStyle(textAlign: value));
+  }
+
+  /// Sets the cursorWidth.
+  RemixTextFieldStyle cursorWidth(double value) {
+    return merge(RemixTextFieldStyle(cursorWidth: value));
   }
 
   /// Sets the cursorHeight.
   RemixTextFieldStyle cursorHeight(double value) {
     return merge(RemixTextFieldStyle(cursorHeight: value));
+  }
+
+  /// Sets the cursorRadius.
+  RemixTextFieldStyle cursorRadius(Radius value) {
+    return merge(RemixTextFieldStyle(cursorRadius: value));
+  }
+
+  /// Sets the cursorColor.
+  RemixTextFieldStyle cursorColor(Color value) {
+    return merge(RemixTextFieldStyle(cursorColor: value));
   }
 
   /// Sets the cursorOffset.
@@ -489,41 +509,6 @@ mixin _$RemixTextFieldStyleMixin on Style<RemixTextFieldSpec>, Diagnosticable {
     return merge(RemixTextFieldStyle(cursorOpacityAnimates: value));
   }
 
-  /// Sets the cursorRadius.
-  RemixTextFieldStyle cursorRadius(Radius value) {
-    return merge(RemixTextFieldStyle(cursorRadius: value));
-  }
-
-  /// Sets the cursorWidth.
-  RemixTextFieldStyle cursorWidth(double value) {
-    return merge(RemixTextFieldStyle(cursorWidth: value));
-  }
-
-  /// Sets the helperText.
-  RemixTextFieldStyle helperText(TextStyler value) {
-    return merge(RemixTextFieldStyle(helperText: value));
-  }
-
-  /// Sets the hintText.
-  RemixTextFieldStyle hintText(TextStyler value) {
-    return merge(RemixTextFieldStyle(hintText: value));
-  }
-
-  /// Sets the keyboardAppearance.
-  RemixTextFieldStyle keyboardAppearance(Brightness value) {
-    return merge(RemixTextFieldStyle(keyboardAppearance: value));
-  }
-
-  /// Sets the label.
-  RemixTextFieldStyle label(TextStyler value) {
-    return merge(RemixTextFieldStyle(label: value));
-  }
-
-  /// Sets the scrollPadding.
-  RemixTextFieldStyle scrollPadding(EdgeInsets value) {
-    return merge(RemixTextFieldStyle(scrollPadding: value));
-  }
-
   /// Sets the selectionHeightStyle.
   RemixTextFieldStyle selectionHeightStyle(BoxHeightStyle value) {
     return merge(RemixTextFieldStyle(selectionHeightStyle: value));
@@ -534,19 +519,34 @@ mixin _$RemixTextFieldStyleMixin on Style<RemixTextFieldSpec>, Diagnosticable {
     return merge(RemixTextFieldStyle(selectionWidthStyle: value));
   }
 
+  /// Sets the scrollPadding.
+  RemixTextFieldStyle scrollPadding(EdgeInsets value) {
+    return merge(RemixTextFieldStyle(scrollPadding: value));
+  }
+
+  /// Sets the keyboardAppearance.
+  RemixTextFieldStyle keyboardAppearance(Brightness value) {
+    return merge(RemixTextFieldStyle(keyboardAppearance: value));
+  }
+
   /// Sets the spacing.
   RemixTextFieldStyle spacing(double value) {
     return merge(RemixTextFieldStyle(spacing: value));
   }
 
-  /// Sets the text.
-  RemixTextFieldStyle text(TextStyler value) {
-    return merge(RemixTextFieldStyle(text: value));
+  /// Sets the container.
+  RemixTextFieldStyle container(FlexBoxStyler value) {
+    return merge(RemixTextFieldStyle(container: value));
   }
 
-  /// Sets the textAlign.
-  RemixTextFieldStyle textAlign(TextAlign value) {
-    return merge(RemixTextFieldStyle(textAlign: value));
+  /// Sets the helperText.
+  RemixTextFieldStyle helperText(TextStyler value) {
+    return merge(RemixTextFieldStyle(helperText: value));
+  }
+
+  /// Sets the label.
+  RemixTextFieldStyle label(TextStyler value) {
+    return merge(RemixTextFieldStyle(label: value));
   }
 
   /// Sets the animation configuration.
@@ -564,28 +564,27 @@ mixin _$RemixTextFieldStyleMixin on Style<RemixTextFieldSpec>, Diagnosticable {
     return merge(RemixTextFieldStyle(modifier: value));
   }
 
+  /// Sets the widget modifier.
+  RemixTextFieldStyle modifier(WidgetModifierConfig value) {
+    return merge(RemixTextFieldStyle(modifier: value));
+  }
+
   /// Merges with another [RemixTextFieldStyle].
   @override
   RemixTextFieldStyle merge(RemixTextFieldStyle? other) {
     return RemixTextFieldStyle.create(
-      container: MixOps.merge($container, other?.$container),
-      cursorColor: MixOps.merge($cursorColor, other?.$cursorColor),
+      text: MixOps.merge($text, other?.$text),
+      hintText: MixOps.merge($hintText, other?.$hintText),
+      textAlign: MixOps.merge($textAlign, other?.$textAlign),
+      cursorWidth: MixOps.merge($cursorWidth, other?.$cursorWidth),
       cursorHeight: MixOps.merge($cursorHeight, other?.$cursorHeight),
+      cursorRadius: MixOps.merge($cursorRadius, other?.$cursorRadius),
+      cursorColor: MixOps.merge($cursorColor, other?.$cursorColor),
       cursorOffset: MixOps.merge($cursorOffset, other?.$cursorOffset),
       cursorOpacityAnimates: MixOps.merge(
         $cursorOpacityAnimates,
         other?.$cursorOpacityAnimates,
       ),
-      cursorRadius: MixOps.merge($cursorRadius, other?.$cursorRadius),
-      cursorWidth: MixOps.merge($cursorWidth, other?.$cursorWidth),
-      helperText: MixOps.merge($helperText, other?.$helperText),
-      hintText: MixOps.merge($hintText, other?.$hintText),
-      keyboardAppearance: MixOps.merge(
-        $keyboardAppearance,
-        other?.$keyboardAppearance,
-      ),
-      label: MixOps.merge($label, other?.$label),
-      scrollPadding: MixOps.merge($scrollPadding, other?.$scrollPadding),
       selectionHeightStyle: MixOps.merge(
         $selectionHeightStyle,
         other?.$selectionHeightStyle,
@@ -594,9 +593,15 @@ mixin _$RemixTextFieldStyleMixin on Style<RemixTextFieldSpec>, Diagnosticable {
         $selectionWidthStyle,
         other?.$selectionWidthStyle,
       ),
+      scrollPadding: MixOps.merge($scrollPadding, other?.$scrollPadding),
+      keyboardAppearance: MixOps.merge(
+        $keyboardAppearance,
+        other?.$keyboardAppearance,
+      ),
       spacing: MixOps.merge($spacing, other?.$spacing),
-      text: MixOps.merge($text, other?.$text),
-      textAlign: MixOps.merge($textAlign, other?.$textAlign),
+      container: MixOps.merge($container, other?.$container),
+      helperText: MixOps.merge($helperText, other?.$helperText),
+      label: MixOps.merge($label, other?.$label),
       variants: MixOps.mergeVariants($variants, other?.$variants),
       modifier: MixOps.mergeModifier($modifier, other?.$modifier),
       animation: MixOps.mergeAnimation($animation, other?.$animation),
@@ -607,23 +612,23 @@ mixin _$RemixTextFieldStyleMixin on Style<RemixTextFieldSpec>, Diagnosticable {
   @override
   StyleSpec<RemixTextFieldSpec> resolve(BuildContext context) {
     final spec = RemixTextFieldSpec(
-      container: MixOps.resolve(context, $container),
-      cursorColor: MixOps.resolve(context, $cursorColor),
+      text: MixOps.resolve(context, $text),
+      hintText: MixOps.resolve(context, $hintText),
+      textAlign: MixOps.resolve(context, $textAlign),
+      cursorWidth: MixOps.resolve(context, $cursorWidth),
       cursorHeight: MixOps.resolve(context, $cursorHeight),
+      cursorRadius: MixOps.resolve(context, $cursorRadius),
+      cursorColor: MixOps.resolve(context, $cursorColor),
       cursorOffset: MixOps.resolve(context, $cursorOffset),
       cursorOpacityAnimates: MixOps.resolve(context, $cursorOpacityAnimates),
-      cursorRadius: MixOps.resolve(context, $cursorRadius),
-      cursorWidth: MixOps.resolve(context, $cursorWidth),
-      helperText: MixOps.resolve(context, $helperText),
-      hintText: MixOps.resolve(context, $hintText),
-      keyboardAppearance: MixOps.resolve(context, $keyboardAppearance),
-      label: MixOps.resolve(context, $label),
-      scrollPadding: MixOps.resolve(context, $scrollPadding),
       selectionHeightStyle: MixOps.resolve(context, $selectionHeightStyle),
       selectionWidthStyle: MixOps.resolve(context, $selectionWidthStyle),
+      scrollPadding: MixOps.resolve(context, $scrollPadding),
+      keyboardAppearance: MixOps.resolve(context, $keyboardAppearance),
       spacing: MixOps.resolve(context, $spacing),
-      text: MixOps.resolve(context, $text),
-      textAlign: MixOps.resolve(context, $textAlign),
+      container: MixOps.resolve(context, $container),
+      helperText: MixOps.resolve(context, $helperText),
+      label: MixOps.resolve(context, $label),
     );
 
     return StyleSpec(
@@ -637,46 +642,46 @@ mixin _$RemixTextFieldStyleMixin on Style<RemixTextFieldSpec>, Diagnosticable {
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties
-      ..add(DiagnosticsProperty('container', $container))
-      ..add(DiagnosticsProperty('cursorColor', $cursorColor))
+      ..add(DiagnosticsProperty('text', $text))
+      ..add(DiagnosticsProperty('hintText', $hintText))
+      ..add(DiagnosticsProperty('textAlign', $textAlign))
+      ..add(DiagnosticsProperty('cursorWidth', $cursorWidth))
       ..add(DiagnosticsProperty('cursorHeight', $cursorHeight))
+      ..add(DiagnosticsProperty('cursorRadius', $cursorRadius))
+      ..add(DiagnosticsProperty('cursorColor', $cursorColor))
       ..add(DiagnosticsProperty('cursorOffset', $cursorOffset))
       ..add(
         DiagnosticsProperty('cursorOpacityAnimates', $cursorOpacityAnimates),
       )
-      ..add(DiagnosticsProperty('cursorRadius', $cursorRadius))
-      ..add(DiagnosticsProperty('cursorWidth', $cursorWidth))
-      ..add(DiagnosticsProperty('helperText', $helperText))
-      ..add(DiagnosticsProperty('hintText', $hintText))
-      ..add(DiagnosticsProperty('keyboardAppearance', $keyboardAppearance))
-      ..add(DiagnosticsProperty('label', $label))
-      ..add(DiagnosticsProperty('scrollPadding', $scrollPadding))
       ..add(DiagnosticsProperty('selectionHeightStyle', $selectionHeightStyle))
       ..add(DiagnosticsProperty('selectionWidthStyle', $selectionWidthStyle))
+      ..add(DiagnosticsProperty('scrollPadding', $scrollPadding))
+      ..add(DiagnosticsProperty('keyboardAppearance', $keyboardAppearance))
       ..add(DiagnosticsProperty('spacing', $spacing))
-      ..add(DiagnosticsProperty('text', $text))
-      ..add(DiagnosticsProperty('textAlign', $textAlign));
+      ..add(DiagnosticsProperty('container', $container))
+      ..add(DiagnosticsProperty('helperText', $helperText))
+      ..add(DiagnosticsProperty('label', $label));
   }
 
   @override
   List<Object?> get props => [
-    $container,
-    $cursorColor,
+    $text,
+    $hintText,
+    $textAlign,
+    $cursorWidth,
     $cursorHeight,
+    $cursorRadius,
+    $cursorColor,
     $cursorOffset,
     $cursorOpacityAnimates,
-    $cursorRadius,
-    $cursorWidth,
-    $helperText,
-    $hintText,
-    $keyboardAppearance,
-    $label,
-    $scrollPadding,
     $selectionHeightStyle,
     $selectionWidthStyle,
+    $scrollPadding,
+    $keyboardAppearance,
     $spacing,
-    $text,
-    $textAlign,
+    $container,
+    $helperText,
+    $label,
     $animation,
     $modifier,
     $variants,

--- a/packages/remix/lib/src/components/toggle/toggle.g.dart
+++ b/packages/remix/lib/src/components/toggle/toggle.g.dart
@@ -158,22 +158,22 @@ class FortalToggle extends StatelessWidget {
 
 mixin _$RemixToggleStyleMixin on Style<RemixToggleSpec>, Diagnosticable {
   Prop<StyleSpec<FlexBoxSpec>>? get $container;
-  Prop<StyleSpec<IconSpec>>? get $icon;
   Prop<StyleSpec<TextSpec>>? get $label;
+  Prop<StyleSpec<IconSpec>>? get $icon;
 
   /// Sets the container.
   RemixToggleStyle container(FlexBoxStyler value) {
     return merge(RemixToggleStyle(container: value));
   }
 
-  /// Sets the icon.
-  RemixToggleStyle icon(IconStyler value) {
-    return merge(RemixToggleStyle(icon: value));
-  }
-
   /// Sets the label.
   RemixToggleStyle label(TextStyler value) {
     return merge(RemixToggleStyle(label: value));
+  }
+
+  /// Sets the icon.
+  RemixToggleStyle icon(IconStyler value) {
+    return merge(RemixToggleStyle(icon: value));
   }
 
   /// Sets the animation configuration.
@@ -191,13 +191,18 @@ mixin _$RemixToggleStyleMixin on Style<RemixToggleSpec>, Diagnosticable {
     return merge(RemixToggleStyle(modifier: value));
   }
 
+  /// Sets the widget modifier.
+  RemixToggleStyle modifier(WidgetModifierConfig value) {
+    return merge(RemixToggleStyle(modifier: value));
+  }
+
   /// Merges with another [RemixToggleStyle].
   @override
   RemixToggleStyle merge(RemixToggleStyle? other) {
     return RemixToggleStyle.create(
       container: MixOps.merge($container, other?.$container),
-      icon: MixOps.merge($icon, other?.$icon),
       label: MixOps.merge($label, other?.$label),
+      icon: MixOps.merge($icon, other?.$icon),
       variants: MixOps.mergeVariants($variants, other?.$variants),
       modifier: MixOps.mergeModifier($modifier, other?.$modifier),
       animation: MixOps.mergeAnimation($animation, other?.$animation),
@@ -209,8 +214,8 @@ mixin _$RemixToggleStyleMixin on Style<RemixToggleSpec>, Diagnosticable {
   StyleSpec<RemixToggleSpec> resolve(BuildContext context) {
     final spec = RemixToggleSpec(
       container: MixOps.resolve(context, $container),
-      icon: MixOps.resolve(context, $icon),
       label: MixOps.resolve(context, $label),
+      icon: MixOps.resolve(context, $icon),
     );
 
     return StyleSpec(
@@ -225,15 +230,15 @@ mixin _$RemixToggleStyleMixin on Style<RemixToggleSpec>, Diagnosticable {
     super.debugFillProperties(properties);
     properties
       ..add(DiagnosticsProperty('container', $container))
-      ..add(DiagnosticsProperty('icon', $icon))
-      ..add(DiagnosticsProperty('label', $label));
+      ..add(DiagnosticsProperty('label', $label))
+      ..add(DiagnosticsProperty('icon', $icon));
   }
 
   @override
   List<Object?> get props => [
     $container,
-    $icon,
     $label,
+    $icon,
     $animation,
     $modifier,
     $variants,

--- a/packages/remix/lib/src/components/tooltip/tooltip.g.dart
+++ b/packages/remix/lib/src/components/tooltip/tooltip.g.dart
@@ -102,8 +102,8 @@ typedef _$RemixTooltipSpecMethods = _$RemixTooltipSpec; // ignore: unused_elemen
 mixin _$RemixTooltipStyleMixin on Style<RemixTooltipSpec>, Diagnosticable {
   Prop<StyleSpec<BoxSpec>>? get $container;
   Prop<StyleSpec<TextSpec>>? get $label;
-  Prop<Duration>? get $showDuration;
   Prop<Duration>? get $waitDuration;
+  Prop<Duration>? get $showDuration;
 
   /// Sets the container.
   RemixTooltipStyle container(BoxStyler value) {
@@ -115,14 +115,14 @@ mixin _$RemixTooltipStyleMixin on Style<RemixTooltipSpec>, Diagnosticable {
     return merge(RemixTooltipStyle(label: value));
   }
 
-  /// Sets the showDuration.
-  RemixTooltipStyle showDuration(Duration value) {
-    return merge(RemixTooltipStyle(showDuration: value));
-  }
-
   /// Sets the waitDuration.
   RemixTooltipStyle waitDuration(Duration value) {
     return merge(RemixTooltipStyle(waitDuration: value));
+  }
+
+  /// Sets the showDuration.
+  RemixTooltipStyle showDuration(Duration value) {
+    return merge(RemixTooltipStyle(showDuration: value));
   }
 
   /// Sets the animation configuration.
@@ -140,14 +140,19 @@ mixin _$RemixTooltipStyleMixin on Style<RemixTooltipSpec>, Diagnosticable {
     return merge(RemixTooltipStyle(modifier: value));
   }
 
+  /// Sets the widget modifier.
+  RemixTooltipStyle modifier(WidgetModifierConfig value) {
+    return merge(RemixTooltipStyle(modifier: value));
+  }
+
   /// Merges with another [RemixTooltipStyle].
   @override
   RemixTooltipStyle merge(RemixTooltipStyle? other) {
     return RemixTooltipStyle.create(
       container: MixOps.merge($container, other?.$container),
       label: MixOps.merge($label, other?.$label),
-      showDuration: MixOps.merge($showDuration, other?.$showDuration),
       waitDuration: MixOps.merge($waitDuration, other?.$waitDuration),
+      showDuration: MixOps.merge($showDuration, other?.$showDuration),
       variants: MixOps.mergeVariants($variants, other?.$variants),
       modifier: MixOps.mergeModifier($modifier, other?.$modifier),
       animation: MixOps.mergeAnimation($animation, other?.$animation),
@@ -160,8 +165,8 @@ mixin _$RemixTooltipStyleMixin on Style<RemixTooltipSpec>, Diagnosticable {
     final spec = RemixTooltipSpec(
       container: MixOps.resolve(context, $container),
       label: MixOps.resolve(context, $label),
-      showDuration: MixOps.resolve(context, $showDuration),
       waitDuration: MixOps.resolve(context, $waitDuration),
+      showDuration: MixOps.resolve(context, $showDuration),
     );
 
     return StyleSpec(
@@ -177,16 +182,16 @@ mixin _$RemixTooltipStyleMixin on Style<RemixTooltipSpec>, Diagnosticable {
     properties
       ..add(DiagnosticsProperty('container', $container))
       ..add(DiagnosticsProperty('label', $label))
-      ..add(DiagnosticsProperty('showDuration', $showDuration))
-      ..add(DiagnosticsProperty('waitDuration', $waitDuration));
+      ..add(DiagnosticsProperty('waitDuration', $waitDuration))
+      ..add(DiagnosticsProperty('showDuration', $showDuration));
   }
 
   @override
   List<Object?> get props => [
     $container,
     $label,
-    $showDuration,
     $waitDuration,
+    $showDuration,
     $animation,
     $modifier,
     $variants,

--- a/packages/remix/lib/src/components/tooltip/tooltip_widget.dart
+++ b/packages/remix/lib/src/components/tooltip/tooltip_widget.dart
@@ -33,11 +33,11 @@ class RemixTooltip extends StatelessWidget {
       style: style,
       builder: (context, spec) {
         return NakedTooltip(
-          overlayBuilder: (context, info) =>
+          overlayBuilder: (context, animation) =>
               Box(styleSpec: spec.container, child: tooltipChild),
-          showDuration: spec.showDuration ?? const Duration(milliseconds: 1500),
-          waitDuration: spec.waitDuration ?? const Duration(milliseconds: 300),
-          semanticsLabel: tooltipSemantics,
+          touchDelay: spec.showDuration ?? const Duration(milliseconds: 1500),
+          hoverDelay: spec.waitDuration ?? const Duration(milliseconds: 300),
+          semanticLabel: tooltipSemantics,
           child: child,
         );
       },

--- a/packages/remix/pubspec.yaml
+++ b/packages/remix/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   flutter:
     sdk: flutter
   mix: ^2.1.0
-  mix_annotations: ^2.1.0
+  mix_annotations: ^2.1.1
   naked_ui: ^1.0.0-beta.1
 
 dev_dependencies:
@@ -25,7 +25,7 @@ dev_dependencies:
   integration_test:
     sdk: flutter
   build_runner: ^2.10.1
-  mix_generator: ^2.1.0
+  mix_generator: ^2.1.1
   mix_lint: any
 
 flutter:

--- a/packages/remix/pubspec.yaml
+++ b/packages/remix/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
     sdk: flutter
   mix: ^2.1.0
   mix_annotations: ^2.1.0
-  naked_ui: ^0.2.0-beta.7
+  naked_ui: ^1.0.0-beta.1
 
 dev_dependencies:
   flutter_test:

--- a/packages/remix/pubspec.yaml
+++ b/packages/remix/pubspec.yaml
@@ -15,8 +15,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  mix: ^2.0.3
-  mix_annotations: ^2.0.0
+  mix: ^2.1.0
+  mix_annotations: ^2.1.0
   naked_ui: ^0.2.0-beta.7
 
 dev_dependencies:
@@ -25,7 +25,8 @@ dev_dependencies:
   integration_test:
     sdk: flutter
   build_runner: ^2.10.1
-  mix_generator: ^2.0.0
+  mix_generator: ^2.1.0
+  mix_lint: any
 
 flutter:
   uses-material-design: true

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -459,18 +459,18 @@ packages:
     dependency: transitive
     description:
       name: mix_annotations
-      sha256: fe52ce2e53efc5af2539882cadbe601688021701cb6e4c425d6c1df4687e2ac7
+      sha256: "926c11dbc6d0df9f7b5eeb22491bb76500d4427bd6a639776216abd5ac71a9d0"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   mix_generator:
     dependency: transitive
     description:
       name: mix_generator
-      sha256: d3d5e718546865933c79f164857b034277fa8a0f5cd12c189d2108e66d3a5ee5
+      sha256: c1a0f693c1c3cd9fdff2ad505efc62e92a29590c0114bfe76bf748a06362b49c
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   mix_lint:
     dependency: "direct overridden"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -492,10 +492,10 @@ packages:
     dependency: "direct main"
     description:
       name: naked_ui
-      sha256: "7c908f67a5b37d6434183bf261d0adc9cd53a52b62e58dca6f1e2e78929b29f7"
+      sha256: "73d6ce1991b38aa27a02c012f7ecdd071ea7398d4faed53d83bcff5ed55d0878"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0-beta.7"
+    version: "1.0.0-beta.1"
   nested:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -17,6 +17,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.8.0"
+  analysis_server_plugin:
+    dependency: transitive
+    description:
+      name: analysis_server_plugin
+      sha256: c9611c4b053f868434400e734c594a7e8464f307f8eaf7ff266d903cd2d615c0
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.10"
   analyzer:
     dependency: transitive
     description:
@@ -25,6 +33,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "10.2.0"
+  analyzer_plugin:
+    dependency: transitive
+    description:
+      name: analyzer_plugin
+      sha256: a886aaa94fb128ffe9cf5ee2495d9ef42ef129fe2e265b84b8820987ca15f4cd
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.14.4"
   ansi_styles:
     dependency: transitive
     description:
@@ -432,31 +448,38 @@ packages:
     source: hosted
     version: "2.0.0"
   mix:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
       name: mix
-      sha256: "9086fd222f2b6faeab9743dc98788c1a1083d8f8072bcd21c2c07ecd16cf876f"
+      sha256: ed8382ac70d5d85c3d0f753c9f8f68f61d74958afbd05f3e3d7144a11ab8efad
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.3"
+    version: "2.1.0"
   mix_annotations:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
-      path: "packages/mix_annotations"
-      ref: "feat/styler-generator"
-      resolved-ref: ee735897748eccbd1d2fdcfb0edba90192e7bebe
-      url: "https://github.com/btwld/mix.git"
-    source: git
-    version: "2.0.1"
+      name: mix_annotations
+      sha256: fe52ce2e53efc5af2539882cadbe601688021701cb6e4c425d6c1df4687e2ac7
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   mix_generator:
+    dependency: transitive
+    description:
+      name: mix_generator
+      sha256: d3d5e718546865933c79f164857b034277fa8a0f5cd12c189d2108e66d3a5ee5
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
+  mix_lint:
     dependency: "direct overridden"
     description:
-      path: "packages/mix_generator"
-      ref: "feat/styler-generator"
-      resolved-ref: ee735897748eccbd1d2fdcfb0edba90192e7bebe
+      path: "packages/mix_lint"
+      ref: main
+      resolved-ref: "52cba7c46bcc579742e55275756d9dd8532ea79b"
       url: "https://github.com/btwld/mix.git"
     source: git
-    version: "2.0.3"
+    version: "2.0.0"
   mustache_template:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ environment:
   flutter: ">=3.44.0"
 
 dependencies:
-  naked_ui: ^0.2.0-beta.7
+  naked_ui: ^1.0.0-beta.1
   meta: ^1.16.0
 
 dependency_overrides:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,26 +4,18 @@ environment:
   flutter: ">=3.44.0"
 
 dependencies:
-  # mix: ^2.0.0-rc.0
   naked_ui: ^0.2.0-beta.7
   meta: ^1.16.0
 
 dependency_overrides:
-  mix:
+  # mix, mix_annotations and mix_generator now resolve from pub.dev (^2.1.0).
+  # mix_lint 2.0.0 (the analysis_server_plugin rebuild required for the
+  # `plugins:` analyzer config) is not published yet, so it is sourced from git.
+  mix_lint:
     git:
       url: https://github.com/btwld/mix.git
-      ref: feat/styler-generator
-      path: packages/mix
-  mix_annotations:
-    git:
-      url: https://github.com/btwld/mix.git
-      ref: feat/styler-generator
-      path: packages/mix_annotations
-  mix_generator:
-    git:
-      url: https://github.com/btwld/mix.git
-      ref: feat/styler-generator
-      path: packages/mix_generator
+      ref: main
+      path: packages/mix_lint
 
 dev_dependencies:
   melos: ^7.1.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ dependencies:
   meta: ^1.16.0
 
 dependency_overrides:
-  # mix, mix_annotations and mix_generator now resolve from pub.dev (^2.1.0).
+  # mix, mix_annotations and mix_generator now resolve from pub.dev (^2.1.1).
   # mix_lint 2.0.0 (the analysis_server_plugin rebuild required for the
   # `plugins:` analyzer config) is not published yet, so it is sourced from git.
   mix_lint:


### PR DESCRIPTION
## Summary

- Bump `mix`, `mix_annotations` and `mix_generator` to `^2.1.0`. The styler-generator work this repo previously pulled from the `feat/styler-generator` git branch has shipped in the published `2.1.0` line, so the `dependency_overrides` for those packages are removed and Mix now resolves from pub.dev.
- Regenerate every component `*.g.dart` with the 2.1.0 generator (field reordering + the new `modifier(WidgetModifierConfig)` setter from `@MixableModifier`).
- Add `mix_lint` with the Mix 2.0 rule set, enabled via the analyzer `plugins:` field in a new **workspace-root** `analysis_options.yaml` (the analyzer rejects `plugins:` inside member packages). `mix_lint 2.0.0` (the `analysis_server_plugin` rebuild required for this config) is not yet published, so it is sourced from git via a `dependency_override`.

Follows the [mix_lint tutorial](https://www.fluttermix.com/documentation/mix/ecosystem/mix-lint).

## Test plan

- [x] `flutter pub get` resolves (mix/mix_annotations/mix_generator at 2.1.0, mix_lint 2.0.0 from git)
- [x] `dart run build_runner build` regenerates outputs cleanly
- [x] `flutter analyze` on the remix package → No issues found
- [ ] Restart the analysis server / IDE to confirm mix_lint diagnostics surface live

Made with [Cursor](https://cursor.com)