### PR TITLE
fix(dialog): compose child with title, description, and actions

### DIFF
--- a/packages/remix/CHANGELOG.md
+++ b/packages/remix/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+- **BREAKING** **FIX**: `RemixDialog.child` now composes with `title`,
+  `description`, and `actions` in `AlertDialog` order instead of silently
+  discarding them. A lone `child` still fills the container directly, so fully
+  custom dialog bodies are unaffected.
+
 ## 0.2.0
 
 - **FEAT**: Add RemixToggle component (#50).

--- a/packages/remix/lib/src/components/dialog/dialog_widget.dart
+++ b/packages/remix/lib/src/components/dialog/dialog_widget.dart
@@ -130,13 +130,15 @@ class RemixDialog extends StatelessWidget {
         style: style,
         builder: (context, spec) {
           final hasActions = actions != null && actions!.isNotEmpty;
+          final isLoneChild =
+              child != null &&
+              title == null &&
+              description == null &&
+              !hasActions;
 
           // A lone child fills the container directly, outside the default
           // column, so fully custom dialog bodies keep their own layout.
-          if (child != null &&
-              title == null &&
-              description == null &&
-              !hasActions) {
+          if (isLoneChild) {
             return Box(styleSpec: spec.container, child: child!);
           }
 

--- a/packages/remix/lib/src/components/dialog/dialog_widget.dart
+++ b/packages/remix/lib/src/components/dialog/dialog_widget.dart
@@ -94,7 +94,11 @@ class RemixDialog extends StatelessWidget {
          'Either child, title, or description must be provided',
        );
 
-  /// Custom content widget (overrides title and description).
+  /// Custom body content.
+  ///
+  /// Composes with [title], [description], and [actions] when they are also
+  /// provided, matching [AlertDialog]: title, description, then [child], then
+  /// actions. When it is the only content, it fills the dialog container.
   final Widget? child;
 
   /// Dialog title text.
@@ -125,12 +129,20 @@ class RemixDialog extends StatelessWidget {
       child: StyleBuilder(
         style: style,
         builder: (context, spec) {
-          // Use custom child if provided
-          if (child != null) {
+          final hasActions = actions != null && actions!.isNotEmpty;
+
+          // A lone child fills the container directly, outside the default
+          // column, so fully custom dialog bodies keep their own layout.
+          if (child != null &&
+              title == null &&
+              description == null &&
+              !hasActions) {
             return Box(styleSpec: spec.container, child: child!);
           }
 
-          // Build default dialog content
+          // Compose everything that was provided, in AlertDialog order.
+          // Previously a non-null child silently discarded title, description,
+          // and actions; provided content must never disappear.
           return Box(
             styleSpec: spec.container,
             child: Column(
@@ -141,7 +153,8 @@ class RemixDialog extends StatelessWidget {
                 if (title != null) StyledText(title!, styleSpec: spec.title),
                 if (description != null)
                   StyledText(description!, styleSpec: spec.description),
-                if (actions != null && actions!.isNotEmpty)
+                if (child != null) child!,
+                if (hasActions)
                   FlexBox(styleSpec: spec.actions, children: actions!),
               ],
             ),

--- a/packages/remix/lib/src/components/dialog/dialog_widget.dart
+++ b/packages/remix/lib/src/components/dialog/dialog_widget.dart
@@ -94,12 +94,10 @@ class RemixDialog extends StatelessWidget {
          'Either child, title, or description must be provided',
        );
 
-  /// Custom content displayed as the dialog body.
+  /// Custom body content.
   ///
-  /// When [title], [description], or [actions] are also provided, this widget
-  /// is rendered after the title and description and before the actions,
-  /// following the [AlertDialog] content order. When it is the only content,
-  /// it is placed directly in the dialog container and keeps its own layout.
+  /// Composes with [title], [description], and [actions] in [AlertDialog]
+  /// order. Alone, placed directly in the container (no default column).
   final Widget? child;
 
   /// Dialog title text.
@@ -137,16 +135,12 @@ class RemixDialog extends StatelessWidget {
               description == null &&
               !hasActions;
 
-          // A lone child is placed directly in the container, outside the
-          // default column, so fully custom dialog bodies keep their own
-          // layout.
+          // Skip the default column so a fully custom body keeps its layout.
           if (isLoneChild) {
             return Box(styleSpec: spec.container, child: child!);
           }
 
-          // Compose all provided content in AlertDialog order: title,
-          // description, child, then actions. Content passed to the dialog
-          // must never be silently discarded.
+          // title → description → child → actions; never discard provided content.
           return Box(
             styleSpec: spec.container,
             child: Column(

--- a/packages/remix/lib/src/components/dialog/dialog_widget.dart
+++ b/packages/remix/lib/src/components/dialog/dialog_widget.dart
@@ -94,11 +94,12 @@ class RemixDialog extends StatelessWidget {
          'Either child, title, or description must be provided',
        );
 
-  /// Custom body content.
+  /// Custom content displayed as the dialog body.
   ///
-  /// Composes with [title], [description], and [actions] when they are also
-  /// provided, matching [AlertDialog]: title, description, then [child], then
-  /// actions. When it is the only content, it fills the dialog container.
+  /// When [title], [description], or [actions] are also provided, this widget
+  /// is rendered after the title and description and before the actions,
+  /// following the [AlertDialog] content order. When it is the only content,
+  /// it is placed directly in the dialog container and keeps its own layout.
   final Widget? child;
 
   /// Dialog title text.
@@ -136,15 +137,16 @@ class RemixDialog extends StatelessWidget {
               description == null &&
               !hasActions;
 
-          // A lone child fills the container directly, outside the default
-          // column, so fully custom dialog bodies keep their own layout.
+          // A lone child is placed directly in the container, outside the
+          // default column, so fully custom dialog bodies keep their own
+          // layout.
           if (isLoneChild) {
             return Box(styleSpec: spec.container, child: child!);
           }
 
-          // Compose everything that was provided, in AlertDialog order.
-          // Previously a non-null child silently discarded title, description,
-          // and actions; provided content must never disappear.
+          // Compose all provided content in AlertDialog order: title,
+          // description, child, then actions. Content passed to the dialog
+          // must never be silently discarded.
           return Box(
             styleSpec: spec.container,
             child: Column(

--- a/packages/remix/test/components/dialog/dialog_widget_test.dart
+++ b/packages/remix/test/components/dialog/dialog_widget_test.dart
@@ -83,9 +83,10 @@ void main() {
     });
 
     group('Content Combinations', () {
-      // Deliberate behavior change: child used to override title/description,
-      // silently discarding them (and actions). Provided content now composes
-      // in AlertDialog order and must never disappear.
+      // These tests pin the composition contract: child composes with title,
+      // description, and actions in AlertDialog order, and provided content
+      // is never silently discarded. Earlier versions let child override the
+      // other content; do not reintroduce that behavior.
       testWidgets('child composes with title and description', (tester) async {
         final testChild = Container(
           key: ValueKey('composed_child'),

--- a/packages/remix/test/components/dialog/dialog_widget_test.dart
+++ b/packages/remix/test/components/dialog/dialog_widget_test.dart
@@ -105,6 +105,16 @@ void main() {
         expect(find.text('Custom Child'), findsOneWidget);
         expect(find.text('Dialog Title'), findsOneWidget);
         expect(find.text('Dialog description'), findsOneWidget);
+
+        // AlertDialog order: title, then description, then child.
+        expect(
+          tester.getTopLeft(find.text('Dialog Title')).dy,
+          lessThan(tester.getTopLeft(find.text('Dialog description')).dy),
+        );
+        expect(
+          tester.getTopLeft(find.text('Dialog description')).dy,
+          lessThan(tester.getTopLeft(find.text('Custom Child')).dy),
+        );
       });
 
       testWidgets('child composes with actions', (tester) async {
@@ -119,6 +129,12 @@ void main() {
         expect(find.text('Body'), findsOneWidget);
         expect(find.text('Cancel'), findsOneWidget);
         expect(find.text('Delete'), findsOneWidget);
+
+        // Child body sits above the actions row.
+        expect(
+          tester.getTopLeft(find.text('Body')).dy,
+          lessThan(tester.getTopLeft(find.text('Cancel')).dy),
+        );
       });
 
       testWidgets('a lone child fills the container directly', (tester) async {
@@ -132,6 +148,31 @@ void main() {
           reason: 'a fully custom body keeps its own layout',
         );
       });
+
+      testWidgets(
+        'child composes with title, description, and actions in order',
+        (tester) async {
+          await tester.pumpRemixApp(
+            RemixDialog(
+              title: 'Title',
+              description: 'Description',
+              child: Text('Body'),
+              actions: [TextButton(onPressed: () {}, child: Text('OK'))],
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          // AlertDialog order: title, description, child, then actions.
+          final titleY = tester.getTopLeft(find.text('Title')).dy;
+          final descY = tester.getTopLeft(find.text('Description')).dy;
+          final bodyY = tester.getTopLeft(find.text('Body')).dy;
+          final actionY = tester.getTopLeft(find.text('OK')).dy;
+
+          expect(titleY, lessThan(descY));
+          expect(descY, lessThan(bodyY));
+          expect(bodyY, lessThan(actionY));
+        },
+      );
 
       testWidgets('title and description are rendered together', (
         tester,

--- a/packages/remix/test/components/dialog/dialog_widget_test.dart
+++ b/packages/remix/test/components/dialog/dialog_widget_test.dart
@@ -83,10 +83,7 @@ void main() {
     });
 
     group('Content Combinations', () {
-      // These tests pin the composition contract: child composes with title,
-      // description, and actions in AlertDialog order, and provided content
-      // is never silently discarded. Earlier versions let child override the
-      // other content; do not reintroduce that behavior.
+      // child composes with other content; it must not override them.
       testWidgets('child composes with title and description', (tester) async {
         final testChild = Container(
           key: ValueKey('composed_child'),
@@ -107,7 +104,6 @@ void main() {
         expect(find.text('Dialog Title'), findsOneWidget);
         expect(find.text('Dialog description'), findsOneWidget);
 
-        // AlertDialog order: title, then description, then child.
         expect(
           tester.getTopLeft(find.text('Dialog Title')).dy,
           lessThan(tester.getTopLeft(find.text('Dialog description')).dy),
@@ -131,7 +127,6 @@ void main() {
         expect(find.text('Cancel'), findsOneWidget);
         expect(find.text('Delete'), findsOneWidget);
 
-        // Child body sits above the actions row.
         expect(
           tester.getTopLeft(find.text('Body')).dy,
           lessThan(tester.getTopLeft(find.text('Cancel')).dy),
@@ -163,7 +158,6 @@ void main() {
           );
           await tester.pumpAndSettle();
 
-          // AlertDialog order: title, description, child, then actions.
           final titleY = tester.getTopLeft(find.text('Title')).dy;
           final descY = tester.getTopLeft(find.text('Description')).dy;
           final bodyY = tester.getTopLeft(find.text('Body')).dy;

--- a/packages/remix/test/components/dialog/dialog_widget_test.dart
+++ b/packages/remix/test/components/dialog/dialog_widget_test.dart
@@ -83,27 +83,54 @@ void main() {
     });
 
     group('Content Combinations', () {
-      testWidgets('child takes priority over title and description', (
-        tester,
-      ) async {
+      // Deliberate behavior change: child used to override title/description,
+      // silently discarding them (and actions). Provided content now composes
+      // in AlertDialog order and must never disappear.
+      testWidgets('child composes with title and description', (tester) async {
         final testChild = Container(
-          key: ValueKey('priority_child'),
+          key: ValueKey('composed_child'),
           child: Text('Custom Child'),
         );
         await tester.pumpRemixApp(
           RemixDialog(
-            title: 'Should not show',
-            description: 'Should not show',
+            title: 'Dialog Title',
+            description: 'Dialog description',
             child: testChild,
           ),
         );
         await tester.pumpAndSettle();
 
         expect(find.byType(RemixDialog), findsOneWidget);
-        expect(find.byType(Box), findsOneWidget);
-        expect(find.byKey(ValueKey('priority_child')), findsOneWidget);
+        expect(find.byKey(ValueKey('composed_child')), findsOneWidget);
         expect(find.text('Custom Child'), findsOneWidget);
-        expect(find.text('Should not show'), findsNothing);
+        expect(find.text('Dialog Title'), findsOneWidget);
+        expect(find.text('Dialog description'), findsOneWidget);
+      });
+
+      testWidgets('child composes with actions', (tester) async {
+        await tester.pumpRemixApp(
+          RemixDialog(
+            child: Text('Body'),
+            actions: [Text('Cancel'), Text('Delete')],
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('Body'), findsOneWidget);
+        expect(find.text('Cancel'), findsOneWidget);
+        expect(find.text('Delete'), findsOneWidget);
+      });
+
+      testWidgets('a lone child fills the container directly', (tester) async {
+        await tester.pumpRemixApp(RemixDialog(child: Text('Only child')));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Only child'), findsOneWidget);
+        expect(
+          find.descendant(of: find.byType(Box), matching: find.byType(Column)),
+          findsNothing,
+          reason: 'a fully custom body keeps its own layout',
+        );
       });
 
       testWidgets('title and description are rendered together', (

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -434,10 +434,11 @@ packages:
   mix:
     dependency: "direct overridden"
     description:
-      name: mix
-      sha256: "9086fd222f2b6faeab9743dc98788c1a1083d8f8072bcd21c2c07ecd16cf876f"
-      url: "https://pub.dev"
-    source: hosted
+      path: "packages/mix"
+      ref: "feat/styler-generator"
+      resolved-ref: ee735897748eccbd1d2fdcfb0edba90192e7bebe
+      url: "https://github.com/btwld/mix.git"
+    source: git
     version: "2.0.3"
   mix_annotations:
     dependency: "direct overridden"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -434,11 +434,10 @@ packages:
   mix:
     dependency: "direct overridden"
     description:
-      path: "packages/mix"
-      ref: "feat/styler-generator"
-      resolved-ref: ee735897748eccbd1d2fdcfb0edba90192e7bebe
-      url: "https://github.com/btwld/mix.git"
-    source: git
+      name: mix
+      sha256: "9086fd222f2b6faeab9743dc98788c1a1083d8f8072bcd21c2c07ecd16cf876f"
+      url: "https://pub.dev"
+    source: hosted
     version: "2.0.3"
   mix_annotations:
     dependency: "direct overridden"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -434,29 +434,30 @@ packages:
   mix:
     dependency: "direct overridden"
     description:
-      name: mix
-      sha256: "9086fd222f2b6faeab9743dc98788c1a1083d8f8072bcd21c2c07ecd16cf876f"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.3"
+      path: "packages/mix"
+      ref: main
+      resolved-ref: "48b685b9f469e3618068160d6a1bf50df26395cc"
+      url: "https://github.com/btwld/mix.git"
+    source: git
+    version: "2.1.0"
   mix_annotations:
     dependency: "direct overridden"
     description:
       path: "packages/mix_annotations"
-      ref: "feat/styler-generator"
-      resolved-ref: ee735897748eccbd1d2fdcfb0edba90192e7bebe
+      ref: main
+      resolved-ref: "48b685b9f469e3618068160d6a1bf50df26395cc"
       url: "https://github.com/btwld/mix.git"
     source: git
-    version: "2.0.1"
+    version: "2.1.1"
   mix_generator:
     dependency: "direct overridden"
     description:
       path: "packages/mix_generator"
-      ref: "feat/styler-generator"
-      resolved-ref: ee735897748eccbd1d2fdcfb0edba90192e7bebe
+      ref: main
+      resolved-ref: "48b685b9f469e3618068160d6a1bf50df26395cc"
       url: "https://github.com/btwld/mix.git"
     source: git
-    version: "2.0.3"
+    version: "2.1.2"
   mustache_template:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,17 +12,17 @@ dependency_overrides:
   mix:
     git:
       url: https://github.com/btwld/mix.git
-      ref: feat/styler-generator
+      ref: main
       path: packages/mix
   mix_annotations:
     git:
       url: https://github.com/btwld/mix.git
-      ref: feat/styler-generator
+      ref: main
       path: packages/mix_annotations
   mix_generator:
     git:
       url: https://github.com/btwld/mix.git
-      ref: feat/styler-generator
+      ref: main
       path: packages/mix_generator
 
 dev_dependencies:


### PR DESCRIPTION
## What

`RemixDialog` silently discarded `title`, `description`, and `actions` whenever a `child` was provided:

```dart
if (child != null) {
  return Box(styleSpec: spec.container, child: child!);  // title, description, actions ignored
}
```

The constructor accepts all four together, asserts only that one of `child`/`title`/`description` is present, and derives `semanticLabel ?? title` — all of which imply `title` is meaningful alongside `child` — yet a non-null `child` dropped the rest without warning. Found via a generative-UI consumer (Muse Remix Studio) where model-produced dialogs with body content lost their headings silently.

## Deliberate semantic change

The override was documented ("overrides title and description") **and** pinned by a test, so this is a design change, not a plain bug fix. Two coherent options existed:

1. Keep override semantics but assert exclusivity (loud instead of silent).
2. Compose in `AlertDialog` order — matching the Material parity remix aims for elsewhere, and what the `actions` drop (never documented) suggests users expect.

This PR takes (2): provided content now composes as title → description → child → actions. **A lone `child` keeps the exact previous direct-fill layout**, so fully custom dialog bodies are unaffected.

## Verification

- The old `child takes priority` test now pins composition; two tests added (child+actions, lone-child fast path).
- Dialog suite on this branch: **80 pass**. Analyzer clean.
- Changelog entry added under `## Unreleased`, marked **BREAKING**.

## Related (not fixed here)

`RemixTabBar` gives its single `child` an unbounded main-axis constraint (`FlexBox` → `mainAxisSize.max`), so a horizontally scrollable tab strip overflows unless callers wrap it in `Expanded`. Suggest accepting `List<Widget> children` or wrapping in `Flexible`; happy to file separately.