### PR TITLE
feat(remix): add toggle group

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -154,6 +154,10 @@
           "href": "/components/toggle"
         },
         {
+          "title": "Toggle Group",
+          "href": "/components/toggle_group"
+        },
+        {
           "title": "Tooltip",
           "href": "/components/tooltip"
         }

--- a/docs/components/toggle_group.mdx
+++ b/docs/components/toggle_group.mdx
@@ -130,6 +130,7 @@ const RemixToggleGroupItem<T>({
   required T value,
   String? label,
   IconData? icon,
+  String? semanticLabel,
   bool enabled = true,
   FocusNode? focusNode,
   bool autofocus = false,

--- a/docs/components/toggle_group.mdx
+++ b/docs/components/toggle_group.mdx
@@ -1,0 +1,150 @@
+---
+title: Toggle Group
+description: A single-select segmented control with roving keyboard focus
+keywords: [flutter, remix, toggle group, segmented control, roving focus, keyboard]
+---
+
+A toggle group presents a compact set of mutually exclusive options. Only one
+item is in the Tab order; arrow keys move focus without changing selection.
+
+## When to use this
+
+- **View switching**: Choose list, grid, or board presentation
+- **Formatting choices**: Pick one alignment or text mode
+- **Compact filters**: Select one option from a short, visible set
+- **Toolbar controls**: Preserve focus-only arrow navigation until activation
+
+## Basic implementation
+
+<CodeGroup title="Basic implementation" defaultLanguage="dart">
+```dart
+class ViewToggle extends StatefulWidget {
+  const ViewToggle({super.key});
+
+  @override
+  State<ViewToggle> createState() => _ViewToggleState();
+}
+
+class _ViewToggleState extends State<ViewToggle> {
+  String _value = 'list';
+
+  @override
+  Widget build(BuildContext context) {
+    return FortalToggleGroup<String>(
+      items: const [
+        RemixToggleGroupItem(
+          value: 'list',
+          label: 'List',
+          icon: Icons.view_list,
+        ),
+        RemixToggleGroupItem(
+          value: 'grid',
+          label: 'Grid',
+          icon: Icons.grid_view,
+        ),
+        RemixToggleGroupItem(
+          value: 'board',
+          label: 'Board',
+          icon: Icons.view_kanban,
+        ),
+      ],
+      selectedValue: _value,
+      onChanged: (value) {
+        if (value != null) setState(() => _value = value);
+      },
+      semanticLabel: 'View style',
+    );
+  }
+}
+```
+</CodeGroup>
+
+## Keyboard behavior
+
+- `Tab` enters on the selected item, or the first enabled item when none is selected
+- A second `Tab` leaves the group instead of visiting every item
+- `Arrow Left` / `Arrow Right` move focus in horizontal groups
+- `Arrow Up` / `Arrow Down` move focus in vertical groups
+- `Home` / `End` move focus to the first / last enabled item
+- `Space` / `Enter` activate the focused item
+- Arrow movement wraps when `loop` is true and clamps when false
+- Horizontal arrow direction follows the ambient text direction in RTL layouts
+
+Arrow, Home, and End keys move focus only. Selection changes after explicit
+activation with Space, Enter, or a pointer.
+
+## Per-item styling
+
+The group's `item` style is the default for every option. An item's `style` is
+merged afterward, so one option can add a local treatment while retaining group
+states and sizing.
+
+<CodeGroup title="Per-item style" defaultLanguage="dart">
+```dart
+RemixToggleGroup<String>(
+  items: [
+    const RemixToggleGroupItem(value: 'draft', label: 'Draft'),
+    RemixToggleGroupItem(
+      value: 'published',
+      label: 'Published',
+      style: RemixToggleGroupItemStyler().foregroundColor(Colors.green),
+    ),
+  ],
+  selectedValue: value,
+  onChanged: onChanged,
+  style: RemixToggleGroupStyler().item(
+    RemixToggleGroupItemStyler()
+        .paddingX(12)
+        .paddingY(8)
+        .onSelected(
+          RemixToggleGroupItemStyler().backgroundColor(Colors.green.shade50),
+        ),
+  ),
+)
+```
+</CodeGroup>
+
+## Constructor
+
+<CodeGroup title="RemixToggleGroup" defaultLanguage="dart">
+```dart
+const RemixToggleGroup<T>({
+  Key? key,
+  required List<RemixToggleGroupItem<T>> items,
+  required T? selectedValue,
+  ValueChanged<T?>? onChanged,
+  bool enabled = true,
+  Axis orientation = Axis.horizontal,
+  bool loop = true,
+  String? semanticLabel,
+  bool excludeSemantics = false,
+  RemixToggleGroupStyler style = const RemixToggleGroupStyler.create(),
+  RemixToggleGroupSpec? styleSpec,
+})
+```
+</CodeGroup>
+
+<CodeGroup title="RemixToggleGroupItem" defaultLanguage="dart">
+```dart
+const RemixToggleGroupItem<T>({
+  required T value,
+  String? label,
+  IconData? icon,
+  bool enabled = true,
+  FocusNode? focusNode,
+  bool autofocus = false,
+  RemixToggleGroupItemStyler style =
+      const RemixToggleGroupItemStyler.create(),
+})
+```
+</CodeGroup>
+
+## Fortal widgets
+
+`FortalToggleGroup` provides `soft` and `surface` variants plus three sizes.
+The recipe uses edge-to-edge items, a bordered surface container, selected
+accent colors, a visible keyboard focus ring, and disabled state styling.
+
+<Info>
+  See the [fortalToggleGroupStyler source code](https://github.com/btwld/remix/blob/main/packages/remix/lib/src/components/toggle_group/fortal_toggle_group_styles.dart) for all available options.
+</Info>

--- a/packages/demo/lib/components/toggle_group.dart
+++ b/packages/demo/lib/components/toggle_group.dart
@@ -1,0 +1,70 @@
+import 'package:demo/helpers/use_case_state.dart';
+import 'package:flutter/material.dart';
+import 'package:remix/remix.dart';
+import 'package:widgetbook/widgetbook.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+
+final _key = GlobalKey();
+
+@widgetbook.UseCase(name: 'Toggle Group Component', type: RemixToggleGroup)
+Widget buildToggleGroupUseCase(BuildContext context) {
+  final knobState = WidgetbookState.of(context);
+  final selectedValue = context.knobs.object.dropdown<String>(
+    label: 'Selected value',
+    options: const ['list', 'grid', 'board'],
+    initialOption: 'list',
+  );
+  final orientation = context.knobs.object.dropdown<Axis>(
+    label: 'Orientation',
+    options: Axis.values,
+    initialOption: Axis.horizontal,
+    labelBuilder: (value) => value.name,
+  );
+
+  return KeyedSubtree(
+    key: _key,
+    child: Scaffold(
+      body: Center(
+        child: FortalToggleGroup<String>(
+          items: const [
+            RemixToggleGroupItem(
+              value: 'list',
+              label: 'List',
+              icon: Icons.view_list,
+            ),
+            RemixToggleGroupItem(
+              value: 'grid',
+              label: 'Grid',
+              icon: Icons.grid_view,
+            ),
+            RemixToggleGroupItem(
+              value: 'board',
+              label: 'Board',
+              icon: Icons.view_kanban,
+            ),
+          ],
+          selectedValue: selectedValue,
+          onChanged: (value) {
+            if (value != null) knobState.updateKnob('Selected value', value);
+          },
+          orientation: orientation,
+          loop: context.knobs.boolean(label: 'Loop', initialValue: true),
+          enabled: context.knobs.boolean(label: 'Enabled', initialValue: true),
+          variant: context.knobs.object.dropdown(
+            label: 'Variant',
+            options: FortalToggleGroupVariant.values,
+            initialOption: FortalToggleGroupVariant.soft,
+            labelBuilder: (value) => value.name,
+          ),
+          size: context.knobs.object.dropdown(
+            label: 'Size',
+            options: FortalToggleGroupSize.values,
+            initialOption: FortalToggleGroupSize.size2,
+            labelBuilder: (value) => value.name,
+          ),
+          semanticLabel: 'View style',
+        ),
+      ),
+    ),
+  );
+}

--- a/packages/demo/lib/main.directories.g.dart
+++ b/packages/demo/lib/main.directories.g.dart
@@ -31,6 +31,8 @@ import 'package:demo/components/switch.dart' as _demo_components_switch;
 import 'package:demo/components/tabs.dart' as _demo_components_tabs;
 import 'package:demo/components/textfield.dart' as _demo_components_textfield;
 import 'package:demo/components/toggle.dart' as _demo_components_toggle;
+import 'package:demo/components/toggle_group.dart'
+    as _demo_components_toggle_group;
 import 'package:demo/components/tooltip.dart' as _demo_components_tooltip;
 import 'package:widgetbook/widgetbook.dart' as _widgetbook;
 
@@ -215,6 +217,15 @@ final directories = <_widgetbook.WidgetbookNode>[
           _widgetbook.WidgetbookUseCase(
             name: 'Toggle Component',
             builder: _demo_components_toggle.buildToggleUseCase,
+          ),
+        ],
+      ),
+      _widgetbook.WidgetbookComponent(
+        name: 'RemixToggleGroup',
+        useCases: [
+          _widgetbook.WidgetbookUseCase(
+            name: 'Toggle Group Component',
+            builder: _demo_components_toggle_group.buildToggleGroupUseCase,
           ),
         ],
       ),

--- a/packages/remix/lib/remix.dart
+++ b/packages/remix/lib/remix.dart
@@ -22,6 +22,7 @@ export 'src/components/switch/switch.dart';
 export 'src/components/tabs/tabs.dart';
 export 'src/components/textfield/textfield.dart';
 export 'src/components/toggle/toggle.dart';
+export 'src/components/toggle_group/toggle_group.dart';
 export 'src/components/tooltip/tooltip.dart';
 
 /// EXTERNAL DEPENDENCIES

--- a/packages/remix/lib/src/components/toggle_group/fortal_toggle_group_styles.dart
+++ b/packages/remix/lib/src/components/toggle_group/fortal_toggle_group_styles.dart
@@ -1,0 +1,113 @@
+part of 'toggle_group.dart';
+
+/// Fortal toggle-group size presets.
+enum FortalToggleGroupSize { size1, size2, size3 }
+
+/// Fortal toggle-group color treatments.
+enum FortalToggleGroupVariant { soft, surface }
+
+/// Fortal-themed segmented-control preset for [RemixToggleGroup].
+@MixWidget(name: 'FortalToggleGroup')
+RemixToggleGroupStyler fortalToggleGroupStyler({
+  FortalToggleGroupVariant variant = .soft,
+  FortalToggleGroupSize size = .size2,
+}) {
+  final selectedColor = switch (variant) {
+    .soft => FortalTokens.accent3(),
+    .surface => FortalTokens.accentSurface(),
+  };
+
+  return RemixToggleGroupStyler(
+    container: FlexBoxStyler(
+      decoration: BoxDecorationMix(
+        border: BorderMix.all(
+          BorderSideMix(
+            color: FortalTokens.gray7(),
+            width: FortalTokens.borderWidth1(),
+          ),
+        ),
+        borderRadius: BorderRadiusMix.all(_fortalToggleGroupRadius(size)),
+        color: FortalTokens.colorSurface(),
+      ),
+      clipBehavior: .hardEdge,
+      mainAxisSize: .min,
+      spacing: 0,
+    ),
+    item: RemixToggleGroupItemStyler()
+        .alignment(.center)
+        .spacing(_fortalToggleGroupSpacing(size))
+        .padding(_fortalToggleGroupPadding(size))
+        .foregroundColor(FortalTokens.gray11())
+        .labelFontWeight(.w500)
+        .labelFontSize(_fortalToggleGroupFontSize(size))
+        .iconSize(_fortalToggleGroupIconSize(size))
+        .onHovered(
+          RemixToggleGroupItemStyler().backgroundColor(FortalTokens.grayA3()),
+        )
+        .onFocused(
+          RemixToggleGroupItemStyler().borderAll(
+            color: FortalTokens.focusA8(),
+            width: FortalTokens.focusRingWidth(),
+            strokeAlign: BorderSide.strokeAlignInside,
+          ),
+        )
+        .onSelected(
+          RemixToggleGroupItemStyler()
+              .backgroundColor(selectedColor)
+              .foregroundColor(FortalTokens.accent11()),
+        )
+        .onDisabled(
+          RemixToggleGroupItemStyler()
+              .backgroundColor(FortalTokens.grayA3())
+              .foregroundColor(FortalTokens.gray8()),
+        ),
+  );
+}
+
+Radius _fortalToggleGroupRadius(FortalToggleGroupSize size) {
+  return switch (size) {
+    .size1 || .size2 => FortalTokens.radius2(),
+    .size3 => FortalTokens.radius3(),
+  };
+}
+
+EdgeInsetsGeometryMix _fortalToggleGroupPadding(FortalToggleGroupSize size) {
+  return switch (size) {
+    .size1 => EdgeInsetsMix.symmetric(
+      vertical: FortalTokens.space1(),
+      horizontal: FortalTokens.space2(),
+    ),
+    .size2 => EdgeInsetsMix.symmetric(
+      vertical: FortalTokens.space2(),
+      horizontal: FortalTokens.space3(),
+    ),
+    .size3 => EdgeInsetsMix.symmetric(
+      vertical: FortalTokens.space2(),
+      horizontal: FortalTokens.space4(),
+    ),
+  };
+}
+
+double _fortalToggleGroupSpacing(FortalToggleGroupSize size) {
+  return switch (size) {
+    .size1 => 2,
+    .size2 => 4,
+    .size3 => 6,
+  };
+}
+
+double _fortalToggleGroupFontSize(FortalToggleGroupSize size) {
+  return switch (size) {
+    .size1 => 12,
+    .size2 => 14,
+    .size3 => 16,
+  };
+}
+
+double _fortalToggleGroupIconSize(FortalToggleGroupSize size) {
+  return switch (size) {
+    .size1 => 12,
+    .size2 => 16,
+    .size3 => 20,
+  };
+}

--- a/packages/remix/lib/src/components/toggle_group/toggle_group.dart
+++ b/packages/remix/lib/src/components/toggle_group/toggle_group.dart
@@ -1,0 +1,19 @@
+library remix_toggle_group;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:mix/mix.dart';
+import 'package:mix_annotations/mix_annotations.dart';
+import 'package:naked_ui/naked_ui.dart';
+
+import '../../fortal/fortal.dart';
+import '../../style/style.dart';
+import '../../utilities/remix_style.dart';
+import '../../utilities/selected_mixin.dart';
+
+part 'toggle_group_spec.dart';
+part 'toggle_group_style.dart';
+part 'toggle_group_widget.dart';
+part 'fortal_toggle_group_styles.dart';
+part 'toggle_group.g.dart';

--- a/packages/remix/lib/src/components/toggle_group/toggle_group.g.dart
+++ b/packages/remix/lib/src/components/toggle_group/toggle_group.g.dart
@@ -1,0 +1,435 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'toggle_group.dart';
+
+// **************************************************************************
+// SpecGenerator
+// **************************************************************************
+
+mixin _$RemixToggleGroupSpec
+    implements Spec<RemixToggleGroupSpec>, Diagnosticable {
+  StyleSpec<FlexBoxSpec> get container;
+  StyleSpec<RemixToggleGroupItemSpec> get item;
+
+  @override
+  Type get type => RemixToggleGroupSpec;
+
+  @override
+  RemixToggleGroupSpec copyWith({
+    StyleSpec<FlexBoxSpec>? container,
+    StyleSpec<RemixToggleGroupItemSpec>? item,
+  }) {
+    return RemixToggleGroupSpec(
+      container: container ?? this.container,
+      item: item ?? this.item,
+    );
+  }
+
+  @override
+  RemixToggleGroupSpec lerp(RemixToggleGroupSpec? other, double t) {
+    return RemixToggleGroupSpec(
+      container: container.lerp(other?.container, t),
+      item: item.lerp(other?.item, t),
+    );
+  }
+
+  @override
+  List<Object?> get props => [container, item];
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        other is RemixToggleGroupSpec &&
+            runtimeType == other.runtimeType &&
+            propsEquals(props, other.props);
+  }
+
+  @override
+  int get hashCode => propsHash(runtimeType, props);
+
+  @override
+  bool get stringify => true;
+
+  @override
+  Map<String, String> getDiff(Equatable other) {
+    if (this == other) return const {};
+
+    return propsDiff(props, other.props);
+  }
+
+  @override
+  String toStringShort() => '$runtimeType';
+
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) =>
+      toDiagnosticsNode(
+        style: DiagnosticsTreeStyle.singleLine,
+      ).toString(minLevel: minLevel);
+
+  @override
+  DiagnosticsNode toDiagnosticsNode({
+    String? name,
+    DiagnosticsTreeStyle? style,
+  }) =>
+      DiagnosticableNode<Diagnosticable>(name: name, value: this, style: style);
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    properties
+      ..add(DiagnosticsProperty('container', container))
+      ..add(DiagnosticsProperty('item', item));
+  }
+}
+
+@Deprecated(
+  'Rename to `_\$RemixToggleGroupSpec` and migrate the class declaration to `class RemixToggleGroupSpec with _\$RemixToggleGroupSpec`. The `_\$RemixToggleGroupSpecMethods` alias will be removed in mix_generator 3.0.',
+)
+typedef _$RemixToggleGroupSpecMethods = _$RemixToggleGroupSpec; // ignore: unused_element
+
+mixin _$RemixToggleGroupItemSpec
+    implements Spec<RemixToggleGroupItemSpec>, Diagnosticable {
+  StyleSpec<FlexBoxSpec> get container;
+  StyleSpec<TextSpec> get label;
+  StyleSpec<IconSpec> get icon;
+
+  @override
+  Type get type => RemixToggleGroupItemSpec;
+
+  @override
+  RemixToggleGroupItemSpec copyWith({
+    StyleSpec<FlexBoxSpec>? container,
+    StyleSpec<TextSpec>? label,
+    StyleSpec<IconSpec>? icon,
+  }) {
+    return RemixToggleGroupItemSpec(
+      container: container ?? this.container,
+      label: label ?? this.label,
+      icon: icon ?? this.icon,
+    );
+  }
+
+  @override
+  RemixToggleGroupItemSpec lerp(RemixToggleGroupItemSpec? other, double t) {
+    return RemixToggleGroupItemSpec(
+      container: container.lerp(other?.container, t),
+      label: label.lerp(other?.label, t),
+      icon: icon.lerp(other?.icon, t),
+    );
+  }
+
+  @override
+  List<Object?> get props => [container, label, icon];
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        other is RemixToggleGroupItemSpec &&
+            runtimeType == other.runtimeType &&
+            propsEquals(props, other.props);
+  }
+
+  @override
+  int get hashCode => propsHash(runtimeType, props);
+
+  @override
+  bool get stringify => true;
+
+  @override
+  Map<String, String> getDiff(Equatable other) {
+    if (this == other) return const {};
+
+    return propsDiff(props, other.props);
+  }
+
+  @override
+  String toStringShort() => '$runtimeType';
+
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) =>
+      toDiagnosticsNode(
+        style: DiagnosticsTreeStyle.singleLine,
+      ).toString(minLevel: minLevel);
+
+  @override
+  DiagnosticsNode toDiagnosticsNode({
+    String? name,
+    DiagnosticsTreeStyle? style,
+  }) =>
+      DiagnosticableNode<Diagnosticable>(name: name, value: this, style: style);
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    properties
+      ..add(DiagnosticsProperty('container', container))
+      ..add(DiagnosticsProperty('label', label))
+      ..add(DiagnosticsProperty('icon', icon));
+  }
+}
+
+@Deprecated(
+  'Rename to `_\$RemixToggleGroupItemSpec` and migrate the class declaration to `class RemixToggleGroupItemSpec with _\$RemixToggleGroupItemSpec`. The `_\$RemixToggleGroupItemSpecMethods` alias will be removed in mix_generator 3.0.',
+)
+typedef _$RemixToggleGroupItemSpecMethods = _$RemixToggleGroupItemSpec; // ignore: unused_element
+
+// **************************************************************************
+// MixWidgetGenerator
+// **************************************************************************
+
+/// Fortal-themed segmented-control preset for [RemixToggleGroup].
+class FortalToggleGroup<T> extends StatelessWidget {
+  const FortalToggleGroup({
+    super.key,
+    this.variant = .soft,
+    this.size = .size2,
+    required this.items,
+    required this.selectedValue,
+    this.onChanged,
+    this.enabled = true,
+    this.orientation = .horizontal,
+    this.loop = true,
+    this.semanticLabel,
+    this.excludeSemantics = false,
+  });
+
+  const FortalToggleGroup.soft({
+    super.key,
+    this.size = .size2,
+    required this.items,
+    required this.selectedValue,
+    this.onChanged,
+    this.enabled = true,
+    this.orientation = .horizontal,
+    this.loop = true,
+    this.semanticLabel,
+    this.excludeSemantics = false,
+  }) : variant = FortalToggleGroupVariant.soft;
+
+  const FortalToggleGroup.surface({
+    super.key,
+    this.size = .size2,
+    required this.items,
+    required this.selectedValue,
+    this.onChanged,
+    this.enabled = true,
+    this.orientation = .horizontal,
+    this.loop = true,
+    this.semanticLabel,
+    this.excludeSemantics = false,
+  }) : variant = FortalToggleGroupVariant.surface;
+
+  final FortalToggleGroupVariant variant;
+
+  final FortalToggleGroupSize size;
+
+  final List<RemixToggleGroupItem<T>> items;
+
+  final T? selectedValue;
+
+  final ValueChanged<T?>? onChanged;
+
+  final bool enabled;
+
+  final Axis orientation;
+
+  final bool loop;
+
+  final String? semanticLabel;
+
+  final bool excludeSemantics;
+
+  @override
+  Widget build(BuildContext context) {
+    return fortalToggleGroupStyler(
+      variant: this.variant,
+      size: this.size,
+    ).call<T>(
+      key: this.key,
+      items: this.items,
+      selectedValue: this.selectedValue,
+      onChanged: this.onChanged,
+      enabled: this.enabled,
+      orientation: this.orientation,
+      loop: this.loop,
+      semanticLabel: this.semanticLabel,
+      excludeSemantics: this.excludeSemantics,
+    );
+  }
+}
+
+// **************************************************************************
+// StylerGenerator
+// **************************************************************************
+
+mixin _$RemixToggleGroupStylerMixin
+    on Style<RemixToggleGroupSpec>, Diagnosticable {
+  Prop<StyleSpec<FlexBoxSpec>>? get $container;
+  Prop<StyleSpec<RemixToggleGroupItemSpec>>? get $item;
+
+  /// Sets the container.
+  RemixToggleGroupStyler container(FlexBoxStyler value) {
+    return merge(RemixToggleGroupStyler(container: value));
+  }
+
+  /// Sets the item.
+  RemixToggleGroupStyler item(RemixToggleGroupItemStyler value) {
+    return merge(RemixToggleGroupStyler(item: value));
+  }
+
+  /// Sets the animation configuration.
+  RemixToggleGroupStyler animate(AnimationConfig value) {
+    return merge(RemixToggleGroupStyler(animation: value));
+  }
+
+  /// Sets the style variants.
+  RemixToggleGroupStyler variants(
+    List<VariantStyle<RemixToggleGroupSpec>> value,
+  ) {
+    return merge(RemixToggleGroupStyler(variants: value));
+  }
+
+  /// Wraps with a widget modifier.
+  RemixToggleGroupStyler wrap(WidgetModifierConfig value) {
+    return merge(RemixToggleGroupStyler(modifier: value));
+  }
+
+  /// Sets the widget modifier.
+  RemixToggleGroupStyler modifier(WidgetModifierConfig value) {
+    return merge(RemixToggleGroupStyler(modifier: value));
+  }
+
+  /// Merges with another [RemixToggleGroupStyler].
+  @override
+  RemixToggleGroupStyler merge(RemixToggleGroupStyler? other) {
+    return RemixToggleGroupStyler.create(
+      container: MixOps.merge($container, other?.$container),
+      item: MixOps.merge($item, other?.$item),
+      variants: MixOps.mergeVariants($variants, other?.$variants),
+      modifier: MixOps.mergeModifier($modifier, other?.$modifier),
+      animation: MixOps.mergeAnimation($animation, other?.$animation),
+    );
+  }
+
+  /// Resolves to [StyleSpec<RemixToggleGroupSpec>] using [context].
+  @override
+  StyleSpec<RemixToggleGroupSpec> resolve(BuildContext context) {
+    final spec = RemixToggleGroupSpec(
+      container: MixOps.resolve(context, $container),
+      item: MixOps.resolve(context, $item),
+    );
+
+    return StyleSpec(
+      spec: spec,
+      animation: $animation,
+      widgetModifiers: $modifier?.resolve(context),
+    );
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties
+      ..add(DiagnosticsProperty('container', $container))
+      ..add(DiagnosticsProperty('item', $item));
+  }
+
+  @override
+  List<Object?> get props => [
+    $container,
+    $item,
+    $animation,
+    $modifier,
+    $variants,
+  ];
+}
+
+mixin _$RemixToggleGroupItemStylerMixin
+    on Style<RemixToggleGroupItemSpec>, Diagnosticable {
+  Prop<StyleSpec<FlexBoxSpec>>? get $container;
+  Prop<StyleSpec<TextSpec>>? get $label;
+  Prop<StyleSpec<IconSpec>>? get $icon;
+
+  /// Sets the container.
+  RemixToggleGroupItemStyler container(FlexBoxStyler value) {
+    return merge(RemixToggleGroupItemStyler(container: value));
+  }
+
+  /// Sets the label.
+  RemixToggleGroupItemStyler label(TextStyler value) {
+    return merge(RemixToggleGroupItemStyler(label: value));
+  }
+
+  /// Sets the icon.
+  RemixToggleGroupItemStyler icon(IconStyler value) {
+    return merge(RemixToggleGroupItemStyler(icon: value));
+  }
+
+  /// Sets the animation configuration.
+  RemixToggleGroupItemStyler animate(AnimationConfig value) {
+    return merge(RemixToggleGroupItemStyler(animation: value));
+  }
+
+  /// Sets the style variants.
+  RemixToggleGroupItemStyler variants(
+    List<VariantStyle<RemixToggleGroupItemSpec>> value,
+  ) {
+    return merge(RemixToggleGroupItemStyler(variants: value));
+  }
+
+  /// Wraps with a widget modifier.
+  RemixToggleGroupItemStyler wrap(WidgetModifierConfig value) {
+    return merge(RemixToggleGroupItemStyler(modifier: value));
+  }
+
+  /// Sets the widget modifier.
+  RemixToggleGroupItemStyler modifier(WidgetModifierConfig value) {
+    return merge(RemixToggleGroupItemStyler(modifier: value));
+  }
+
+  /// Merges with another [RemixToggleGroupItemStyler].
+  @override
+  RemixToggleGroupItemStyler merge(RemixToggleGroupItemStyler? other) {
+    return RemixToggleGroupItemStyler.create(
+      container: MixOps.merge($container, other?.$container),
+      label: MixOps.merge($label, other?.$label),
+      icon: MixOps.merge($icon, other?.$icon),
+      variants: MixOps.mergeVariants($variants, other?.$variants),
+      modifier: MixOps.mergeModifier($modifier, other?.$modifier),
+      animation: MixOps.mergeAnimation($animation, other?.$animation),
+    );
+  }
+
+  /// Resolves to [StyleSpec<RemixToggleGroupItemSpec>] using [context].
+  @override
+  StyleSpec<RemixToggleGroupItemSpec> resolve(BuildContext context) {
+    final spec = RemixToggleGroupItemSpec(
+      container: MixOps.resolve(context, $container),
+      label: MixOps.resolve(context, $label),
+      icon: MixOps.resolve(context, $icon),
+    );
+
+    return StyleSpec(
+      spec: spec,
+      animation: $animation,
+      widgetModifiers: $modifier?.resolve(context),
+    );
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties
+      ..add(DiagnosticsProperty('container', $container))
+      ..add(DiagnosticsProperty('label', $label))
+      ..add(DiagnosticsProperty('icon', $icon));
+  }
+
+  @override
+  List<Object?> get props => [
+    $container,
+    $label,
+    $icon,
+    $animation,
+    $modifier,
+    $variants,
+  ];
+}

--- a/packages/remix/lib/src/components/toggle_group/toggle_group_spec.dart
+++ b/packages/remix/lib/src/components/toggle_group/toggle_group_spec.dart
@@ -1,0 +1,43 @@
+part of 'toggle_group.dart';
+
+/// Resolved visual properties for a [RemixToggleGroup].
+@MixableSpec()
+class RemixToggleGroupSpec with _$RemixToggleGroupSpec {
+  /// Layout and decoration for the group container.
+  @override
+  final StyleSpec<FlexBoxSpec> container;
+
+  /// Default visual style for every option in the group.
+  @override
+  final StyleSpec<RemixToggleGroupItemSpec> item;
+
+  const RemixToggleGroupSpec({
+    StyleSpec<FlexBoxSpec>? container,
+    StyleSpec<RemixToggleGroupItemSpec>? item,
+  }) : container = container ?? const StyleSpec(spec: FlexBoxSpec()),
+       item = item ?? const StyleSpec(spec: RemixToggleGroupItemSpec());
+}
+
+/// Resolved visual properties for an item in a [RemixToggleGroup].
+@MixableSpec()
+class RemixToggleGroupItemSpec with _$RemixToggleGroupItemSpec {
+  /// Layout and decoration for the item content.
+  @override
+  final StyleSpec<FlexBoxSpec> container;
+
+  /// Text style for the optional label.
+  @override
+  final StyleSpec<TextSpec> label;
+
+  /// Icon style for the optional icon.
+  @override
+  final StyleSpec<IconSpec> icon;
+
+  const RemixToggleGroupItemSpec({
+    StyleSpec<FlexBoxSpec>? container,
+    StyleSpec<TextSpec>? label,
+    StyleSpec<IconSpec>? icon,
+  }) : container = container ?? const StyleSpec(spec: FlexBoxSpec()),
+       label = label ?? const StyleSpec(spec: TextSpec()),
+       icon = icon ?? const StyleSpec(spec: IconSpec());
+}

--- a/packages/remix/lib/src/components/toggle_group/toggle_group_style.dart
+++ b/packages/remix/lib/src/components/toggle_group/toggle_group_style.dart
@@ -1,0 +1,339 @@
+part of 'toggle_group.dart';
+
+/// Style configuration for a [RemixToggleGroup] container and its items.
+@MixableStyler()
+class RemixToggleGroupStyler
+    extends
+        RemixFlexContainerStyler<RemixToggleGroupSpec, RemixToggleGroupStyler>
+    with Diagnosticable, _$RemixToggleGroupStylerMixin {
+  @MixableField(setterType: FlexBoxStyler)
+  final Prop<StyleSpec<FlexBoxSpec>>? $container;
+
+  @MixableField(setterType: RemixToggleGroupItemStyler)
+  final Prop<StyleSpec<RemixToggleGroupItemSpec>>? $item;
+
+  const RemixToggleGroupStyler.create({
+    Prop<StyleSpec<FlexBoxSpec>>? container,
+    Prop<StyleSpec<RemixToggleGroupItemSpec>>? item,
+    super.variants,
+    super.animation,
+    super.modifier,
+  }) : $container = container,
+       $item = item;
+
+  RemixToggleGroupStyler({
+    FlexBoxStyler? container,
+    RemixToggleGroupItemStyler? item,
+    AnimationConfig? animation,
+    List<VariantStyle<RemixToggleGroupSpec>>? variants,
+    WidgetModifierConfig? modifier,
+  }) : this.create(
+         container: Prop.maybeMix(container),
+         item: Prop.maybeMix(item),
+         variants: variants,
+         animation: animation,
+         modifier: modifier,
+       );
+
+  /// Sets the group background color.
+  RemixToggleGroupStyler backgroundColor(Color value) => color(value);
+
+  /// Creates a [RemixToggleGroup] with this style applied.
+  RemixToggleGroup<T> call<T>({
+    Key? key,
+    required List<RemixToggleGroupItem<T>> items,
+    required T? selectedValue,
+    ValueChanged<T?>? onChanged,
+    bool enabled = true,
+    Axis orientation = .horizontal,
+    bool loop = true,
+    String? semanticLabel,
+    bool excludeSemantics = false,
+  }) {
+    return RemixToggleGroup(
+      key: key,
+      items: items,
+      selectedValue: selectedValue,
+      onChanged: onChanged,
+      enabled: enabled,
+      orientation: orientation,
+      loop: loop,
+      semanticLabel: semanticLabel,
+      excludeSemantics: excludeSemantics,
+      style: this,
+    );
+  }
+
+  @override
+  RemixToggleGroupStyler alignment(Alignment value) {
+    return merge(
+      RemixToggleGroupStyler(container: FlexBoxStyler(alignment: value)),
+    );
+  }
+
+  @override
+  RemixToggleGroupStyler padding(EdgeInsetsGeometryMix value) {
+    return merge(
+      RemixToggleGroupStyler(container: FlexBoxStyler(padding: value)),
+    );
+  }
+
+  @override
+  RemixToggleGroupStyler color(Color value) {
+    return merge(
+      RemixToggleGroupStyler(
+        container: FlexBoxStyler(decoration: BoxDecorationMix(color: value)),
+      ),
+    );
+  }
+
+  @override
+  RemixToggleGroupStyler size(double width, double height) {
+    return merge(
+      RemixToggleGroupStyler(
+        container: FlexBoxStyler(
+          constraints: BoxConstraintsMix(
+            minWidth: width,
+            maxWidth: width,
+            minHeight: height,
+            maxHeight: height,
+          ),
+        ),
+      ),
+    );
+  }
+
+  @override
+  RemixToggleGroupStyler borderRadius(BorderRadiusGeometryMix radius) {
+    return merge(
+      RemixToggleGroupStyler(
+        container: FlexBoxStyler(
+          decoration: BoxDecorationMix(borderRadius: radius),
+        ),
+      ),
+    );
+  }
+
+  @override
+  RemixToggleGroupStyler constraints(BoxConstraintsMix value) {
+    return merge(
+      RemixToggleGroupStyler(container: FlexBoxStyler(constraints: value)),
+    );
+  }
+
+  @override
+  RemixToggleGroupStyler decoration(DecorationMix value) {
+    return merge(
+      RemixToggleGroupStyler(container: FlexBoxStyler(decoration: value)),
+    );
+  }
+
+  @override
+  RemixToggleGroupStyler margin(EdgeInsetsGeometryMix value) {
+    return merge(
+      RemixToggleGroupStyler(container: FlexBoxStyler(margin: value)),
+    );
+  }
+
+  @override
+  RemixToggleGroupStyler foregroundDecoration(DecorationMix value) {
+    return merge(
+      RemixToggleGroupStyler(
+        container: FlexBoxStyler(foregroundDecoration: value),
+      ),
+    );
+  }
+
+  @override
+  RemixToggleGroupStyler transform(
+    Matrix4 value, {
+    AlignmentGeometry alignment = Alignment.center,
+  }) {
+    return merge(
+      RemixToggleGroupStyler(
+        container: FlexBoxStyler(
+          transform: value,
+          transformAlignment: alignment,
+        ),
+      ),
+    );
+  }
+
+  @override
+  RemixToggleGroupStyler flex(FlexStyler value) {
+    return merge(
+      RemixToggleGroupStyler(container: FlexBoxStyler().flex(value)),
+    );
+  }
+}
+
+/// Style configuration for an option in a [RemixToggleGroup].
+@MixableStyler()
+class RemixToggleGroupItemStyler
+    extends
+        RemixFlexContainerStyler<
+          RemixToggleGroupItemSpec,
+          RemixToggleGroupItemStyler
+        >
+    with
+        LabelStyleMixin<RemixToggleGroupItemStyler>,
+        IconStyleMixin<RemixToggleGroupItemStyler>,
+        SelectedWidgetStateVariantMixin<
+          RemixToggleGroupItemSpec,
+          RemixToggleGroupItemStyler
+        >,
+        Diagnosticable,
+        _$RemixToggleGroupItemStylerMixin {
+  @MixableField(setterType: FlexBoxStyler)
+  final Prop<StyleSpec<FlexBoxSpec>>? $container;
+
+  @MixableField(setterType: TextStyler)
+  final Prop<StyleSpec<TextSpec>>? $label;
+
+  @MixableField(setterType: IconStyler)
+  final Prop<StyleSpec<IconSpec>>? $icon;
+
+  const RemixToggleGroupItemStyler.create({
+    Prop<StyleSpec<FlexBoxSpec>>? container,
+    Prop<StyleSpec<TextSpec>>? label,
+    Prop<StyleSpec<IconSpec>>? icon,
+    super.variants,
+    super.animation,
+    super.modifier,
+  }) : $container = container,
+       $label = label,
+       $icon = icon;
+
+  RemixToggleGroupItemStyler({
+    FlexBoxStyler? container,
+    TextStyler? label,
+    IconStyler? icon,
+    AnimationConfig? animation,
+    List<VariantStyle<RemixToggleGroupItemSpec>>? variants,
+    WidgetModifierConfig? modifier,
+  }) : this.create(
+         container: Prop.maybeMix(container),
+         label: Prop.maybeMix(label),
+         icon: Prop.maybeMix(icon),
+         variants: variants,
+         animation: animation,
+         modifier: modifier,
+       );
+
+  /// Sets the item background color.
+  RemixToggleGroupItemStyler backgroundColor(Color value) {
+    return merge(
+      RemixToggleGroupItemStyler(
+        container: FlexBoxStyler(decoration: BoxDecorationMix(color: value)),
+      ),
+    );
+  }
+
+  /// Sets the item foreground color for both label and icon.
+  RemixToggleGroupItemStyler foregroundColor(Color value) {
+    return labelColor(value).iconColor(value);
+  }
+
+  /// Sets spacing between the optional icon and label.
+  RemixToggleGroupItemStyler spacing(double value) {
+    return merge(
+      RemixToggleGroupItemStyler(container: FlexBoxStyler(spacing: value)),
+    );
+  }
+
+  @override
+  RemixToggleGroupItemStyler alignment(Alignment value) {
+    return merge(
+      RemixToggleGroupItemStyler(container: FlexBoxStyler(alignment: value)),
+    );
+  }
+
+  @override
+  RemixToggleGroupItemStyler padding(EdgeInsetsGeometryMix value) {
+    return merge(
+      RemixToggleGroupItemStyler(container: FlexBoxStyler(padding: value)),
+    );
+  }
+
+  @override
+  RemixToggleGroupItemStyler color(Color value) => backgroundColor(value);
+
+  @override
+  RemixToggleGroupItemStyler size(double width, double height) {
+    return merge(
+      RemixToggleGroupItemStyler(
+        container: FlexBoxStyler(
+          constraints: BoxConstraintsMix(
+            minWidth: width,
+            maxWidth: width,
+            minHeight: height,
+            maxHeight: height,
+          ),
+        ),
+      ),
+    );
+  }
+
+  @override
+  RemixToggleGroupItemStyler borderRadius(BorderRadiusGeometryMix radius) {
+    return merge(
+      RemixToggleGroupItemStyler(
+        container: FlexBoxStyler(
+          decoration: BoxDecorationMix(borderRadius: radius),
+        ),
+      ),
+    );
+  }
+
+  @override
+  RemixToggleGroupItemStyler constraints(BoxConstraintsMix value) {
+    return merge(
+      RemixToggleGroupItemStyler(container: FlexBoxStyler(constraints: value)),
+    );
+  }
+
+  @override
+  RemixToggleGroupItemStyler decoration(DecorationMix value) {
+    return merge(
+      RemixToggleGroupItemStyler(container: FlexBoxStyler(decoration: value)),
+    );
+  }
+
+  @override
+  RemixToggleGroupItemStyler margin(EdgeInsetsGeometryMix value) {
+    return merge(
+      RemixToggleGroupItemStyler(container: FlexBoxStyler(margin: value)),
+    );
+  }
+
+  @override
+  RemixToggleGroupItemStyler foregroundDecoration(DecorationMix value) {
+    return merge(
+      RemixToggleGroupItemStyler(
+        container: FlexBoxStyler(foregroundDecoration: value),
+      ),
+    );
+  }
+
+  @override
+  RemixToggleGroupItemStyler transform(
+    Matrix4 value, {
+    AlignmentGeometry alignment = Alignment.center,
+  }) {
+    return merge(
+      RemixToggleGroupItemStyler(
+        container: FlexBoxStyler(
+          transform: value,
+          transformAlignment: alignment,
+        ),
+      ),
+    );
+  }
+
+  @override
+  RemixToggleGroupItemStyler flex(FlexStyler value) {
+    return merge(
+      RemixToggleGroupItemStyler(container: FlexBoxStyler().flex(value)),
+    );
+  }
+}

--- a/packages/remix/lib/src/components/toggle_group/toggle_group_widget.dart
+++ b/packages/remix/lib/src/components/toggle_group/toggle_group_widget.dart
@@ -11,6 +11,11 @@ class RemixToggleGroupItem<T> {
   /// Optional icon shown before [label].
   final IconData? icon;
 
+  /// Accessibility label for this item.
+  ///
+  /// Falls back to [label] when omitted.
+  final String? semanticLabel;
+
   /// Whether the item can receive focus and be activated.
   final bool enabled;
 
@@ -27,6 +32,7 @@ class RemixToggleGroupItem<T> {
     required this.value,
     this.label,
     this.icon,
+    this.semanticLabel,
     this.enabled = true,
     this.focusNode,
     this.autofocus = false,
@@ -85,6 +91,16 @@ class RemixToggleGroup<T> extends StatelessWidget {
 
   static final styleFrom = RemixToggleGroupStyler.new;
 
+  StyleSpec<FlexBoxSpec> _withOrientation(StyleSpec<FlexBoxSpec> container) {
+    final flex = container.spec.flex ?? const StyleSpec(spec: FlexSpec());
+
+    return container.copyWith(
+      spec: container.spec.copyWith(
+        flex: flex.copyWith(spec: flex.spec.copyWith(direction: orientation)),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final effectiveStyle = RemixToggleGroupStyler(
@@ -93,6 +109,13 @@ class RemixToggleGroup<T> extends StatelessWidget {
         mainAxisSize: .min,
       ).wrap(.intrinsicWidth().intrinsicHeight()),
     ).merge(style);
+    // Resolve group-level context variants now, while retaining nested item
+    // variants for resolution inside each option's WidgetStateProvider.
+    final activeStyle =
+        // Mix does not expose another way to retain nested item variants.
+        // ignore: invalid_use_of_visible_for_testing_member
+        effectiveStyle.mergeActiveVariants(context, namedVariants: const {})
+            as RemixToggleGroupStyler;
 
     return NakedToggleGroup<T>(
       selectedValue: selectedValue,
@@ -107,13 +130,13 @@ class RemixToggleGroup<T> extends StatelessWidget {
         styleSpec: styleSpec,
         builder: (context, spec) {
           return FlexBox(
-            styleSpec: spec.container,
+            styleSpec: _withOrientation(spec.container),
             children: [
               for (final item in items)
                 _RemixToggleGroupItemWidget(
                   key: ValueKey(item.value),
                   data: item,
-                  defaultStyle: styleSpec == null ? effectiveStyle.$item : null,
+                  defaultStyle: styleSpec == null ? activeStyle.$item : null,
                   defaultStyleSpec: styleSpec == null ? null : spec.item,
                 ),
             ],
@@ -172,7 +195,7 @@ class _RemixToggleGroupItemWidget<T> extends StatelessWidget {
       enabled: data.enabled,
       focusNode: data.focusNode,
       autofocus: data.autofocus,
-      semanticLabel: data.label,
+      semanticLabel: data.semanticLabel ?? data.label,
       builder: (context, state, _) {
         return WidgetStateProvider(
           states: state.states,

--- a/packages/remix/lib/src/components/toggle_group/toggle_group_widget.dart
+++ b/packages/remix/lib/src/components/toggle_group/toggle_group_widget.dart
@@ -105,6 +105,11 @@ class RemixToggleGroup<T> extends StatelessWidget {
 
   static final styleFrom = RemixToggleGroupStyler.new;
 
+  /// Forces the flex [direction] onto a resolved container so the [orientation]
+  /// argument wins over any direction coming from [style] or a raw [styleSpec].
+  ///
+  /// Applied after resolution because the raw [styleSpec] path bypasses styler
+  /// merging entirely, so this is the single point that covers both paths.
   StyleSpec<FlexBoxSpec> _withOrientation(StyleSpec<FlexBoxSpec> container) {
     final flex = container.spec.flex ?? const StyleSpec(spec: FlexSpec());
 
@@ -117,9 +122,11 @@ class RemixToggleGroup<T> extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // Direction is enforced once, post-resolution, by _withOrientation (which
+    // must also cover the raw styleSpec path), so it is intentionally not set
+    // on this base styler.
     final effectiveStyle = RemixToggleGroupStyler(
       container: FlexBoxStyler(
-        direction: orientation,
         mainAxisSize: .min,
       ).wrap(.intrinsicWidth().intrinsicHeight()),
     ).merge(style);

--- a/packages/remix/lib/src/components/toggle_group/toggle_group_widget.dart
+++ b/packages/remix/lib/src/components/toggle_group/toggle_group_widget.dart
@@ -1,0 +1,201 @@
+part of 'toggle_group.dart';
+
+/// Declarative data for one option in a [RemixToggleGroup].
+class RemixToggleGroupItem<T> {
+  /// The value selected when this item is activated.
+  final T value;
+
+  /// Optional text shown in the item.
+  final String? label;
+
+  /// Optional icon shown before [label].
+  final IconData? icon;
+
+  /// Whether the item can receive focus and be activated.
+  final bool enabled;
+
+  /// Optional caller-owned focus node.
+  final FocusNode? focusNode;
+
+  /// Whether this item requests initial focus when the group mounts.
+  final bool autofocus;
+
+  /// Per-item style merged after the group's default item style.
+  final RemixToggleGroupItemStyler style;
+
+  const RemixToggleGroupItem({
+    required this.value,
+    this.label,
+    this.icon,
+    this.enabled = true,
+    this.focusNode,
+    this.autofocus = false,
+    this.style = const RemixToggleGroupItemStyler.create(),
+  }) : assert(
+         label != null || icon != null,
+         'At least one of label or icon must be provided',
+       );
+}
+
+/// A styled, single-select toggle group with roving keyboard focus.
+class RemixToggleGroup<T> extends StatelessWidget {
+  const RemixToggleGroup({
+    super.key,
+    required this.items,
+    required this.selectedValue,
+    this.onChanged,
+    this.enabled = true,
+    this.orientation = .horizontal,
+    this.loop = true,
+    this.semanticLabel,
+    this.excludeSemantics = false,
+    this.style = const RemixToggleGroupStyler.create(),
+    this.styleSpec,
+  });
+
+  /// Items rendered in visual and focus-traversal order.
+  final List<RemixToggleGroupItem<T>> items;
+
+  /// The currently selected item value.
+  final T? selectedValue;
+
+  /// Called when an item is activated with a different value.
+  final ValueChanged<T?>? onChanged;
+
+  /// Whether the whole group is interactive.
+  final bool enabled;
+
+  /// Axis used for layout and arrow-key navigation.
+  final Axis orientation;
+
+  /// Whether arrow navigation wraps at the ends.
+  final bool loop;
+
+  /// Accessibility label for the group.
+  final String? semanticLabel;
+
+  /// Whether the group and all items are hidden from semantics.
+  final bool excludeSemantics;
+
+  /// Fluent visual style for the group and its default item style.
+  final RemixToggleGroupStyler style;
+
+  /// Optional raw style spec that bypasses fluent group style resolution.
+  final RemixToggleGroupSpec? styleSpec;
+
+  static final styleFrom = RemixToggleGroupStyler.new;
+
+  @override
+  Widget build(BuildContext context) {
+    final effectiveStyle = RemixToggleGroupStyler(
+      container: FlexBoxStyler(
+        direction: orientation,
+        mainAxisSize: .min,
+      ).wrap(.intrinsicWidth().intrinsicHeight()),
+    ).merge(style);
+
+    return NakedToggleGroup<T>(
+      selectedValue: selectedValue,
+      onChanged: onChanged,
+      enabled: enabled,
+      orientation: orientation,
+      loop: loop,
+      semanticLabel: semanticLabel,
+      excludeSemantics: excludeSemantics,
+      child: RemixStyleSpecBuilder<RemixToggleGroupSpec>(
+        style: effectiveStyle,
+        styleSpec: styleSpec,
+        builder: (context, spec) {
+          return FlexBox(
+            styleSpec: spec.container,
+            children: [
+              for (final item in items)
+                _RemixToggleGroupItemWidget(
+                  key: ValueKey(item.value),
+                  data: item,
+                  defaultStyle: styleSpec == null ? effectiveStyle.$item : null,
+                  defaultStyleSpec: styleSpec == null ? null : spec.item,
+                ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _RemixToggleGroupItemWidget<T> extends StatelessWidget {
+  const _RemixToggleGroupItemWidget({
+    super.key,
+    required this.data,
+    this.defaultStyle,
+    this.defaultStyleSpec,
+  });
+
+  final RemixToggleGroupItem<T> data;
+  final Prop<StyleSpec<RemixToggleGroupItemSpec>>? defaultStyle;
+  final StyleSpec<RemixToggleGroupItemSpec>? defaultStyleSpec;
+
+  StyleSpec<RemixToggleGroupItemSpec> _resolveStyle(BuildContext context) {
+    final rawDefault = defaultStyleSpec;
+    if (rawDefault != null) {
+      final resolved = RemixToggleGroupItemStyler.create(
+        container: Prop.value(rawDefault.spec.container),
+        label: Prop.value(rawDefault.spec.label),
+        icon: Prop.value(rawDefault.spec.icon),
+      ).merge(data.style).build(context);
+      final modifiers = [
+        ...?rawDefault.widgetModifiers,
+        ...?resolved.widgetModifiers,
+      ];
+
+      return StyleSpec(
+        spec: resolved.spec,
+        animation: resolved.animation ?? rawDefault.animation,
+        widgetModifiers: modifiers.isEmpty ? null : modifiers,
+      );
+    }
+
+    final itemStyle = MixOps.merge(
+      defaultStyle,
+      Prop.maybeMix<StyleSpec<RemixToggleGroupItemSpec>>(data.style),
+    );
+
+    return MixOps.resolve(context, itemStyle) ??
+        const StyleSpec(spec: RemixToggleGroupItemSpec());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return NakedToggleOption<T>(
+      value: data.value,
+      enabled: data.enabled,
+      focusNode: data.focusNode,
+      autofocus: data.autofocus,
+      semanticLabel: data.label,
+      builder: (context, state, _) {
+        return WidgetStateProvider(
+          states: state.states,
+          child: Builder(
+            builder: (context) {
+              return StyleSpecBuilder<RemixToggleGroupItemSpec>(
+                styleSpec: _resolveStyle(context),
+                builder: (context, spec) {
+                  return RowBox(
+                    styleSpec: spec.container,
+                    children: [
+                      if (data.icon != null)
+                        StyledIcon(icon: data.icon!, styleSpec: spec.icon),
+                      if (data.label != null)
+                        StyledText(data.label!, styleSpec: spec.label),
+                    ],
+                  );
+                },
+              );
+            },
+          ),
+        );
+      },
+    );
+  }
+}

--- a/packages/remix/lib/src/components/toggle_group/toggle_group_widget.dart
+++ b/packages/remix/lib/src/components/toggle_group/toggle_group_widget.dart
@@ -44,6 +44,20 @@ class RemixToggleGroupItem<T> {
 }
 
 /// A styled, single-select toggle group with roving keyboard focus.
+///
+/// ## Example
+///
+/// ```dart
+/// RemixToggleGroup<String>(
+///   selectedValue: selectedValue,
+///   onChanged: (value) => setState(() => selectedValue = value),
+///   items: const [
+///     RemixToggleGroupItem(value: 'left', icon: Icons.format_align_left),
+///     RemixToggleGroupItem(value: 'center', icon: Icons.format_align_center),
+///     RemixToggleGroupItem(value: 'right', icon: Icons.format_align_right),
+///   ],
+/// )
+/// ```
 class RemixToggleGroup<T> extends StatelessWidget {
   const RemixToggleGroup({
     super.key,
@@ -109,13 +123,6 @@ class RemixToggleGroup<T> extends StatelessWidget {
         mainAxisSize: .min,
       ).wrap(.intrinsicWidth().intrinsicHeight()),
     ).merge(style);
-    // Resolve group-level context variants now, while retaining nested item
-    // variants for resolution inside each option's WidgetStateProvider.
-    final activeStyle =
-        // Mix does not expose another way to retain nested item variants.
-        // ignore: invalid_use_of_visible_for_testing_member
-        effectiveStyle.mergeActiveVariants(context, namedVariants: const {})
-            as RemixToggleGroupStyler;
 
     return NakedToggleGroup<T>(
       selectedValue: selectedValue,
@@ -136,7 +143,10 @@ class RemixToggleGroup<T> extends StatelessWidget {
                 _RemixToggleGroupItemWidget(
                   key: ValueKey(item.value),
                   data: item,
-                  defaultStyle: styleSpec == null ? activeStyle.$item : null,
+                  // Pass the item default with its nested variants intact; each
+                  // option resolves them inside its own WidgetStateProvider,
+                  // matching RemixSelect/RemixMenu.
+                  defaultStyle: styleSpec == null ? effectiveStyle.$item : null,
                   defaultStyleSpec: styleSpec == null ? null : spec.item,
                 ),
             ],

--- a/packages/remix/pubspec.yaml
+++ b/packages/remix/pubspec.yaml
@@ -23,14 +23,7 @@ dependencies:
     sdk: flutter
   mix: ^2.1.0
   mix_annotations: ^2.1.2
-  naked_ui: ^1.0.0-beta.3
-
-dependency_overrides:
-  naked_ui:
-    git:
-      url: https://github.com/btwld/naked_ui.git
-      ref: main
-      path: packages/naked_ui
+  naked_ui: ^1.0.0-beta.4
 
 dev_dependencies:
   dart_code_metrics_presets: ^2.32.0

--- a/packages/remix/pubspec.yaml
+++ b/packages/remix/pubspec.yaml
@@ -25,6 +25,13 @@ dependencies:
   mix_annotations: ^2.1.2
   naked_ui: ^1.0.0-beta.3
 
+dependency_overrides:
+  naked_ui:
+    git:
+      url: https://github.com/btwld/naked_ui.git
+      ref: main
+      path: packages/naked_ui
+
 dev_dependencies:
   dart_code_metrics_presets: ^2.32.0
   flutter_test:

--- a/packages/remix/test/components/fortal_widget_test.dart
+++ b/packages/remix/test/components/fortal_widget_test.dart
@@ -160,6 +160,22 @@ void main() {
       expect(find.byType(RemixToggle), findsOneWidget);
     });
 
+    testWidgets('renders FortalToggleGroup', (tester) async {
+      await tester.pumpRemixApp(
+        FortalToggleGroup<String>(
+          selectedValue: 'a',
+          onChanged: (_) {},
+          items: const [
+            RemixToggleGroupItem(value: 'a', label: 'A'),
+            RemixToggleGroupItem(value: 'b', label: 'B'),
+          ],
+        ),
+      );
+
+      expect(find.byType(FortalToggleGroup<String>), findsOneWidget);
+      expect(find.byType(RemixToggleGroup<String>), findsOneWidget);
+    });
+
     testWidgets('renders FortalDialog', (tester) async {
       await tester.pumpRemixApp(const FortalDialog(title: 'Hello'));
       expect(find.byType(FortalDialog), findsOneWidget);

--- a/packages/remix/test/components/toggle_group/toggle_group_spec_test.dart
+++ b/packages/remix/test/components/toggle_group/toggle_group_spec_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:remix/remix.dart';
+
+void main() {
+  group('RemixToggleGroupSpec', () {
+    test('creates default child specs', () {
+      const spec = RemixToggleGroupSpec();
+
+      expect(spec.container, isA<StyleSpec<FlexBoxSpec>>());
+      expect(spec.item, isA<StyleSpec<RemixToggleGroupItemSpec>>());
+      expect(spec.props, hasLength(2));
+    });
+
+    test('copyWith replaces selected properties', () {
+      const original = RemixToggleGroupSpec();
+      final container = StyleSpec(spec: FlexBoxSpec());
+
+      final copy = original.copyWith(container: container);
+
+      expect(copy, isNot(same(original)));
+      expect(copy.container, container);
+      expect(copy.item, original.item);
+    });
+
+    test('lerp supports endpoints and null', () {
+      const first = RemixToggleGroupSpec();
+      const second = RemixToggleGroupSpec();
+
+      expect(first.lerp(null, 0.5), first);
+      expect(first.lerp(second, 0), first);
+      expect(first.lerp(second, 1), second);
+    });
+
+    test('supports diagnostics', () {
+      const spec = RemixToggleGroupSpec();
+      final builder = DiagnosticPropertiesBuilder();
+
+      expect(() => spec.debugFillProperties(builder), returnsNormally);
+      expect(builder.properties.map((property) => property.name), [
+        'container',
+        'item',
+      ]);
+    });
+  });
+
+  group('RemixToggleGroupItemSpec', () {
+    test('creates default child specs', () {
+      const spec = RemixToggleGroupItemSpec();
+
+      expect(spec.container, isA<StyleSpec<FlexBoxSpec>>());
+      expect(spec.label, isA<StyleSpec<TextSpec>>());
+      expect(spec.icon, isA<StyleSpec<IconSpec>>());
+      expect(spec.props, hasLength(3));
+    });
+
+    test('copyWith and lerp preserve value semantics', () {
+      const original = RemixToggleGroupItemSpec();
+      final label = StyleSpec(spec: TextSpec());
+      final copy = original.copyWith(label: label);
+
+      expect(copy.label, label);
+      expect(copy.container, original.container);
+      expect(original.lerp(null, 0.5), original);
+      expect(const RemixToggleGroupItemSpec(), original);
+      expect(const RemixToggleGroupItemSpec().hashCode, original.hashCode);
+    });
+  });
+}

--- a/packages/remix/test/components/toggle_group/toggle_group_style_test.dart
+++ b/packages/remix/test/components/toggle_group/toggle_group_style_test.dart
@@ -1,0 +1,104 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:remix/remix.dart';
+
+import '../../helpers/test_methods.dart';
+
+void main() {
+  group('RemixToggleGroupStyler', () {
+    test('constructors retain container and item styles', () {
+      final container = FlexBoxStyler();
+      final item = RemixToggleGroupItemStyler();
+      final style = RemixToggleGroupStyler(container: container, item: item);
+
+      expect(style.$container, Prop.maybeMix(container));
+      expect(style.$item, Prop.maybeMix(item));
+    });
+
+    styleMethodTest(
+      'sets the group background color',
+      initial: RemixToggleGroupStyler(),
+      modify: (style) => style.backgroundColor(Colors.blue),
+      expect: (style) {
+        expect(
+          style.$container,
+          Prop.maybeMix(
+            FlexBoxStyler(decoration: BoxDecorationMix(color: Colors.blue)),
+          ),
+        );
+      },
+    );
+
+    styleMethodTest(
+      'sets the default item style',
+      initial: RemixToggleGroupStyler(),
+      modify: (style) => style.item(RemixToggleGroupItemStyler()),
+      expect: (style) {
+        expect(style.$item, Prop.maybeMix(RemixToggleGroupItemStyler()));
+      },
+    );
+
+    test('generic call creates a typed group', () {
+      final widget = RemixToggleGroupStyler().call<String>(
+        items: const [RemixToggleGroupItem(value: 'list', label: 'List')],
+        selectedValue: 'list',
+        onChanged: (_) {},
+      );
+
+      expect(widget, isA<RemixToggleGroup<String>>());
+    });
+
+    testWidgets('Fortal recipe resolves in a Fortal scope', (tester) async {
+      await tester.pumpWidget(
+        FortalScope(
+          child: MaterialApp(
+            home: FortalToggleGroup<String>(
+              items: const [
+                RemixToggleGroupItem(value: 'list', label: 'List'),
+                RemixToggleGroupItem(value: 'grid', label: 'Grid'),
+              ],
+              selectedValue: 'list',
+              onChanged: (_) {},
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(RemixToggleGroup<String>), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+  });
+
+  group('RemixToggleGroupItemStyler', () {
+    styleMethodTest(
+      'sets foreground color on label and icon',
+      initial: RemixToggleGroupItemStyler(),
+      modify: (style) => style.foregroundColor(Colors.red),
+      expect: (style) {
+        expect(style.$label, isNotNull);
+        expect(style.$icon, isNotNull);
+      },
+    );
+
+    styleMethodTest(
+      'adds a selected-state variant',
+      initial: RemixToggleGroupItemStyler(),
+      modify: (style) => style.onSelected(
+        RemixToggleGroupItemStyler().backgroundColor(Colors.purple),
+      ),
+      expect: (style) {
+        expect(style.$variants, hasLength(1));
+      },
+    );
+
+    styleMethodTest(
+      'sets icon and label spacing',
+      initial: RemixToggleGroupItemStyler(),
+      modify: (style) => style.spacing(8),
+      expect: (style) {
+        expect(style.$container, Prop.maybeMix(FlexBoxStyler(spacing: 8)));
+      },
+    );
+  });
+}

--- a/packages/remix/test/components/toggle_group/toggle_group_widget_test.dart
+++ b/packages/remix/test/components/toggle_group/toggle_group_widget_test.dart
@@ -1,0 +1,455 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:naked_ui/naked_ui.dart';
+import 'package:remix/remix.dart';
+
+import '../../helpers/test_helpers.dart';
+import '../../helpers/test_methods.dart';
+
+List<RemixToggleGroupItem<String>> _items(
+  List<FocusNode> nodes, {
+  bool disableMiddle = false,
+}) {
+  return [
+    RemixToggleGroupItem(
+      value: 'list',
+      label: 'List',
+      icon: Icons.view_list,
+      focusNode: nodes[0],
+    ),
+    RemixToggleGroupItem(
+      value: 'grid',
+      label: 'Grid',
+      icon: Icons.grid_view,
+      enabled: !disableMiddle,
+      focusNode: nodes[1],
+    ),
+    RemixToggleGroupItem(
+      value: 'board',
+      label: 'Board',
+      icon: Icons.view_kanban,
+      focusNode: nodes[2],
+    ),
+  ];
+}
+
+List<FocusNode> _focusNodes() => List.generate(3, (index) => FocusNode());
+
+void _disposeNodes(List<FocusNode> nodes) {
+  for (final node in nodes) {
+    node.dispose();
+  }
+}
+
+void main() {
+  group('RemixToggleGroup', () {
+    testWidgets('renders all items', (tester) async {
+      final nodes = _focusNodes();
+      addTearDown(() => _disposeNodes(nodes));
+
+      await tester.pumpRemixApp(
+        RemixToggleGroup<String>(
+          items: _items(nodes),
+          selectedValue: 'list',
+          onChanged: (_) {},
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(NakedToggleGroup<String>), findsOneWidget);
+      expect(find.byType(NakedToggleOption<String>), findsNWidgets(3));
+      expect(find.text('List'), findsOneWidget);
+      expect(find.text('Grid'), findsOneWidget);
+      expect(find.text('Board'), findsOneWidget);
+      expect(find.byIcon(Icons.grid_view), findsOneWidget);
+    });
+
+    testWidgets('shrink-wraps the segmented-control container', (tester) async {
+      final nodes = _focusNodes();
+      addTearDown(() => _disposeNodes(nodes));
+
+      await tester.pumpRemixApp(
+        FortalToggleGroup<String>(
+          items: _items(nodes),
+          selectedValue: 'list',
+          onChanged: (_) {},
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final size = tester.getSize(find.byType(FlexBox));
+      expect(size.width, lessThan(400));
+      expect(size.height, lessThan(100));
+    });
+
+    testWidgets('tapping an item selects its value', (tester) async {
+      final nodes = _focusNodes();
+      addTearDown(() => _disposeNodes(nodes));
+      String? selected;
+
+      await tester.pumpRemixApp(
+        RemixToggleGroup<String>(
+          items: _items(nodes),
+          selectedValue: 'list',
+          onChanged: (value) => selected = value,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Grid'));
+      await tester.pumpAndSettle();
+
+      expect(selected, 'grid');
+    });
+
+    testWidgets('a disabled item ignores taps', (tester) async {
+      final nodes = _focusNodes();
+      addTearDown(() => _disposeNodes(nodes));
+      var changes = 0;
+
+      await tester.pumpRemixApp(
+        RemixToggleGroup<String>(
+          items: _items(nodes, disableMiddle: true),
+          selectedValue: 'list',
+          onChanged: (_) => changes += 1,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Grid'));
+      await tester.pumpAndSettle();
+
+      expect(changes, 0);
+    });
+
+    testWidgets('exposes one tab stop and then exits the group', (
+      tester,
+    ) async {
+      final nodes = _focusNodes();
+      final before = FocusNode();
+      final after = FocusNode();
+      addTearDown(() {
+        _disposeNodes(nodes);
+        before.dispose();
+        after.dispose();
+      });
+
+      await tester.pumpRemixApp(
+        Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            TextButton(
+              focusNode: before,
+              autofocus: true,
+              onPressed: () {},
+              child: const Text('Before'),
+            ),
+            RemixToggleGroup<String>(
+              items: _items(nodes),
+              selectedValue: 'grid',
+              onChanged: (_) {},
+            ),
+            TextButton(
+              focusNode: after,
+              onPressed: () {},
+              child: const Text('After'),
+            ),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(before.hasFocus, isTrue);
+
+      await sendKeyAndSettle(tester, LogicalKeyboardKey.tab);
+      expect(nodes[1].hasFocus, isTrue);
+
+      await sendKeyAndSettle(tester, LogicalKeyboardKey.tab);
+      expect(after.hasFocus, isTrue);
+    });
+
+    for (final (orientation, key) in [
+      (Axis.horizontal, LogicalKeyboardKey.arrowRight),
+      (Axis.vertical, LogicalKeyboardKey.arrowDown),
+    ]) {
+      testWidgets('$key moves focus forward without selecting', (tester) async {
+        final nodes = _focusNodes();
+        addTearDown(() => _disposeNodes(nodes));
+        var changes = 0;
+
+        await tester.pumpRemixApp(
+          RemixToggleGroup<String>(
+            items: _items(nodes),
+            selectedValue: 'list',
+            onChanged: (_) => changes += 1,
+            orientation: orientation,
+          ),
+        );
+        await tester.pumpAndSettle();
+        nodes[0].requestFocus();
+        await tester.pumpAndSettle();
+
+        await sendKeyAndSettle(tester, key);
+
+        expect(nodes[1].hasFocus, isTrue);
+        expect(changes, 0);
+      });
+    }
+
+    for (final (orientation, key) in [
+      (Axis.horizontal, LogicalKeyboardKey.arrowLeft),
+      (Axis.vertical, LogicalKeyboardKey.arrowUp),
+    ]) {
+      testWidgets('$key moves focus backward', (tester) async {
+        final nodes = _focusNodes();
+        addTearDown(() => _disposeNodes(nodes));
+
+        await tester.pumpRemixApp(
+          RemixToggleGroup<String>(
+            items: _items(nodes),
+            selectedValue: 'grid',
+            onChanged: (_) {},
+            orientation: orientation,
+          ),
+        );
+        await tester.pumpAndSettle();
+        nodes[1].requestFocus();
+        await tester.pumpAndSettle();
+
+        await sendKeyAndSettle(tester, key);
+
+        expect(nodes[0].hasFocus, isTrue);
+      });
+    }
+
+    testWidgets('Home and End move to the first and last item', (tester) async {
+      final nodes = _focusNodes();
+      addTearDown(() => _disposeNodes(nodes));
+
+      await tester.pumpRemixApp(
+        RemixToggleGroup<String>(
+          items: _items(nodes),
+          selectedValue: 'grid',
+          onChanged: (_) {},
+        ),
+      );
+      await tester.pumpAndSettle();
+      nodes[1].requestFocus();
+      await tester.pumpAndSettle();
+
+      await sendKeyAndSettle(tester, LogicalKeyboardKey.home);
+      expect(nodes[0].hasFocus, isTrue);
+
+      await sendKeyAndSettle(tester, LogicalKeyboardKey.end);
+      expect(nodes[2].hasFocus, isTrue);
+    });
+
+    testWidgets('arrow traversal skips disabled items', (tester) async {
+      final nodes = _focusNodes();
+      addTearDown(() => _disposeNodes(nodes));
+
+      await tester.pumpRemixApp(
+        RemixToggleGroup<String>(
+          items: _items(nodes, disableMiddle: true),
+          selectedValue: 'list',
+          onChanged: (_) {},
+        ),
+      );
+      await tester.pumpAndSettle();
+      nodes[0].requestFocus();
+      await tester.pumpAndSettle();
+
+      await sendKeyAndSettle(tester, LogicalKeyboardKey.arrowRight);
+
+      expect(nodes[2].hasFocus, isTrue);
+      expect(nodes[1].hasFocus, isFalse);
+    });
+
+    testWidgets('loop wraps while non-looping navigation clamps', (
+      tester,
+    ) async {
+      final loopingNodes = _focusNodes();
+      final clampedNodes = _focusNodes();
+      addTearDown(() {
+        _disposeNodes(loopingNodes);
+        _disposeNodes(clampedNodes);
+      });
+
+      await tester.pumpRemixApp(
+        RemixToggleGroup<String>(
+          items: _items(loopingNodes),
+          selectedValue: 'board',
+          onChanged: (_) {},
+        ),
+      );
+      await tester.pumpAndSettle();
+      loopingNodes[2].requestFocus();
+      await tester.pumpAndSettle();
+      await sendKeyAndSettle(tester, LogicalKeyboardKey.arrowRight);
+      expect(loopingNodes[0].hasFocus, isTrue);
+
+      await tester.pumpRemixApp(
+        RemixToggleGroup<String>(
+          items: _items(clampedNodes),
+          selectedValue: 'board',
+          onChanged: (_) {},
+          loop: false,
+        ),
+      );
+      await tester.pumpAndSettle();
+      clampedNodes[2].requestFocus();
+      await tester.pumpAndSettle();
+      await sendKeyAndSettle(tester, LogicalKeyboardKey.arrowRight);
+      expect(clampedNodes[2].hasFocus, isTrue);
+    });
+
+    testWidgets('RTL inverts horizontal arrow direction', (tester) async {
+      final nodes = _focusNodes();
+      addTearDown(() => _disposeNodes(nodes));
+
+      await tester.pumpRemixApp(
+        RemixToggleGroup<String>(
+          items: _items(nodes),
+          selectedValue: 'grid',
+          onChanged: (_) {},
+        ),
+        textDirection: TextDirection.rtl,
+      );
+      await tester.pumpAndSettle();
+      nodes[1].requestFocus();
+      await tester.pumpAndSettle();
+
+      await sendKeyAndSettle(tester, LogicalKeyboardKey.arrowRight);
+
+      expect(nodes[0].hasFocus, isTrue);
+    });
+
+    for (final key in [LogicalKeyboardKey.space, LogicalKeyboardKey.enter]) {
+      testWidgets('$key activates the focused item', (tester) async {
+        final nodes = _focusNodes();
+        addTearDown(() => _disposeNodes(nodes));
+        String? selected;
+
+        await tester.pumpRemixApp(
+          RemixToggleGroup<String>(
+            items: _items(nodes),
+            selectedValue: 'list',
+            onChanged: (value) => selected = value,
+          ),
+        );
+        await tester.pumpAndSettle();
+        nodes[1].requestFocus();
+        await tester.pumpAndSettle();
+
+        await sendKeyAndSettle(tester, key);
+
+        expect(selected, 'grid');
+      });
+    }
+
+    testWidgets('a disabled group has no tab stop', (tester) async {
+      final nodes = _focusNodes();
+      final before = FocusNode();
+      final after = FocusNode();
+      addTearDown(() {
+        _disposeNodes(nodes);
+        before.dispose();
+        after.dispose();
+      });
+
+      await tester.pumpRemixApp(
+        Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            TextButton(
+              focusNode: before,
+              autofocus: true,
+              onPressed: () {},
+              child: const Text('Before'),
+            ),
+            RemixToggleGroup<String>(
+              items: _items(nodes),
+              selectedValue: 'list',
+              onChanged: (_) {},
+              enabled: false,
+            ),
+            TextButton(
+              focusNode: after,
+              onPressed: () {},
+              child: const Text('After'),
+            ),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await sendKeyAndSettle(tester, LogicalKeyboardKey.tab);
+
+      expect(after.hasFocus, isTrue);
+      expect(nodes.every((node) => !node.hasFocus), isTrue);
+    });
+
+    testWidgets('vertical orientation ignores horizontal arrows', (
+      tester,
+    ) async {
+      final nodes = _focusNodes();
+      addTearDown(() => _disposeNodes(nodes));
+
+      await tester.pumpRemixApp(
+        RemixToggleGroup<String>(
+          items: _items(nodes),
+          selectedValue: 'list',
+          onChanged: (_) {},
+          orientation: Axis.vertical,
+        ),
+      );
+      await tester.pumpAndSettle();
+      nodes[0].requestFocus();
+      await tester.pumpAndSettle();
+
+      await sendKeyAndSettle(tester, LogicalKeyboardKey.arrowRight);
+      expect(nodes[0].hasFocus, isTrue);
+
+      await sendKeyAndSettle(tester, LogicalKeyboardKey.arrowDown);
+      expect(nodes[1].hasFocus, isTrue);
+    });
+  });
+
+  group('item widget states', () {
+    late List<FocusNode> selectedNodes;
+    widgetControllerTestAt<RemixToggleGroupItemSpec>(
+      'selected item exposes selected state',
+      index: 1,
+      build: () {
+        selectedNodes = _focusNodes();
+        addTearDown(() => _disposeNodes(selectedNodes));
+        return RemixToggleGroup<String>(
+          items: _items(selectedNodes),
+          selectedValue: 'grid',
+          onChanged: (_) {},
+        );
+      },
+      expectedStates: {WidgetState.selected},
+    );
+
+    late List<FocusNode> focusedNodes;
+    widgetControllerTestAt<RemixToggleGroupItemSpec>(
+      'focused item exposes focused state',
+      index: 0,
+      build: () {
+        focusedNodes = _focusNodes();
+        addTearDown(() => _disposeNodes(focusedNodes));
+        return RemixToggleGroup<String>(
+          items: _items(focusedNodes),
+          selectedValue: 'grid',
+          onChanged: (_) {},
+        );
+      },
+      act: (tester) async {
+        focusedNodes[0].requestFocus();
+        await tester.pumpAndSettle();
+      },
+      expectedStates: {WidgetState.focused},
+    );
+  });
+}

--- a/packages/remix/test/components/toggle_group/toggle_group_widget_test.dart
+++ b/packages/remix/test/components/toggle_group/toggle_group_widget_test.dart
@@ -83,6 +83,69 @@ void main() {
       expect(size.height, lessThan(100));
     });
 
+    testWidgets('styleSpec preserves vertical layout orientation', (
+      tester,
+    ) async {
+      await tester.pumpRemixApp(
+        RemixToggleGroup<String>(
+          items: const [
+            RemixToggleGroupItem(value: 'list', label: 'List'),
+            RemixToggleGroupItem(value: 'grid', label: 'Grid'),
+          ],
+          selectedValue: 'list',
+          onChanged: (_) {},
+          orientation: Axis.vertical,
+          styleSpec: const RemixToggleGroupSpec(),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final listPosition = tester.getTopLeft(find.text('List'));
+      final gridPosition = tester.getTopLeft(find.text('Grid'));
+      expect(listPosition.dx, gridPosition.dx);
+      expect(listPosition.dy, lessThan(gridPosition.dy));
+    });
+
+    testWidgets('group context variants compose with item state variants', (
+      tester,
+    ) async {
+      final style =
+          RemixToggleGroupStyler(
+            item: RemixToggleGroupItemStyler()
+                .foregroundColor(Colors.red)
+                .onSelected(
+                  RemixToggleGroupItemStyler().foregroundColor(Colors.blue),
+                ),
+          ).onRtl(
+            RemixToggleGroupStyler(
+              item: RemixToggleGroupItemStyler().foregroundColor(Colors.green),
+            ),
+          );
+
+      await tester.pumpRemixApp(
+        RemixToggleGroup<String>(
+          items: const [
+            RemixToggleGroupItem(value: 'selected', label: 'Selected'),
+            RemixToggleGroupItem(value: 'other', label: 'Other'),
+          ],
+          selectedValue: 'selected',
+          onChanged: (_) {},
+          style: style,
+        ),
+        textDirection: TextDirection.rtl,
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        tester.widget<Text>(find.text('Selected')).style?.color,
+        Colors.blue,
+      );
+      expect(
+        tester.widget<Text>(find.text('Other')).style?.color,
+        Colors.green,
+      );
+    });
+
     testWidgets('tapping an item selects its value', (tester) async {
       final nodes = _focusNodes();
       addTearDown(() => _disposeNodes(nodes));
@@ -387,6 +450,39 @@ void main() {
 
       expect(after.hasFocus, isTrue);
       expect(nodes.every((node) => !node.hasFocus), isTrue);
+    });
+
+    testWidgets('icon-only items use their semantic label', (tester) async {
+      final semantics = tester.ensureSemantics();
+
+      await tester.pumpRemixApp(
+        RemixToggleGroup<String>(
+          items: const [
+            RemixToggleGroupItem(
+              value: 'grid',
+              icon: Icons.grid_view,
+              semanticLabel: 'Grid view',
+            ),
+          ],
+          selectedValue: 'grid',
+          onChanged: (_) {},
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final option = find.bySemanticsLabel('Grid view');
+      expect(option, findsOneWidget);
+      expect(
+        tester.getSemantics(option),
+        isSemantics(
+          label: 'Grid view',
+          isButton: true,
+          isSelected: true,
+          hasSelectedState: true,
+        ),
+      );
+
+      semantics.dispose();
     });
 
     testWidgets('vertical orientation ignores horizontal arrows', (

--- a/packages/remix/test/components/toggle_group/toggle_group_widget_test.dart
+++ b/packages/remix/test/components/toggle_group/toggle_group_widget_test.dart
@@ -106,21 +106,19 @@ void main() {
       expect(listPosition.dy, lessThan(gridPosition.dy));
     });
 
-    testWidgets('group context variants compose with item state variants', (
+    testWidgets('item context variants compose with item state variants', (
       tester,
     ) async {
-      final style =
-          RemixToggleGroupStyler(
-            item: RemixToggleGroupItemStyler()
-                .foregroundColor(Colors.red)
-                .onSelected(
-                  RemixToggleGroupItemStyler().foregroundColor(Colors.blue),
-                ),
-          ).onRtl(
-            RemixToggleGroupStyler(
-              item: RemixToggleGroupItemStyler().foregroundColor(Colors.green),
+      final style = RemixToggleGroupStyler(
+        item: RemixToggleGroupItemStyler()
+            .foregroundColor(Colors.red)
+            .onSelected(
+              RemixToggleGroupItemStyler().foregroundColor(Colors.blue),
+            )
+            .onRtl(
+              RemixToggleGroupItemStyler().foregroundColor(Colors.green),
             ),
-          );
+      );
 
       await tester.pumpRemixApp(
         RemixToggleGroup<String>(

--- a/packages/remix/test/helpers/test_helpers.dart
+++ b/packages/remix/test/helpers/test_helpers.dart
@@ -6,11 +6,17 @@ import 'package:remix/remix.dart';
 /// Extension methods for WidgetTester to simplify test setup and interactions
 extension WidgetTesterHelpers on WidgetTester {
   /// Pumps a Remix widget wrapped in a MaterialApp with Scaffold
-  Future<void> pumpRemixApp(Widget widget) async {
+  Future<void> pumpRemixApp(
+    Widget widget, {
+    TextDirection textDirection = TextDirection.ltr,
+  }) async {
     await pumpWidget(
       FortalScope(
         child: MaterialApp(
-          home: Scaffold(body: Center(child: widget)),
+          home: Directionality(
+            textDirection: textDirection,
+            child: Scaffold(body: Center(child: widget)),
+          ),
         ),
       ),
     );

--- a/packages/remix/test/helpers/test_methods.dart
+++ b/packages/remix/test/helpers/test_methods.dart
@@ -75,6 +75,76 @@ void widgetControllerTest<S extends Spec<S>>(
   });
 }
 
+@isTest
+void widgetControllerTestAt<S extends Spec<S>>(
+  String description, {
+  required int index,
+  required Widget Function() build,
+  Future<void> Function(WidgetTester tester)? act,
+  required Set<WidgetState> expectedStates,
+}) {
+  ftest.testWidgets(description, (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: Padding(padding: const EdgeInsets.all(8.0), child: build()),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await act?.call(tester);
+
+    final elements = find
+        .byType(StyleBuilder<S>)
+        .evaluate()
+        .whereType<StatefulElement>()
+        .toList();
+    if (elements.length > index) {
+      final styleBuilder = elements[index].widget as StyleBuilder<S>;
+      final controller = styleBuilder.controller;
+      if (controller == null) {
+        throw Exception(
+          'WidgetStatesController not found in StyleBuilder widget at index '
+          '$index.',
+        );
+      }
+
+      expect(controller.value, equals(expectedStates));
+      return;
+    }
+
+    final providers = find
+        .byType(WidgetStateProvider)
+        .evaluate()
+        .map((element) => element.widget)
+        .whereType<WidgetStateProvider>()
+        .toList();
+    ftest.expect(providers.length, ftest.greaterThan(index));
+    final provider = providers[index];
+    final states = <WidgetState>{
+      if (provider.disabled) WidgetState.disabled,
+      if (provider.hovered) WidgetState.hovered,
+      if (provider.focused) WidgetState.focused,
+      if (provider.pressed) WidgetState.pressed,
+      if (provider.dragged) WidgetState.dragged,
+      if (provider.selected) WidgetState.selected,
+      if (provider.error) WidgetState.error,
+    };
+    expect(states, equals(expectedStates));
+  });
+}
+
+Future<void> sendKeyAndSettle(
+  WidgetTester tester,
+  LogicalKeyboardKey key,
+) async {
+  await tester.sendKeyEvent(key);
+  await tester.pumpAndSettle();
+}
+
 Future<void> hoverAction<T>(WidgetTester tester) async {
   final offset = tester.getCenter(find.byType(T));
   final testPointer = TestPointer(1, PointerDeviceKind.mouse)..hover(offset);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -493,14 +493,13 @@ packages:
     source: hosted
     version: "2.0.5"
   naked_ui:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
-      path: "packages/naked_ui"
-      ref: main
-      resolved-ref: d4148753b9c7cc103b76787bb390285a2ddf971e
-      url: "https://github.com/btwld/naked_ui.git"
-    source: git
-    version: "1.0.0-beta.3"
+      name: naked_ui
+      sha256: f0add49dead1ddb1d1823b0f0d39d33b65959640b5dfc21c9de4f9e8db658494
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0-beta.4"
   nested:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -493,12 +493,13 @@ packages:
     source: hosted
     version: "2.0.5"
   naked_ui:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
-      name: naked_ui
-      sha256: d83e2dbb89daad44243dae199ebe9a7149086be43ec4732a77128270d2f6ac69
-      url: "https://pub.dev"
-    source: hosted
+      path: "packages/naked_ui"
+      ref: main
+      resolved-ref: d4148753b9c7cc103b76787bb390285a2ddf971e
+      url: "https://github.com/btwld/naked_ui.git"
+    source: git
     version: "1.0.0-beta.3"
   nested:
     dependency: transitive


### PR DESCRIPTION
## Summary

- add a complete, data-driven `RemixToggleGroup<T>` component backed by `NakedToggleGroup<T>`
- add group/item specs and stylers, selected/focused/disabled state styling, generated APIs, and a Fortal segmented-control recipe
- add a Widgetbook use case with orientation, loop, enabled, variant, size, and selection controls
- add component documentation and navigation
- add test helpers and a full pointer, keyboard, focus, RTL, disabled, loop/clamp, layout, spec, and style matrix

## Why

Remix had standalone toggles but no single-select segmented-control component. Toggle Group provides one Tab stop, focus-only arrow navigation, explicit Space/Enter activation, orientation-aware movement, Home/End, disabled-item skipping, optional looping, and RTL-aware horizontal navigation.

## Dependency note

The publishable dependency remains `naked_ui: ^1.0.0-beta.3`. A temporary dependency override tracks `naked_ui` main at `d414875`, where the roving-focus Toggle Group was merged in naked_ui PR #68. The override can return to a hosted version after the next naked_ui release.

## Verification

- `fvm dart run melos run ci --no-select`
- generation check passed with no diff
- DCM passed with fatal style and warning checks
- demo package: 15 tests passed
- Remix package: 1,829 tests passed
- `git diff --check origin/main...HEAD`

