### PR TITLE
fix(accordion): set default content text color in Fortal styler

### DIFF
--- a/packages/remix/lib/src/components/accordion/fortal_accordion_styles.dart
+++ b/packages/remix/lib/src/components/accordion/fortal_accordion_styles.dart
@@ -38,7 +38,12 @@ RemixAccordionStyler _fortalAccordionSurfaceStyler([
               color: FortalTokens.gray6(),
               width: FortalTokens.borderWidth1(),
             )
-            .color(FortalTokens.gray2()),
+            .color(FortalTokens.gray2())
+            .wrap(
+              .defaultTextStyle(
+                style: TextStyleMix().color(FortalTokens.gray12()),
+              ),
+            ),
       );
 }
 
@@ -55,7 +60,12 @@ RemixAccordionStyler _fortalAccordionSoftStyler([
               color: FortalTokens.accent6(),
               width: FortalTokens.borderWidth1(),
             )
-            .color(FortalTokens.accent2()),
+            .color(FortalTokens.accent2())
+            .wrap(
+              .defaultTextStyle(
+                style: TextStyleMix().color(FortalTokens.accent12()),
+              ),
+            ),
       );
 }
 


### PR DESCRIPTION
## Summary

The Fortal accordion `content` styled its box (border, background, padding) but never established a default text color for the body — so content text fell back to the ambient `DefaultTextStyle`.

This wraps `content` with a `defaultTextStyle` modifier (the same pattern already used in `fortal_tooltip_styles.dart`), matching each variant's title color:

- **Surface** variant → `FortalTokens.gray12()`
- **Soft** variant → `FortalTokens.accent12()`

## Testing

- `flutter analyze` on the accordion component: no issues found

🤖 Generated with [Claude Code](https://claude.com/claude-code)