### PR TITLE
feat: rename button styler

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Flutter developers commonly face these challenges when building custom UIs:
 ### The Solution
 
 ```dart
-final style = RemixButtonStyler()
+final style = ButtonStyler()
   .paddingX(16)
   .paddingY(10)
   .color(Colors.blue)
@@ -38,7 +38,7 @@ RemixButton(
 
 Or using callable styles:
 ```dart
-final button = RemixButtonStyler()
+final button = ButtonStyler()
   .paddingX(16)
   .paddingY(10)
   .color(Colors.blue)
@@ -85,7 +85,7 @@ import 'package:remix/remix.dart';
 
 class MyApp extends StatelessWidget {
 
-  final button = RemixButtonStyler()
+  final button = ButtonStyler()
     .paddingX(16)
     .paddingY(10)
     .color(Colors.blue)
@@ -113,7 +113,7 @@ class MyApp extends StatelessWidget {
 Easily define how components should look in different interaction states.
 
 ```dart
-final button = RemixButtonStyler()
+final button = ButtonStyler()
   .paddingX(16)
   .paddingY(10)
   .color(Colors.blue)
@@ -128,7 +128,7 @@ final button = RemixButtonStyler()
 Make your button style smoothly animate when its state changes by chaining `.animate()` with your state-specific styles. You can use `AnimationConfig.spring` to get natural, spring-based motion.
 
 ```dart
-final style = RemixButtonStyler()
+final style = ButtonStyler()
   .paddingX(16)
   .paddingY(10)
   .color(Colors.blue)
@@ -147,7 +147,7 @@ This example animates both the color on hover and the scale on press, creating a
 Create base styles and extend them to build variants:
 
 ```dart
-final baseButtonStyle = RemixButtonStyler()
+final baseButtonStyle = ButtonStyler()
     .paddingX(16)
     .paddingY(10)
     .borderRadiusAll(const Radius.circular(8));
@@ -217,7 +217,7 @@ Fortal styles are built on a robust token system that includes:
 You can use these tokens directly in your custom styles:
 
 ```dart
-final style = RemixButtonStyler()
+final style = ButtonStyler()
   .color(FortalTokens.accent9())
   .paddingAll(FortalTokens.space4())
   .borderRadiusAll(FortalTokens.radius3())

--- a/atlas/fortal/README.md
+++ b/atlas/fortal/README.md
@@ -22,7 +22,7 @@ The capture covers five Button variants, four sizes, and default, hovered,
 pressed, focused, disabled, and loading scenarios in light and dark themes:
 240 cells total, 200 non-loading cells, and 40 loading cells.
 
-The producer adapter walks the real `RemixButtonStyler` sources and variants,
+The producer adapter walks the real `ButtonStyler` sources and variants,
 then uses each built-in leaf styler's normal merge semantics. It does not copy
 the Fortal recipe. It calls `RemixButton.composeStyle` first so widget-owned
 defaults and tooling share one source of truth. Container, label, and icon

--- a/atlas/fortal/capture.json
+++ b/atlas/fortal/capture.json
@@ -58,8 +58,8 @@
     },
     {
       "path": "protocol/coverage.json",
-      "sha256": "bd34c03c2ff05bc2a540071edca2c2d1885fefbb074bb5e3d772607af098d96b",
-      "bytes": 7886
+      "sha256": "7b1615f04774c6a1ec3bbc80b703fa4557a5a6371680e1da686bd15937c01abb",
+      "bytes": 7836
     },
     {
       "path": "protocol/fixtures/fortal-tokenized-flex-box.mix.json",

--- a/atlas/fortal/protocol/coverage.json
+++ b/atlas/fortal/protocol/coverage.json
@@ -147,7 +147,7 @@
     },
     {
       "id": "fortal-button-portable",
-      "runtimeType": "RemixButtonStyler projection",
+      "runtimeType": "ButtonStyler projection",
       "status": "partial",
       "recipeCount": 20,
       "totalMatrixCells": 240,
@@ -165,56 +165,56 @@
     },
     {
       "id": "fortal-button",
-      "runtimeType": "RemixButtonStyler",
+      "runtimeType": "ButtonStyler",
       "status": "unsupported",
       "diagnostics": [
         {
           "code": "unsupported_encode_value",
           "severity": "error",
           "path": "",
-          "message": "Expected box, got RemixButtonStyler."
+          "message": "Expected box, got ButtonStyler."
         },
         {
           "code": "unsupported_encode_value",
           "severity": "error",
           "path": "",
-          "message": "Expected text, got RemixButtonStyler."
+          "message": "Expected text, got ButtonStyler."
         },
         {
           "code": "unsupported_encode_value",
           "severity": "error",
           "path": "",
-          "message": "Expected flex, got RemixButtonStyler."
+          "message": "Expected flex, got ButtonStyler."
         },
         {
           "code": "unsupported_encode_value",
           "severity": "error",
           "path": "",
-          "message": "Expected stack, got RemixButtonStyler."
+          "message": "Expected stack, got ButtonStyler."
         },
         {
           "code": "unsupported_encode_value",
           "severity": "error",
           "path": "",
-          "message": "Expected icon, got RemixButtonStyler."
+          "message": "Expected icon, got ButtonStyler."
         },
         {
           "code": "unsupported_encode_value",
           "severity": "error",
           "path": "",
-          "message": "Expected image, got RemixButtonStyler."
+          "message": "Expected image, got ButtonStyler."
         },
         {
           "code": "unsupported_encode_value",
           "severity": "error",
           "path": "",
-          "message": "Expected flex_box, got RemixButtonStyler."
+          "message": "Expected flex_box, got ButtonStyler."
         },
         {
           "code": "unsupported_encode_value",
           "severity": "error",
           "path": "",
-          "message": "Expected stack_box, got RemixButtonStyler."
+          "message": "Expected stack_box, got ButtonStyler."
         }
       ]
     }

--- a/docs/components/button.mdx
+++ b/docs/components/button.mdx
@@ -45,8 +45,8 @@ class ButtonExample extends StatelessWidget {
     );
   }
 
-  RemixButtonStyler get destructiveStyle {
-    return RemixButtonStyler()
+  ButtonStyler get destructiveStyle {
+    return ButtonStyler()
         .paddingX(16)
         .paddingY(10)
         .backgroundColor(const Color(0xFF4D1919))
@@ -75,7 +75,7 @@ class ButtonExample extends StatelessWidget {
         );
   }
 
-  RemixButtonStyler get successStyle {
+  ButtonStyler get successStyle {
     return destructiveStyle
         .backgroundColor(const Color.fromARGB(255, 15, 61, 15))
         .label(TextStyler().uppercase().color(Colors.greenAccent))
@@ -175,7 +175,7 @@ const RemixButton({
   String? semanticHint,
   bool excludeSemantics = false,
   MouseCursor mouseCursor = SystemMouseCursors.click,
-  RemixButtonStyler style = const RemixButtonStyler.create(),
+  ButtonStyler style = const ButtonStyler.create(),
   RemixButtonSpec? styleSpec,
 })
 ```
@@ -185,7 +185,7 @@ const RemixButton({
 ## Properties
 ### Widget Properties
 
-#### `style` → `RemixButtonStyler`
+#### `style` → `ButtonStyler`
 
 Optional. The style configuration for the button. Customize colors, sizing, spacing, and state-based styling.
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -23,7 +23,7 @@ Flutter developers commonly face these challenges when building custom UIs:
 ### The Solution
 
 ```dart
-final style = RemixButtonStyler()
+final style = ButtonStyler()
   .paddingX(16)
   .paddingY(10)
   .color(Colors.blue)
@@ -40,7 +40,7 @@ RemixButton(
 
 Or using callable styles:
 ```dart
-final button = RemixButtonStyler()
+final button = ButtonStyler()
   .paddingX(16)
   .paddingY(10)
   .color(Colors.blue)
@@ -87,7 +87,7 @@ import 'package:remix/remix.dart';
 
 class MyApp extends StatelessWidget {
 
-  final button = RemixButtonStyler()
+  final button = ButtonStyler()
     .paddingX(16)
     .paddingY(10)
     .color(Colors.blue)
@@ -115,7 +115,7 @@ class MyApp extends StatelessWidget {
 Easily define how components should look in different interaction states.
 
 ```dart
-final style = RemixButtonStyler()
+final style = ButtonStyler()
   .paddingX(16)
   .paddingY(10)
   .color(Colors.blue)
@@ -130,7 +130,7 @@ final style = RemixButtonStyler()
 Make your button style smoothly animate when its state changes by chaining `.animate()` with your state-specific styles. You can use `AnimationConfig.spring` to get natural, spring-based motion.
 
 ```dart
-final style = RemixButtonStyler()
+final style = ButtonStyler()
   .paddingX(16)
   .paddingY(10)
   .color(Colors.blue)
@@ -149,7 +149,7 @@ This example animates both the color on hover and the scale on press, creating a
 Create base styles and extend them to build variants:
 
 ```dart
-final baseButtonStyle = RemixButtonStyler()
+final baseButtonStyle = ButtonStyler()
     .paddingX(16)
     .paddingY(10)
     .borderRadiusAll(const Radius.circular(8));
@@ -219,7 +219,7 @@ Fortal styles are built on a robust token system that includes:
 You can use these tokens directly in your custom styles:
 
 ```dart
-final style = RemixButtonStyler()
+final style = ButtonStyler()
   .color(FortalTokens.accent9())
   .paddingAll(FortalTokens.space4())
   .borderRadiusAll(FortalTokens.radius3())

--- a/docs/styler-api.mdx
+++ b/docs/styler-api.mdx
@@ -7,8 +7,11 @@ Remix stylers expose matching named factories and fluent methods for canonical
 style operations. This symmetry lets a state variant use Dart's contextual dot
 shorthand without constructing another styler explicitly:
 
+For buttons, use `ButtonStyler`. `RemixButtonStyler` is retained as a
+deprecated compatibility alias.
+
 ```dart
-final style = RemixButtonStyler()
+final style = ButtonStyler()
     .color(Colors.blue)
     .onHovered(.color(Colors.indigo))
     .onPressed(.scale(0.97));
@@ -116,7 +119,7 @@ names:
 | Styler | Canonical generated API | Component-specific helper |
 | --- | --- | --- |
 | `RemixTextFieldStyler` | `color` styles the container | `textColor` styles editable text |
-| `RemixButtonStyler` | `rotate` transforms the container | `modifierRotate` rotates the complete widget with a modifier |
+| `ButtonStyler` | `rotate` transforms the container | `modifierRotate` rotates the complete widget with a modifier |
 | `RemixCalloutStyler` | `textStyle(TextStyler)` applies the container text style | `contentTextStyle(TextStyleMix)` styles callout content |
 
 This keeps contextual shorthand predictable while preserving each specialized
@@ -124,7 +127,7 @@ operation without ambiguous overloads.
 
 ## Generation boundary
 
-`Remix*Styler` classes are generated from `@MixableSpec`. Fortal widget wrapper
+Component stylers are generated from `@MixableSpec`. Fortal widget wrapper
 classes are source-authored even though they were previously emitted by
 `@MixWidget`. Both upstream generators write shared parts for the same library;
 during a clean build, the widget generator cannot resolve a Styler that the

--- a/packages/demo/test/atlas/fortal_button_protocol_adapter_test.dart
+++ b/packages/demo/test/atlas/fortal_button_protocol_adapter_test.dart
@@ -11,7 +11,7 @@ import 'support/fortal_button_component_artifact.dart';
 void main() {
   group('Fortal Button protocol adapter', () {
     test('projects real composite sources without restating the recipe', () {
-      final projection = projectRemixButtonStyler(
+      final projection = projectButtonStyler(
         fortalButtonStyler(
           variant: FortalButtonVariant.surface,
           size: FortalButtonSize.size3,
@@ -38,7 +38,7 @@ void main() {
     test('all projected slots encode as built-in protocol styles', () {
       for (final variant in FortalButtonVariant.values) {
         for (final size in FortalButtonSize.values) {
-          final projection = projectRemixButtonStyler(
+          final projection = projectButtonStyler(
             fortalButtonStyler(variant: variant, size: size),
           );
 
@@ -64,7 +64,7 @@ void main() {
     test(
       'keeps spinner support explicit instead of projecting custom code',
       () {
-        final projection = projectRemixButtonStyler(fortalButtonStyler());
+        final projection = projectButtonStyler(fortalButtonStyler());
 
         expect(projection.spinnerSupported, isFalse);
         expect(projection.spinnerDiagnostic.code, 'unsupported_slot_primitive');

--- a/packages/demo/test/atlas/fortal_protocol_probe_test.dart
+++ b/packages/demo/test/atlas/fortal_protocol_probe_test.dart
@@ -95,7 +95,7 @@ void main() {
       });
     });
 
-    test('custom RemixButtonStyler fails with a structured diagnostic', () {
+    test('custom ButtonStyler fails with a structured diagnostic', () {
       final errors = _expectFailure(
         mixProtocol.encodeStyle(fortalButtonStyler()),
       );
@@ -240,7 +240,7 @@ void main() {
           },
           {
             'id': 'fortal-button-portable',
-            'runtimeType': 'RemixButtonStyler projection',
+            'runtimeType': 'ButtonStyler projection',
             'status': componentArtifacts.supportedContainerRecipes == 20
                 ? 'partial'
                 : 'unsupported',
@@ -255,7 +255,7 @@ void main() {
           },
           {
             'id': 'fortal-button',
-            'runtimeType': 'RemixButtonStyler',
+            'runtimeType': 'ButtonStyler',
             'status': 'unsupported',
             'diagnostics': [for (final error in customErrors) error.toJson()],
           },

--- a/packages/demo/test/atlas/goldens/protocol/coverage.json
+++ b/packages/demo/test/atlas/goldens/protocol/coverage.json
@@ -147,7 +147,7 @@
     },
     {
       "id": "fortal-button-portable",
-      "runtimeType": "RemixButtonStyler projection",
+      "runtimeType": "ButtonStyler projection",
       "status": "partial",
       "recipeCount": 20,
       "totalMatrixCells": 240,
@@ -165,56 +165,56 @@
     },
     {
       "id": "fortal-button",
-      "runtimeType": "RemixButtonStyler",
+      "runtimeType": "ButtonStyler",
       "status": "unsupported",
       "diagnostics": [
         {
           "code": "unsupported_encode_value",
           "severity": "error",
           "path": "",
-          "message": "Expected box, got RemixButtonStyler."
+          "message": "Expected box, got ButtonStyler."
         },
         {
           "code": "unsupported_encode_value",
           "severity": "error",
           "path": "",
-          "message": "Expected text, got RemixButtonStyler."
+          "message": "Expected text, got ButtonStyler."
         },
         {
           "code": "unsupported_encode_value",
           "severity": "error",
           "path": "",
-          "message": "Expected flex, got RemixButtonStyler."
+          "message": "Expected flex, got ButtonStyler."
         },
         {
           "code": "unsupported_encode_value",
           "severity": "error",
           "path": "",
-          "message": "Expected stack, got RemixButtonStyler."
+          "message": "Expected stack, got ButtonStyler."
         },
         {
           "code": "unsupported_encode_value",
           "severity": "error",
           "path": "",
-          "message": "Expected icon, got RemixButtonStyler."
+          "message": "Expected icon, got ButtonStyler."
         },
         {
           "code": "unsupported_encode_value",
           "severity": "error",
           "path": "",
-          "message": "Expected image, got RemixButtonStyler."
+          "message": "Expected image, got ButtonStyler."
         },
         {
           "code": "unsupported_encode_value",
           "severity": "error",
           "path": "",
-          "message": "Expected flex_box, got RemixButtonStyler."
+          "message": "Expected flex_box, got ButtonStyler."
         },
         {
           "code": "unsupported_encode_value",
           "severity": "error",
           "path": "",
-          "message": "Expected stack_box, got RemixButtonStyler."
+          "message": "Expected stack_box, got ButtonStyler."
         }
       ]
     }

--- a/packages/demo/test/atlas/support/fortal_button_component_artifact.dart
+++ b/packages/demo/test/atlas/support/fortal_button_component_artifact.dart
@@ -35,7 +35,7 @@ FortalButtonComponentArtifacts buildFortalButtonComponentArtifacts() {
   for (final variant in FortalButtonVariant.values) {
     for (final size in FortalButtonSize.values) {
       final id = '${variant.name}-${size.name}';
-      final projection = projectRemixButtonStyler(
+      final projection = projectButtonStyler(
         fortalButtonStyler(variant: variant, size: size),
       );
       if (projection.diagnostics.isNotEmpty) {

--- a/packages/demo/test/atlas/support/fortal_button_protocol_adapter.dart
+++ b/packages/demo/test/atlas/support/fortal_button_protocol_adapter.dart
@@ -50,9 +50,7 @@ final class RemixButtonProtocolProjection {
 /// It reads the composite style's existing sources and variants, then combines
 /// leaf stylers through their generated `merge` implementations. It does not
 /// resolve a widget, inspect private fields, or restate the Fortal recipe.
-RemixButtonProtocolProjection projectRemixButtonStyler(
-  RemixButtonStyler style,
-) {
+RemixButtonProtocolProjection projectButtonStyler(ButtonStyler style) {
   final effectiveStyle = RemixButton.composeStyle(style);
   final container = _projectContainer(effectiveStyle, depth: 0);
   final label = _projectLabel(effectiveStyle, depth: 0);
@@ -109,7 +107,7 @@ final class _Projection<T extends Object> {
 }
 
 _Projection<FlexBoxStyler> _projectContainer(
-  RemixButtonStyler style, {
+  ButtonStyler style, {
   required int depth,
 }) {
   if (depth > 16) return _depthFailure('container');
@@ -136,7 +134,7 @@ _Projection<FlexBoxStyler> _projectContainer(
   for (final variant
       in style.$variants ?? const <VariantStyle<RemixButtonSpec>>[]) {
     final nested = variant.value;
-    if (nested is! RemixButtonStyler) {
+    if (nested is! ButtonStyler) {
       diagnostics.add(
         _unsupportedSource('container', nested.runtimeType.toString()),
       );
@@ -156,7 +154,7 @@ _Projection<FlexBoxStyler> _projectContainer(
 }
 
 _Projection<TextStyler> _projectLabel(
-  RemixButtonStyler style, {
+  ButtonStyler style, {
   required int depth,
 }) {
   if (depth > 16) return _depthFailure('label');
@@ -183,7 +181,7 @@ _Projection<TextStyler> _projectLabel(
   for (final variant
       in style.$variants ?? const <VariantStyle<RemixButtonSpec>>[]) {
     final nested = variant.value;
-    if (nested is! RemixButtonStyler) {
+    if (nested is! ButtonStyler) {
       diagnostics.add(
         _unsupportedSource('label', nested.runtimeType.toString()),
       );
@@ -202,10 +200,7 @@ _Projection<TextStyler> _projectLabel(
   return _Projection(value: result, diagnostics: diagnostics);
 }
 
-_Projection<IconStyler> _projectIcon(
-  RemixButtonStyler style, {
-  required int depth,
-}) {
+_Projection<IconStyler> _projectIcon(ButtonStyler style, {required int depth}) {
   if (depth > 16) return _depthFailure('icon');
   final diagnostics = <ButtonProjectionDiagnostic>[];
   IconStyler? result;
@@ -230,7 +225,7 @@ _Projection<IconStyler> _projectIcon(
   for (final variant
       in style.$variants ?? const <VariantStyle<RemixButtonSpec>>[]) {
     final nested = variant.value;
-    if (nested is! RemixButtonStyler) {
+    if (nested is! ButtonStyler) {
       diagnostics.add(
         _unsupportedSource('icon', nested.runtimeType.toString()),
       );

--- a/packages/example/lib/api/button.0.dart
+++ b/packages/example/lib/api/button.0.dart
@@ -30,8 +30,8 @@ class ButtonExample extends StatelessWidget {
     );
   }
 
-  RemixButtonStyler get destructiveStyle {
-    return RemixButtonStyler()
+  ButtonStyler get destructiveStyle {
+    return ButtonStyler()
         .paddingX(16)
         .paddingY(10)
         .backgroundColor(const Color(0xFF4D1919))
@@ -46,18 +46,16 @@ class ButtonExample extends StatelessWidget {
           side: BorderSideMix.width(1).color(Colors.redAccent),
         )
         .wrap(.scale(x: 1, y: 1))
-        .onPressed(RemixButtonStyler().wrap(.scale(x: 0.90, y: 0.90)))
+        .onPressed(ButtonStyler().wrap(.scale(x: 0.90, y: 0.90)))
         .onHovered(
-          RemixButtonStyler()
+          ButtonStyler()
               .backgroundColor(const Color(0xFF732D2D))
               .animate(.spring(300.ms)),
         )
-        .onFocused(
-          RemixButtonStyler().backgroundColor(const Color(0xFF732D2D)),
-        );
+        .onFocused(ButtonStyler().backgroundColor(const Color(0xFF732D2D)));
   }
 
-  RemixButtonStyler get successStyle {
+  ButtonStyler get successStyle {
     return destructiveStyle
         .backgroundColor(const Color.fromARGB(255, 15, 61, 15))
         .label(TextStyler().uppercase().color(Colors.greenAccent))
@@ -68,9 +66,7 @@ class ButtonExample extends StatelessWidget {
               .blurRadius(10)
               .spreadRadius(0),
         )
-        .onHovered(RemixButtonStyler().backgroundColor(const Color(0xFF357857)))
-        .onFocused(
-          RemixButtonStyler().backgroundColor(const Color(0xFF357857)),
-        );
+        .onHovered(ButtonStyler().backgroundColor(const Color(0xFF357857)))
+        .onFocused(ButtonStyler().backgroundColor(const Color(0xFF357857)));
   }
 }

--- a/packages/example/lib/misc/radix_button_comprehensive_test.dart
+++ b/packages/example/lib/misc/radix_button_comprehensive_test.dart
@@ -220,7 +220,7 @@ class _AllVariantsSection extends StatelessWidget {
     ).showSnackBar(SnackBar(content: Text(message)));
   }
 
-  RemixButtonStyler _getSizedStyle(FortalButtonVariant variant) {
+  ButtonStyler _getSizedStyle(FortalButtonVariant variant) {
     return switch (size) {
       1 => fortalButtonStyler(variant: variant, size: .size1),
       2 => fortalButtonStyler(variant: variant, size: .size2),
@@ -321,7 +321,7 @@ class _SizeComparisonSection extends StatelessWidget {
 class _StateTestingSection extends StatelessWidget {
   const _StateTestingSection();
 
-  RemixButtonStyler _getVariantButton(String variantName) {
+  ButtonStyler _getVariantButton(String variantName) {
     switch (variantName) {
       case 'Solid':
         return fortalButtonStyler(variant: .solid);

--- a/packages/playground/lib/registry/entries/button_entry.dart
+++ b/packages/playground/lib/registry/entries/button_entry.dart
@@ -9,7 +9,7 @@ Widget buildButtonExample() {
       RemixButton(
         label: 'Primary Button',
         onPressed: () {},
-        style: RemixButtonStyler()
+        style: ButtonStyler()
             .paddingX(16)
             .paddingY(10)
             .borderRadiusAll(const Radius.circular(8))
@@ -19,7 +19,7 @@ Widget buildButtonExample() {
       RemixButton(
         label: 'Disabled',
         onPressed: null,
-        style: RemixButtonStyler()
+        style: ButtonStyler()
             .paddingX(16)
             .paddingY(10)
             .borderRadiusAll(const Radius.circular(8))
@@ -30,7 +30,7 @@ Widget buildButtonExample() {
         label: 'Loading',
         loading: true,
         onPressed: () {},
-        style: RemixButtonStyler()
+        style: ButtonStyler()
             .paddingX(16)
             .paddingY(10)
             .borderRadiusAll(const Radius.circular(8))
@@ -42,7 +42,7 @@ Widget buildButtonExample() {
         label: 'With Icon',
         leadingIcon: Icons.star,
         onPressed: () {},
-        style: RemixButtonStyler()
+        style: ButtonStyler()
             .paddingX(16)
             .paddingY(10)
             .borderRadiusAll(const Radius.circular(8))

--- a/packages/remix/CHANGELOG.md
+++ b/packages/remix/CHANGELOG.md
@@ -5,7 +5,10 @@
   discarding them. A lone `child` still fills the container directly, so fully
   custom dialog bodies are unaffected.
 
-- **BREAKING**: Rename fluent style builders from `RemixXStyle` to `RemixXStyler` and Fortal helpers from `fortalXStyle()` to `fortalXStyler()`, matching Mix terminology (`BoxStyler`, `TextStyler`, `MixStyler`). Widget parameter stays `style:`. No deprecated aliases.
+- **FEAT**: Expose `ButtonStyler` as the canonical button styling API.
+  `RemixButtonStyler` remains available as a deprecated compatibility alias.
+
+- **BREAKING**: Rename fluent style builders from `RemixXStyle` to `RemixXStyler` and Fortal helpers from `fortalXStyle()` to `fortalXStyler()`, matching Mix terminology (`BoxStyler`, `TextStyler`, `MixStyler`). Widget parameter stays `style:`. No deprecated aliases were kept for the removed `RemixXStyle` names.
 - **BREAKING**: Public `styleSpec` is raw `RemixXSpec?` on all component surfaces (resolved via `RemixStyleSpecBuilder`); StyleWidget-based components converted to explicit widgets.
 - **BREAKING**: `RemixSelect` overlay placement is `positioning: OverlayPositionConfig` (removed public `targetAnchor`/`followerAnchor`).
 - **BREAKING**: Remove `enableFeedback` from `RemixRadio` (not exposed by `NakedRadio`).

--- a/packages/remix/CHANGELOG.md
+++ b/packages/remix/CHANGELOG.md
@@ -1,12 +1,14 @@
+## Unreleased
+
+- **FEAT**: Expose `ButtonStyler` as the canonical button styling API.
+  `RemixButtonStyler` remains available as a deprecated compatibility alias.
+
 ## 1.0.0-beta.1
 
 - **BREAKING** **FIX**: `RemixDialog.child` now composes with `title`,
   `description`, and `actions` in `AlertDialog` order instead of silently
   discarding them. A lone `child` still fills the container directly, so fully
   custom dialog bodies are unaffected.
-
-- **FEAT**: Expose `ButtonStyler` as the canonical button styling API.
-  `RemixButtonStyler` remains available as a deprecated compatibility alias.
 
 - **BREAKING**: Rename fluent style builders from `RemixXStyle` to `RemixXStyler` and Fortal helpers from `fortalXStyle()` to `fortalXStyler()`, matching Mix terminology (`BoxStyler`, `TextStyler`, `MixStyler`). Widget parameter stays `style:`. No deprecated aliases were kept for the removed `RemixXStyle` names.
 - **BREAKING**: Public `styleSpec` is raw `RemixXSpec?` on all component surfaces (resolved via `RemixStyleSpecBuilder`); StyleWidget-based components converted to explicit widgets.

--- a/packages/remix/README.md
+++ b/packages/remix/README.md
@@ -21,7 +21,7 @@ Flutter developers commonly face these challenges when building custom UIs:
 ### The Solution
 
 ```dart
-final style = RemixButtonStyler()
+final style = ButtonStyler()
   .paddingX(16)
   .paddingY(10)
   .color(Colors.blue)
@@ -38,7 +38,7 @@ RemixButton(
 
 Or using callable styles:
 ```dart
-final button = RemixButtonStyler()
+final button = ButtonStyler()
   .paddingX(16)
   .paddingY(10)
   .color(Colors.blue)
@@ -85,7 +85,7 @@ import 'package:remix/remix.dart';
 
 class MyApp extends StatelessWidget {
 
-  final button = RemixButtonStyler()
+  final button = ButtonStyler()
     .paddingX(16)
     .paddingY(10)
     .color(Colors.blue)
@@ -113,7 +113,7 @@ class MyApp extends StatelessWidget {
 Easily define how components should look in different interaction states.
 
 ```dart
-final button = RemixButtonStyler()
+final button = ButtonStyler()
   .paddingX(16)
   .paddingY(10)
   .color(Colors.blue)
@@ -128,7 +128,7 @@ final button = RemixButtonStyler()
 Make your button style smoothly animate when its state changes by chaining `.animate()` with your state-specific styles. You can use `AnimationConfig.spring` to get natural, spring-based motion.
 
 ```dart
-final style = RemixButtonStyler()
+final style = ButtonStyler()
   .paddingX(16)
   .paddingY(10)
   .color(Colors.blue)
@@ -147,7 +147,7 @@ This example animates both the color on hover and the scale on press, creating a
 Create base styles and extend them to build variants:
 
 ```dart
-final baseButtonStyle = RemixButtonStyler()
+final baseButtonStyle = ButtonStyler()
     .paddingX(16)
     .paddingY(10)
     .borderRadiusAll(const Radius.circular(8));
@@ -217,7 +217,7 @@ Fortal styles are built on a robust token system that includes:
 You can use these tokens directly in your custom styles:
 
 ```dart
-final style = RemixButtonStyler()
+final style = ButtonStyler()
   .color(FortalTokens.accent9())
   .paddingAll(FortalTokens.space4())
   .borderRadiusAll(FortalTokens.radius3())

--- a/packages/remix/lib/deprecated.dart
+++ b/packages/remix/lib/deprecated.dart
@@ -1,0 +1,8 @@
+/// Deprecated Remix APIs retained for source compatibility.
+library;
+
+import 'src/components/button/button.dart' show ButtonStyler;
+
+/// Use `ButtonStyler` instead.
+@Deprecated('Use ButtonStyler instead.')
+typedef RemixButtonStyler = ButtonStyler;

--- a/packages/remix/lib/remix.dart
+++ b/packages/remix/lib/remix.dart
@@ -38,3 +38,6 @@ export 'src/utilities/remix_style.dart'
     show RemixBoxStylerAnchors, RemixBoxStylerMixin, RemixBoxStylerConvenience;
 export 'src/utilities/selected_mixin.dart'
     show SelectedWidgetStateVariantExtension;
+
+/// DEPRECATED
+export 'deprecated.dart' show RemixButtonStyler;

--- a/packages/remix/lib/src/components/button/button.g.dart
+++ b/packages/remix/lib/src/components/button/button.g.dart
@@ -6,7 +6,7 @@ part of 'button.dart';
 // SpecGenerator
 // **************************************************************************
 
-mixin _$RemixButtonSpec implements Spec<RemixButtonSpec>, Diagnosticable {
+mixin _$ButtonSpec implements Spec<ButtonSpec>, Diagnosticable {
   StyleSpec<FlexBoxSpec> get container;
   StyleSpec<TextSpec> get label;
   StyleSpec<IconSpec> get icon;
@@ -14,17 +14,17 @@ mixin _$RemixButtonSpec implements Spec<RemixButtonSpec>, Diagnosticable {
   IconAlignment? get iconAlignment;
 
   @override
-  Type get type => RemixButtonSpec;
+  Type get type => ButtonSpec;
 
   @override
-  RemixButtonSpec copyWith({
+  ButtonSpec copyWith({
     StyleSpec<FlexBoxSpec>? container,
     StyleSpec<TextSpec>? label,
     StyleSpec<IconSpec>? icon,
     StyleSpec<RemixSpinnerSpec>? spinner,
     IconAlignment? iconAlignment,
   }) {
-    return RemixButtonSpec(
+    return ButtonSpec(
       container: container ?? this.container,
       label: label ?? this.label,
       icon: icon ?? this.icon,
@@ -34,8 +34,8 @@ mixin _$RemixButtonSpec implements Spec<RemixButtonSpec>, Diagnosticable {
   }
 
   @override
-  RemixButtonSpec lerp(RemixButtonSpec? other, double t) {
-    return RemixButtonSpec(
+  ButtonSpec lerp(ButtonSpec? other, double t) {
+    return ButtonSpec(
       container: container.lerp(other?.container, t),
       label: label.lerp(other?.label, t),
       icon: icon.lerp(other?.icon, t),
@@ -50,7 +50,7 @@ mixin _$RemixButtonSpec implements Spec<RemixButtonSpec>, Diagnosticable {
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
-        other is RemixButtonSpec &&
+        other is ButtonSpec &&
             runtimeType == other.runtimeType &&
             propsEquals(props, other.props);
   }
@@ -96,27 +96,27 @@ mixin _$RemixButtonSpec implements Spec<RemixButtonSpec>, Diagnosticable {
 }
 
 @Deprecated(
-  'Rename to `_\$RemixButtonSpec` and migrate the class declaration to `class RemixButtonSpec with _\$RemixButtonSpec`. The `_\$RemixButtonSpecMethods` alias will be removed in mix_generator 3.0.',
+  'Rename to `_\$ButtonSpec` and migrate the class declaration to `class ButtonSpec with _\$ButtonSpec`. The `_\$ButtonSpecMethods` alias will be removed in mix_generator 3.0.',
 )
-typedef _$RemixButtonSpecMethods = _$RemixButtonSpec; // ignore: unused_element
+typedef _$ButtonSpecMethods = _$ButtonSpec; // ignore: unused_element
 
 // **************************************************************************
 // SpecStylerGenerator
 // **************************************************************************
 
-class RemixButtonStyler extends MixStyler<RemixButtonStyler, RemixButtonSpec>
+class ButtonStyler extends MixStyler<ButtonStyler, ButtonSpec>
     with
-        RemixBoxStylerMixin<RemixButtonStyler>,
-        LabelStyleMixin<RemixButtonStyler>,
-        IconStyleMixin<RemixButtonStyler>,
-        SpinnerStyleMixin<RemixButtonStyler> {
+        RemixBoxStylerMixin<ButtonStyler>,
+        LabelStyleMixin<ButtonStyler>,
+        IconStyleMixin<ButtonStyler>,
+        SpinnerStyleMixin<ButtonStyler> {
   final Prop<StyleSpec<FlexBoxSpec>>? $container;
   final Prop<StyleSpec<TextSpec>>? $label;
   final Prop<StyleSpec<IconSpec>>? $icon;
   final Prop<StyleSpec<RemixSpinnerSpec>>? $spinner;
   final Prop<IconAlignment>? $iconAlignment;
 
-  const RemixButtonStyler.create({
+  const ButtonStyler.create({
     Prop<StyleSpec<FlexBoxSpec>>? container,
     Prop<StyleSpec<TextSpec>>? label,
     Prop<StyleSpec<IconSpec>>? icon,
@@ -131,7 +131,7 @@ class RemixButtonStyler extends MixStyler<RemixButtonStyler, RemixButtonSpec>
        $spinner = spinner,
        $iconAlignment = iconAlignment;
 
-  RemixButtonStyler({
+  ButtonStyler({
     FlexBoxStyler? container,
     TextStyler? label,
     IconStyler? icon,
@@ -139,7 +139,7 @@ class RemixButtonStyler extends MixStyler<RemixButtonStyler, RemixButtonSpec>
     IconAlignment? iconAlignment,
     AnimationConfig? animation,
     WidgetModifierConfig? modifier,
-    List<VariantStyle<RemixButtonSpec>>? variants,
+    List<VariantStyle<ButtonSpec>>? variants,
   }) : this.create(
          container: Prop.maybeMix(container),
          label: Prop.maybeMix(label),
@@ -151,109 +151,100 @@ class RemixButtonStyler extends MixStyler<RemixButtonStyler, RemixButtonSpec>
          animation: animation,
        );
 
-  factory RemixButtonStyler.container(FlexBoxStyler value) =>
-      RemixButtonStyler().container(value);
-  factory RemixButtonStyler.label(TextStyler value) =>
-      RemixButtonStyler().label(value);
-  factory RemixButtonStyler.icon(IconStyler value) =>
-      RemixButtonStyler().icon(value);
-  factory RemixButtonStyler.spinner(RemixSpinnerStyler value) =>
-      RemixButtonStyler().spinner(value);
-  factory RemixButtonStyler.iconAlignment(IconAlignment value) =>
-      RemixButtonStyler().iconAlignment(value);
-  factory RemixButtonStyler.color(Color value) =>
-      RemixButtonStyler().color(value);
-  factory RemixButtonStyler.gradient(GradientMix value) =>
-      RemixButtonStyler().gradient(value);
-  factory RemixButtonStyler.border(BoxBorderMix value) =>
-      RemixButtonStyler().border(value);
-  factory RemixButtonStyler.borderRadius(BorderRadiusGeometryMix value) =>
-      RemixButtonStyler().borderRadius(value);
-  factory RemixButtonStyler.elevation(ElevationShadow value) =>
-      RemixButtonStyler().elevation(value);
-  factory RemixButtonStyler.shadow(BoxShadowMix value) =>
-      RemixButtonStyler().shadow(value);
-  factory RemixButtonStyler.shadows(List<BoxShadowMix> value) =>
-      RemixButtonStyler().shadows(value);
-  factory RemixButtonStyler.width(double value) =>
-      RemixButtonStyler().width(value);
-  factory RemixButtonStyler.height(double value) =>
-      RemixButtonStyler().height(value);
-  factory RemixButtonStyler.size(double width, double height) =>
-      RemixButtonStyler().size(width, height);
-  factory RemixButtonStyler.minWidth(double value) =>
-      RemixButtonStyler().minWidth(value);
-  factory RemixButtonStyler.maxWidth(double value) =>
-      RemixButtonStyler().maxWidth(value);
-  factory RemixButtonStyler.minHeight(double value) =>
-      RemixButtonStyler().minHeight(value);
-  factory RemixButtonStyler.maxHeight(double value) =>
-      RemixButtonStyler().maxHeight(value);
-  factory RemixButtonStyler.scale(
-    double scale, {
-    Alignment alignment = .center,
-  }) => RemixButtonStyler().scale(scale, alignment: alignment);
-  factory RemixButtonStyler.rotate(
+  factory ButtonStyler.container(FlexBoxStyler value) =>
+      ButtonStyler().container(value);
+  factory ButtonStyler.label(TextStyler value) => ButtonStyler().label(value);
+  factory ButtonStyler.icon(IconStyler value) => ButtonStyler().icon(value);
+  factory ButtonStyler.spinner(RemixSpinnerStyler value) =>
+      ButtonStyler().spinner(value);
+  factory ButtonStyler.iconAlignment(IconAlignment value) =>
+      ButtonStyler().iconAlignment(value);
+  factory ButtonStyler.color(Color value) => ButtonStyler().color(value);
+  factory ButtonStyler.gradient(GradientMix value) =>
+      ButtonStyler().gradient(value);
+  factory ButtonStyler.border(BoxBorderMix value) =>
+      ButtonStyler().border(value);
+  factory ButtonStyler.borderRadius(BorderRadiusGeometryMix value) =>
+      ButtonStyler().borderRadius(value);
+  factory ButtonStyler.elevation(ElevationShadow value) =>
+      ButtonStyler().elevation(value);
+  factory ButtonStyler.shadow(BoxShadowMix value) =>
+      ButtonStyler().shadow(value);
+  factory ButtonStyler.shadows(List<BoxShadowMix> value) =>
+      ButtonStyler().shadows(value);
+  factory ButtonStyler.width(double value) => ButtonStyler().width(value);
+  factory ButtonStyler.height(double value) => ButtonStyler().height(value);
+  factory ButtonStyler.size(double width, double height) =>
+      ButtonStyler().size(width, height);
+  factory ButtonStyler.minWidth(double value) => ButtonStyler().minWidth(value);
+  factory ButtonStyler.maxWidth(double value) => ButtonStyler().maxWidth(value);
+  factory ButtonStyler.minHeight(double value) =>
+      ButtonStyler().minHeight(value);
+  factory ButtonStyler.maxHeight(double value) =>
+      ButtonStyler().maxHeight(value);
+  factory ButtonStyler.scale(double scale, {Alignment alignment = .center}) =>
+      ButtonStyler().scale(scale, alignment: alignment);
+  factory ButtonStyler.rotate(
     double radians, {
     Alignment alignment = .center,
-  }) => RemixButtonStyler().rotate(radians, alignment: alignment);
-  factory RemixButtonStyler.translate(double x, double y, [double z = 0.0]) =>
-      RemixButtonStyler().translate(x, y, z);
-  factory RemixButtonStyler.skew(double skewX, double skewY) =>
-      RemixButtonStyler().skew(skewX, skewY);
-  factory RemixButtonStyler.textStyle(TextStyler value) =>
-      RemixButtonStyler().textStyle(value);
-  factory RemixButtonStyler.image(DecorationImageMix value) =>
-      RemixButtonStyler().image(value);
-  factory RemixButtonStyler.shape(ShapeBorderMix value) =>
-      RemixButtonStyler().shape(value);
-  factory RemixButtonStyler.backgroundImage(
+  }) => ButtonStyler().rotate(radians, alignment: alignment);
+  factory ButtonStyler.translate(double x, double y, [double z = 0.0]) =>
+      ButtonStyler().translate(x, y, z);
+  factory ButtonStyler.skew(double skewX, double skewY) =>
+      ButtonStyler().skew(skewX, skewY);
+  factory ButtonStyler.textStyle(TextStyler value) =>
+      ButtonStyler().textStyle(value);
+  factory ButtonStyler.image(DecorationImageMix value) =>
+      ButtonStyler().image(value);
+  factory ButtonStyler.shape(ShapeBorderMix value) =>
+      ButtonStyler().shape(value);
+  factory ButtonStyler.backgroundImage(
     ImageProvider image, {
     BoxFit? fit,
     AlignmentGeometry? alignment,
     ImageRepeat repeat = .noRepeat,
-  }) => RemixButtonStyler().backgroundImage(
+  }) => ButtonStyler().backgroundImage(
     image,
     fit: fit,
     alignment: alignment,
     repeat: repeat,
   );
-  factory RemixButtonStyler.backgroundImageUrl(
+  factory ButtonStyler.backgroundImageUrl(
     String url, {
     BoxFit? fit,
     AlignmentGeometry? alignment,
     ImageRepeat repeat = .noRepeat,
-  }) => RemixButtonStyler().backgroundImageUrl(
+  }) => ButtonStyler().backgroundImageUrl(
     url,
     fit: fit,
     alignment: alignment,
     repeat: repeat,
   );
-  factory RemixButtonStyler.backgroundImageAsset(
+  factory ButtonStyler.backgroundImageAsset(
     String path, {
     BoxFit? fit,
     AlignmentGeometry? alignment,
     ImageRepeat repeat = .noRepeat,
-  }) => RemixButtonStyler().backgroundImageAsset(
+  }) => ButtonStyler().backgroundImageAsset(
     path,
     fit: fit,
     alignment: alignment,
     repeat: repeat,
   );
-  factory RemixButtonStyler.linearGradient({
+  factory ButtonStyler.linearGradient({
     required List<Color> colors,
     List<double>? stops,
     AlignmentGeometry? begin,
     AlignmentGeometry? end,
     TileMode? tileMode,
-  }) => RemixButtonStyler().linearGradient(
+  }) => ButtonStyler().linearGradient(
     colors: colors,
     stops: stops,
     begin: begin,
     end: end,
     tileMode: tileMode,
   );
-  factory RemixButtonStyler.radialGradient({
+  factory ButtonStyler.radialGradient({
     required List<Color> colors,
     List<double>? stops,
     AlignmentGeometry? center,
@@ -261,7 +252,7 @@ class RemixButtonStyler extends MixStyler<RemixButtonStyler, RemixButtonSpec>
     AlignmentGeometry? focal,
     double? focalRadius,
     TileMode? tileMode,
-  }) => RemixButtonStyler().radialGradient(
+  }) => ButtonStyler().radialGradient(
     colors: colors,
     stops: stops,
     center: center,
@@ -270,14 +261,14 @@ class RemixButtonStyler extends MixStyler<RemixButtonStyler, RemixButtonSpec>
     focalRadius: focalRadius,
     tileMode: tileMode,
   );
-  factory RemixButtonStyler.sweepGradient({
+  factory ButtonStyler.sweepGradient({
     required List<Color> colors,
     List<double>? stops,
     AlignmentGeometry? center,
     double? startAngle,
     double? endAngle,
     TileMode? tileMode,
-  }) => RemixButtonStyler().sweepGradient(
+  }) => ButtonStyler().sweepGradient(
     colors: colors,
     stops: stops,
     center: center,
@@ -285,20 +276,20 @@ class RemixButtonStyler extends MixStyler<RemixButtonStyler, RemixButtonSpec>
     endAngle: endAngle,
     tileMode: tileMode,
   );
-  factory RemixButtonStyler.foregroundLinearGradient({
+  factory ButtonStyler.foregroundLinearGradient({
     required List<Color> colors,
     List<double>? stops,
     AlignmentGeometry? begin,
     AlignmentGeometry? end,
     TileMode? tileMode,
-  }) => RemixButtonStyler().foregroundLinearGradient(
+  }) => ButtonStyler().foregroundLinearGradient(
     colors: colors,
     stops: stops,
     begin: begin,
     end: end,
     tileMode: tileMode,
   );
-  factory RemixButtonStyler.foregroundRadialGradient({
+  factory ButtonStyler.foregroundRadialGradient({
     required List<Color> colors,
     List<double>? stops,
     AlignmentGeometry? center,
@@ -306,7 +297,7 @@ class RemixButtonStyler extends MixStyler<RemixButtonStyler, RemixButtonSpec>
     AlignmentGeometry? focal,
     double? focalRadius,
     TileMode? tileMode,
-  }) => RemixButtonStyler().foregroundRadialGradient(
+  }) => ButtonStyler().foregroundRadialGradient(
     colors: colors,
     stops: stops,
     center: center,
@@ -315,14 +306,14 @@ class RemixButtonStyler extends MixStyler<RemixButtonStyler, RemixButtonSpec>
     focalRadius: focalRadius,
     tileMode: tileMode,
   );
-  factory RemixButtonStyler.foregroundSweepGradient({
+  factory ButtonStyler.foregroundSweepGradient({
     required List<Color> colors,
     List<double>? stops,
     AlignmentGeometry? center,
     double? startAngle,
     double? endAngle,
     TileMode? tileMode,
-  }) => RemixButtonStyler().foregroundSweepGradient(
+  }) => ButtonStyler().foregroundSweepGradient(
     colors: colors,
     stops: stops,
     center: center,
@@ -330,128 +321,126 @@ class RemixButtonStyler extends MixStyler<RemixButtonStyler, RemixButtonSpec>
     endAngle: endAngle,
     tileMode: tileMode,
   );
-  factory RemixButtonStyler.row() => RemixButtonStyler().row();
-  factory RemixButtonStyler.column() => RemixButtonStyler().column();
-  factory RemixButtonStyler.alignment(AlignmentGeometry value) =>
-      RemixButtonStyler().alignment(value);
-  factory RemixButtonStyler.padding(EdgeInsetsGeometryMix value) =>
-      RemixButtonStyler().padding(value);
-  factory RemixButtonStyler.margin(EdgeInsetsGeometryMix value) =>
-      RemixButtonStyler().margin(value);
-  factory RemixButtonStyler.constraints(BoxConstraintsMix value) =>
-      RemixButtonStyler().constraints(value);
-  factory RemixButtonStyler.decoration(DecorationMix value) =>
-      RemixButtonStyler().decoration(value);
-  factory RemixButtonStyler.foregroundDecoration(DecorationMix value) =>
-      RemixButtonStyler().foregroundDecoration(value);
-  factory RemixButtonStyler.clipBehavior(Clip value) =>
-      RemixButtonStyler().clipBehavior(value);
-  factory RemixButtonStyler.direction(Axis value) =>
-      RemixButtonStyler().direction(value);
-  factory RemixButtonStyler.mainAxisAlignment(MainAxisAlignment value) =>
-      RemixButtonStyler().mainAxisAlignment(value);
-  factory RemixButtonStyler.crossAxisAlignment(CrossAxisAlignment value) =>
-      RemixButtonStyler().crossAxisAlignment(value);
-  factory RemixButtonStyler.mainAxisSize(MainAxisSize value) =>
-      RemixButtonStyler().mainAxisSize(value);
-  factory RemixButtonStyler.spacing(double value) =>
-      RemixButtonStyler().spacing(value);
-  factory RemixButtonStyler.verticalDirection(VerticalDirection value) =>
-      RemixButtonStyler().verticalDirection(value);
-  factory RemixButtonStyler.textDirection(TextDirection value) =>
-      RemixButtonStyler().textDirection(value);
-  factory RemixButtonStyler.textBaseline(TextBaseline value) =>
-      RemixButtonStyler().textBaseline(value);
-  factory RemixButtonStyler.transform(
+  factory ButtonStyler.row() => ButtonStyler().row();
+  factory ButtonStyler.column() => ButtonStyler().column();
+  factory ButtonStyler.alignment(AlignmentGeometry value) =>
+      ButtonStyler().alignment(value);
+  factory ButtonStyler.padding(EdgeInsetsGeometryMix value) =>
+      ButtonStyler().padding(value);
+  factory ButtonStyler.margin(EdgeInsetsGeometryMix value) =>
+      ButtonStyler().margin(value);
+  factory ButtonStyler.constraints(BoxConstraintsMix value) =>
+      ButtonStyler().constraints(value);
+  factory ButtonStyler.decoration(DecorationMix value) =>
+      ButtonStyler().decoration(value);
+  factory ButtonStyler.foregroundDecoration(DecorationMix value) =>
+      ButtonStyler().foregroundDecoration(value);
+  factory ButtonStyler.clipBehavior(Clip value) =>
+      ButtonStyler().clipBehavior(value);
+  factory ButtonStyler.direction(Axis value) => ButtonStyler().direction(value);
+  factory ButtonStyler.mainAxisAlignment(MainAxisAlignment value) =>
+      ButtonStyler().mainAxisAlignment(value);
+  factory ButtonStyler.crossAxisAlignment(CrossAxisAlignment value) =>
+      ButtonStyler().crossAxisAlignment(value);
+  factory ButtonStyler.mainAxisSize(MainAxisSize value) =>
+      ButtonStyler().mainAxisSize(value);
+  factory ButtonStyler.spacing(double value) => ButtonStyler().spacing(value);
+  factory ButtonStyler.verticalDirection(VerticalDirection value) =>
+      ButtonStyler().verticalDirection(value);
+  factory ButtonStyler.textDirection(TextDirection value) =>
+      ButtonStyler().textDirection(value);
+  factory ButtonStyler.textBaseline(TextBaseline value) =>
+      ButtonStyler().textBaseline(value);
+  factory ButtonStyler.transform(
     Matrix4 value, {
     Alignment alignment = .center,
-  }) => RemixButtonStyler().transform(value, alignment: alignment);
+  }) => ButtonStyler().transform(value, alignment: alignment);
 
-  RemixButtonStyler color(Color value) {
+  ButtonStyler color(Color value) {
     return container(FlexBoxStyler().color(value));
   }
 
-  RemixButtonStyler gradient(GradientMix value) {
+  ButtonStyler gradient(GradientMix value) {
     return container(FlexBoxStyler().gradient(value));
   }
 
-  RemixButtonStyler border(BoxBorderMix value) {
+  ButtonStyler border(BoxBorderMix value) {
     return container(FlexBoxStyler().border(value));
   }
 
-  RemixButtonStyler borderRadius(BorderRadiusGeometryMix value) {
+  ButtonStyler borderRadius(BorderRadiusGeometryMix value) {
     return container(FlexBoxStyler().borderRadius(value));
   }
 
-  RemixButtonStyler elevation(ElevationShadow value) {
+  ButtonStyler elevation(ElevationShadow value) {
     return container(FlexBoxStyler().elevation(value));
   }
 
-  RemixButtonStyler shadow(BoxShadowMix value) {
+  ButtonStyler shadow(BoxShadowMix value) {
     return container(FlexBoxStyler().shadow(value));
   }
 
-  RemixButtonStyler shadows(List<BoxShadowMix> value) {
+  ButtonStyler shadows(List<BoxShadowMix> value) {
     return container(FlexBoxStyler().shadows(value));
   }
 
-  RemixButtonStyler width(double value) {
+  ButtonStyler width(double value) {
     return container(FlexBoxStyler().width(value));
   }
 
-  RemixButtonStyler height(double value) {
+  ButtonStyler height(double value) {
     return container(FlexBoxStyler().height(value));
   }
 
-  RemixButtonStyler size(double width, double height) {
+  ButtonStyler size(double width, double height) {
     return container(FlexBoxStyler().size(width, height));
   }
 
-  RemixButtonStyler minWidth(double value) {
+  ButtonStyler minWidth(double value) {
     return container(FlexBoxStyler().minWidth(value));
   }
 
-  RemixButtonStyler maxWidth(double value) {
+  ButtonStyler maxWidth(double value) {
     return container(FlexBoxStyler().maxWidth(value));
   }
 
-  RemixButtonStyler minHeight(double value) {
+  ButtonStyler minHeight(double value) {
     return container(FlexBoxStyler().minHeight(value));
   }
 
-  RemixButtonStyler maxHeight(double value) {
+  ButtonStyler maxHeight(double value) {
     return container(FlexBoxStyler().maxHeight(value));
   }
 
-  RemixButtonStyler scale(double scale, {Alignment alignment = .center}) {
+  ButtonStyler scale(double scale, {Alignment alignment = .center}) {
     return container(FlexBoxStyler().scale(scale, alignment: alignment));
   }
 
-  RemixButtonStyler rotate(double radians, {Alignment alignment = .center}) {
+  ButtonStyler rotate(double radians, {Alignment alignment = .center}) {
     return container(FlexBoxStyler().rotate(radians, alignment: alignment));
   }
 
-  RemixButtonStyler translate(double x, double y, [double z = 0.0]) {
+  ButtonStyler translate(double x, double y, [double z = 0.0]) {
     return container(FlexBoxStyler().translate(x, y, z));
   }
 
-  RemixButtonStyler skew(double skewX, double skewY) {
+  ButtonStyler skew(double skewX, double skewY) {
     return container(FlexBoxStyler().skew(skewX, skewY));
   }
 
-  RemixButtonStyler textStyle(TextStyler value) {
+  ButtonStyler textStyle(TextStyler value) {
     return container(FlexBoxStyler().textStyle(value));
   }
 
-  RemixButtonStyler image(DecorationImageMix value) {
+  ButtonStyler image(DecorationImageMix value) {
     return container(FlexBoxStyler().image(value));
   }
 
-  RemixButtonStyler shape(ShapeBorderMix value) {
+  ButtonStyler shape(ShapeBorderMix value) {
     return container(FlexBoxStyler().shape(value));
   }
 
-  RemixButtonStyler backgroundImage(
+  ButtonStyler backgroundImage(
     ImageProvider image, {
     BoxFit? fit,
     AlignmentGeometry? alignment,
@@ -467,7 +456,7 @@ class RemixButtonStyler extends MixStyler<RemixButtonStyler, RemixButtonSpec>
     );
   }
 
-  RemixButtonStyler backgroundImageUrl(
+  ButtonStyler backgroundImageUrl(
     String url, {
     BoxFit? fit,
     AlignmentGeometry? alignment,
@@ -483,7 +472,7 @@ class RemixButtonStyler extends MixStyler<RemixButtonStyler, RemixButtonSpec>
     );
   }
 
-  RemixButtonStyler backgroundImageAsset(
+  ButtonStyler backgroundImageAsset(
     String path, {
     BoxFit? fit,
     AlignmentGeometry? alignment,
@@ -499,7 +488,7 @@ class RemixButtonStyler extends MixStyler<RemixButtonStyler, RemixButtonSpec>
     );
   }
 
-  RemixButtonStyler linearGradient({
+  ButtonStyler linearGradient({
     required List<Color> colors,
     List<double>? stops,
     AlignmentGeometry? begin,
@@ -517,7 +506,7 @@ class RemixButtonStyler extends MixStyler<RemixButtonStyler, RemixButtonSpec>
     );
   }
 
-  RemixButtonStyler radialGradient({
+  ButtonStyler radialGradient({
     required List<Color> colors,
     List<double>? stops,
     AlignmentGeometry? center,
@@ -539,7 +528,7 @@ class RemixButtonStyler extends MixStyler<RemixButtonStyler, RemixButtonSpec>
     );
   }
 
-  RemixButtonStyler sweepGradient({
+  ButtonStyler sweepGradient({
     required List<Color> colors,
     List<double>? stops,
     AlignmentGeometry? center,
@@ -559,7 +548,7 @@ class RemixButtonStyler extends MixStyler<RemixButtonStyler, RemixButtonSpec>
     );
   }
 
-  RemixButtonStyler foregroundLinearGradient({
+  ButtonStyler foregroundLinearGradient({
     required List<Color> colors,
     List<double>? stops,
     AlignmentGeometry? begin,
@@ -577,7 +566,7 @@ class RemixButtonStyler extends MixStyler<RemixButtonStyler, RemixButtonSpec>
     );
   }
 
-  RemixButtonStyler foregroundRadialGradient({
+  ButtonStyler foregroundRadialGradient({
     required List<Color> colors,
     List<double>? stops,
     AlignmentGeometry? center,
@@ -599,7 +588,7 @@ class RemixButtonStyler extends MixStyler<RemixButtonStyler, RemixButtonSpec>
     );
   }
 
-  RemixButtonStyler foregroundSweepGradient({
+  ButtonStyler foregroundSweepGradient({
     required List<Color> colors,
     List<double>? stops,
     AlignmentGeometry? center,
@@ -619,133 +608,133 @@ class RemixButtonStyler extends MixStyler<RemixButtonStyler, RemixButtonSpec>
     );
   }
 
-  RemixButtonStyler row() {
+  ButtonStyler row() {
     return container(FlexBoxStyler().row());
   }
 
-  RemixButtonStyler column() {
+  ButtonStyler column() {
     return container(FlexBoxStyler().column());
   }
 
-  RemixButtonStyler alignment(AlignmentGeometry value) {
+  ButtonStyler alignment(AlignmentGeometry value) {
     return container(FlexBoxStyler().alignment(value));
   }
 
-  RemixButtonStyler padding(EdgeInsetsGeometryMix value) {
+  ButtonStyler padding(EdgeInsetsGeometryMix value) {
     return container(FlexBoxStyler().padding(value));
   }
 
-  RemixButtonStyler margin(EdgeInsetsGeometryMix value) {
+  ButtonStyler margin(EdgeInsetsGeometryMix value) {
     return container(FlexBoxStyler().margin(value));
   }
 
-  RemixButtonStyler constraints(BoxConstraintsMix value) {
+  ButtonStyler constraints(BoxConstraintsMix value) {
     return container(FlexBoxStyler().constraints(value));
   }
 
-  RemixButtonStyler decoration(DecorationMix value) {
+  ButtonStyler decoration(DecorationMix value) {
     return container(FlexBoxStyler().decoration(value));
   }
 
-  RemixButtonStyler foregroundDecoration(DecorationMix value) {
+  ButtonStyler foregroundDecoration(DecorationMix value) {
     return container(FlexBoxStyler().foregroundDecoration(value));
   }
 
-  RemixButtonStyler clipBehavior(Clip value) {
+  ButtonStyler clipBehavior(Clip value) {
     return container(FlexBoxStyler().clipBehavior(value));
   }
 
-  RemixButtonStyler direction(Axis value) {
+  ButtonStyler direction(Axis value) {
     return container(FlexBoxStyler().direction(value));
   }
 
-  RemixButtonStyler mainAxisAlignment(MainAxisAlignment value) {
+  ButtonStyler mainAxisAlignment(MainAxisAlignment value) {
     return container(FlexBoxStyler().mainAxisAlignment(value));
   }
 
-  RemixButtonStyler crossAxisAlignment(CrossAxisAlignment value) {
+  ButtonStyler crossAxisAlignment(CrossAxisAlignment value) {
     return container(FlexBoxStyler().crossAxisAlignment(value));
   }
 
-  RemixButtonStyler mainAxisSize(MainAxisSize value) {
+  ButtonStyler mainAxisSize(MainAxisSize value) {
     return container(FlexBoxStyler().mainAxisSize(value));
   }
 
-  RemixButtonStyler spacing(double value) {
+  ButtonStyler spacing(double value) {
     return container(FlexBoxStyler().spacing(value));
   }
 
-  RemixButtonStyler verticalDirection(VerticalDirection value) {
+  ButtonStyler verticalDirection(VerticalDirection value) {
     return container(FlexBoxStyler().verticalDirection(value));
   }
 
-  RemixButtonStyler textDirection(TextDirection value) {
+  ButtonStyler textDirection(TextDirection value) {
     return container(FlexBoxStyler().textDirection(value));
   }
 
-  RemixButtonStyler textBaseline(TextBaseline value) {
+  ButtonStyler textBaseline(TextBaseline value) {
     return container(FlexBoxStyler().textBaseline(value));
   }
 
-  RemixButtonStyler transform(Matrix4 value, {Alignment alignment = .center}) {
+  ButtonStyler transform(Matrix4 value, {Alignment alignment = .center}) {
     return container(FlexBoxStyler().transform(value, alignment: alignment));
   }
 
   /// Sets the container.
-  RemixButtonStyler container(FlexBoxStyler value) {
-    return merge(RemixButtonStyler(container: value));
+  ButtonStyler container(FlexBoxStyler value) {
+    return merge(ButtonStyler(container: value));
   }
 
   /// Sets the label.
   @override
-  RemixButtonStyler label(TextStyler value) {
-    return merge(RemixButtonStyler(label: value));
+  ButtonStyler label(TextStyler value) {
+    return merge(ButtonStyler(label: value));
   }
 
   /// Sets the icon.
   @override
-  RemixButtonStyler icon(IconStyler value) {
-    return merge(RemixButtonStyler(icon: value));
+  ButtonStyler icon(IconStyler value) {
+    return merge(ButtonStyler(icon: value));
   }
 
   /// Sets the spinner.
   @override
-  RemixButtonStyler spinner(RemixSpinnerStyler value) {
-    return merge(RemixButtonStyler(spinner: value));
+  ButtonStyler spinner(RemixSpinnerStyler value) {
+    return merge(ButtonStyler(spinner: value));
   }
 
   /// Sets the iconAlignment.
-  RemixButtonStyler iconAlignment(IconAlignment value) {
-    return merge(RemixButtonStyler(iconAlignment: value));
+  ButtonStyler iconAlignment(IconAlignment value) {
+    return merge(ButtonStyler(iconAlignment: value));
   }
 
   /// Sets the animation configuration.
   @override
-  RemixButtonStyler animate(AnimationConfig value) {
-    return merge(RemixButtonStyler(animation: value));
+  ButtonStyler animate(AnimationConfig value) {
+    return merge(ButtonStyler(animation: value));
   }
 
   /// Sets the style variants.
   @override
-  RemixButtonStyler variants(List<VariantStyle<RemixButtonSpec>> value) {
-    return merge(RemixButtonStyler(variants: value));
+  ButtonStyler variants(List<VariantStyle<ButtonSpec>> value) {
+    return merge(ButtonStyler(variants: value));
   }
 
   /// Wraps with a widget modifier.
   @override
-  RemixButtonStyler wrap(WidgetModifierConfig value) {
-    return merge(RemixButtonStyler(modifier: value));
+  ButtonStyler wrap(WidgetModifierConfig value) {
+    return merge(ButtonStyler(modifier: value));
   }
 
   /// Sets the widget modifier.
-  RemixButtonStyler modifier(WidgetModifierConfig value) {
-    return merge(RemixButtonStyler(modifier: value));
+  ButtonStyler modifier(WidgetModifierConfig value) {
+    return merge(ButtonStyler(modifier: value));
   }
 
-  /// Merges with another [RemixButtonStyler].
+  /// Merges with another [ButtonStyler].
   @override
-  RemixButtonStyler merge(RemixButtonStyler? other) {
-    return RemixButtonStyler.create(
+  ButtonStyler merge(ButtonStyler? other) {
+    return ButtonStyler.create(
       container: MixOps.merge($container, other?.$container),
       label: MixOps.merge($label, other?.$label),
       icon: MixOps.merge($icon, other?.$icon),
@@ -757,10 +746,10 @@ class RemixButtonStyler extends MixStyler<RemixButtonStyler, RemixButtonSpec>
     );
   }
 
-  /// Resolves to [StyleSpec<RemixButtonSpec>] using [context].
+  /// Resolves to [StyleSpec<ButtonSpec>] using [context].
   @override
-  StyleSpec<RemixButtonSpec> resolve(BuildContext context) {
-    final spec = RemixButtonSpec(
+  StyleSpec<ButtonSpec> resolve(BuildContext context) {
+    final spec = ButtonSpec(
       container: MixOps.resolve(context, $container),
       label: MixOps.resolve(context, $label),
       icon: MixOps.resolve(context, $icon),

--- a/packages/remix/lib/src/components/button/button_spec.dart
+++ b/packages/remix/lib/src/components/button/button_spec.dart
@@ -2,23 +2,23 @@ part of 'button.dart';
 
 /// Defines the structure and styling properties for a button component.
 ///
-/// RemixButtonSpec is the resolved specification that describes how a button
+/// ButtonSpec is the resolved specification that describes how a button
 /// should be styled and structured. It follows the Spec pattern used
 /// throughout the Remix framework, where:
 ///
-/// 1. **Style classes** (like [RemixButtonStyler]) define styling APIs
-/// 2. **Spec classes** (like [RemixButtonSpec]) hold resolved styling properties
+/// 1. **Style classes** (like [ButtonStyler]) define styling APIs
+/// 2. **Spec classes** (like [ButtonSpec]) hold resolved styling properties
 /// 3. **Widget classes** (like [RemixButton]) consume specs to render UI
 ///
-/// The RemixButtonSpec contains [StyleSpec] properties for each visual element
+/// The ButtonSpec contains [StyleSpec] properties for each visual element
 /// of the button: container layout, text label, icon, and loading spinner.
-/// These properties are built by [RemixButtonStyler] and consumed by
+/// These properties are built by [ButtonStyler] and consumed by
 /// [RemixButton] to create the final rendered widget.
 ///
 /// ## Architecture Overview
 ///
 /// ```
-/// RemixButtonStyler -> RemixButtonSpec -> RemixButton Widget
+/// ButtonStyler -> ButtonSpec -> RemixButton Widget
 /// (Define styles)    (Hold props)   (Render UI)
 /// ```
 ///
@@ -29,7 +29,7 @@ part of 'button.dart';
 ///
 /// ```dart
 /// // Style creates and populates the spec
-/// final style = RemixButtonStyler()
+/// final style = ButtonStyler()
 ///   .backgroundColor(Colors.blue)
 ///   .foregroundColor(Colors.white)
 ///   .iconSize(20.0);
@@ -51,7 +51,7 @@ part of 'button.dart';
 /// - [spinner]: Loading spinner styling during async operations
 ///
 /// See also:
-/// - [RemixButtonStyler] for the styling API
+/// - [ButtonStyler] for the styling API
 /// - [RemixButton] for the widget implementation
 /// - [Spec] for the base specification pattern
 @MixableSpec(
@@ -62,7 +62,7 @@ part of 'button.dart';
     SpinnerStyleMixin,
   ],
 )
-class RemixButtonSpec with _$RemixButtonSpec {
+class ButtonSpec with _$ButtonSpec {
   /// Styling specification for the button's container.
   ///
   /// Controls the button's layout, background, borders, padding,
@@ -103,7 +103,7 @@ class RemixButtonSpec with _$RemixButtonSpec {
   @override
   final IconAlignment? iconAlignment;
 
-  /// Creates a RemixButtonSpec with optional styling specifications.
+  /// Creates a ButtonSpec with optional styling specifications.
   ///
   /// If any [StyleSpec] is not provided, a default specification
   /// with empty styling is used. This ensures all properties are
@@ -111,12 +111,12 @@ class RemixButtonSpec with _$RemixButtonSpec {
   ///
   /// Example:
   /// ```dart
-  /// const spec = RemixButtonSpec(
+  /// const spec = ButtonSpec(
   ///   container: StyleSpec(spec: FlexBoxSpec()),
   ///   label: StyleSpec(spec: TextSpec()),
   /// );
   /// ```
-  const RemixButtonSpec({
+  const ButtonSpec({
     StyleSpec<FlexBoxSpec>? container,
     StyleSpec<TextSpec>? label,
     StyleSpec<IconSpec>? icon,
@@ -128,3 +128,9 @@ class RemixButtonSpec with _$RemixButtonSpec {
        spinner = spinner ?? const StyleSpec(spec: RemixSpinnerSpec()),
        iconAlignment = iconAlignment;
 }
+
+/// Backward-compatible name for [ButtonSpec].
+///
+/// The generated button style API is based on [ButtonSpec], so resolved
+/// values use `ButtonSpec` as their runtime type.
+typedef RemixButtonSpec = ButtonSpec;

--- a/packages/remix/lib/src/components/button/button_style.dart
+++ b/packages/remix/lib/src/components/button/button_style.dart
@@ -5,7 +5,7 @@ part of 'button.dart';
 /// Use this class to style the button container, label, icons, and loading
 /// spinner. It supports Mix variants and widget state variants for focused,
 /// hovered, pressed, disabled, and loading states.
-extension ButtonStylerRemixHelpers on ButtonStyler {
+extension RemixButtonStylerRemixHelpers on ButtonStyler {
   /// Creates a [RemixButton] widget with this style applied.
   RemixButton call({
     Key? key,

--- a/packages/remix/lib/src/components/button/button_style.dart
+++ b/packages/remix/lib/src/components/button/button_style.dart
@@ -5,7 +5,7 @@ part of 'button.dart';
 /// Use this class to style the button container, label, icons, and loading
 /// spinner. It supports Mix variants and widget state variants for focused,
 /// hovered, pressed, disabled, and loading states.
-extension RemixButtonStylerRemixHelpers on RemixButtonStyler {
+extension ButtonStylerRemixHelpers on ButtonStyler {
   /// Creates a [RemixButton] widget with this style applied.
   RemixButton call({
     Key? key,
@@ -53,44 +53,44 @@ extension RemixButtonStylerRemixHelpers on RemixButtonStyler {
   }
 }
 
-extension RemixButtonStyleContainerHelpers on RemixButtonStyler {
-  RemixButtonStyler paddingTop(double value) {
+extension RemixButtonStyleContainerHelpers on ButtonStyler {
+  ButtonStyler paddingTop(double value) {
     return padding(EdgeInsetsGeometryMix.top(value));
   }
 
-  RemixButtonStyler paddingBottom(double value) {
+  ButtonStyler paddingBottom(double value) {
     return padding(EdgeInsetsGeometryMix.bottom(value));
   }
 
-  RemixButtonStyler paddingLeft(double value) {
+  ButtonStyler paddingLeft(double value) {
     return padding(EdgeInsetsGeometryMix.left(value));
   }
 
-  RemixButtonStyler paddingRight(double value) {
+  ButtonStyler paddingRight(double value) {
     return padding(EdgeInsetsGeometryMix.right(value));
   }
 
-  RemixButtonStyler paddingX(double value) {
+  ButtonStyler paddingX(double value) {
     return padding(EdgeInsetsGeometryMix.horizontal(value));
   }
 
-  RemixButtonStyler paddingY(double value) {
+  ButtonStyler paddingY(double value) {
     return padding(EdgeInsetsGeometryMix.vertical(value));
   }
 
-  RemixButtonStyler paddingAll(double value) {
+  ButtonStyler paddingAll(double value) {
     return padding(EdgeInsetsGeometryMix.all(value));
   }
 
-  RemixButtonStyler paddingStart(double value) {
+  ButtonStyler paddingStart(double value) {
     return padding(EdgeInsetsGeometryMix.start(value));
   }
 
-  RemixButtonStyler paddingEnd(double value) {
+  ButtonStyler paddingEnd(double value) {
     return padding(EdgeInsetsGeometryMix.end(value));
   }
 
-  RemixButtonStyler paddingOnly({
+  ButtonStyler paddingOnly({
     double? horizontal,
     double? vertical,
     double? start,
@@ -121,43 +121,43 @@ extension RemixButtonStyleContainerHelpers on RemixButtonStyler {
     );
   }
 
-  RemixButtonStyler marginTop(double value) {
+  ButtonStyler marginTop(double value) {
     return margin(EdgeInsetsGeometryMix.top(value));
   }
 
-  RemixButtonStyler marginBottom(double value) {
+  ButtonStyler marginBottom(double value) {
     return margin(EdgeInsetsGeometryMix.bottom(value));
   }
 
-  RemixButtonStyler marginLeft(double value) {
+  ButtonStyler marginLeft(double value) {
     return margin(EdgeInsetsGeometryMix.left(value));
   }
 
-  RemixButtonStyler marginRight(double value) {
+  ButtonStyler marginRight(double value) {
     return margin(EdgeInsetsGeometryMix.right(value));
   }
 
-  RemixButtonStyler marginX(double value) {
+  ButtonStyler marginX(double value) {
     return margin(EdgeInsetsGeometryMix.horizontal(value));
   }
 
-  RemixButtonStyler marginY(double value) {
+  ButtonStyler marginY(double value) {
     return margin(EdgeInsetsGeometryMix.vertical(value));
   }
 
-  RemixButtonStyler marginAll(double value) {
+  ButtonStyler marginAll(double value) {
     return margin(EdgeInsetsGeometryMix.all(value));
   }
 
-  RemixButtonStyler marginStart(double value) {
+  ButtonStyler marginStart(double value) {
     return margin(EdgeInsetsGeometryMix.start(value));
   }
 
-  RemixButtonStyler marginEnd(double value) {
+  ButtonStyler marginEnd(double value) {
     return margin(EdgeInsetsGeometryMix.end(value));
   }
 
-  RemixButtonStyler marginOnly({
+  ButtonStyler marginOnly({
     double? horizontal,
     double? vertical,
     double? start,
@@ -188,7 +188,7 @@ extension RemixButtonStyleContainerHelpers on RemixButtonStyler {
     );
   }
 
-  RemixButtonStyler constraintsOnly({
+  ButtonStyler constraintsOnly({
     double? width,
     double? height,
     double? minWidth,
@@ -206,11 +206,11 @@ extension RemixButtonStyleContainerHelpers on RemixButtonStyler {
     );
   }
 
-  RemixButtonStyler minimumSize(Size value) {
+  ButtonStyler minimumSize(Size value) {
     return constraintsOnly(minWidth: value.width, minHeight: value.height);
   }
 
-  RemixButtonStyler fixedSize(Size value) {
+  ButtonStyler fixedSize(Size value) {
     return constraintsOnly(
       minWidth: value.width,
       maxWidth: value.width,
@@ -219,38 +219,35 @@ extension RemixButtonStyleContainerHelpers on RemixButtonStyler {
     );
   }
 
-  RemixButtonStyler maximumSize(Size value) {
+  ButtonStyler maximumSize(Size value) {
     return constraintsOnly(maxWidth: value.width, maxHeight: value.height);
   }
 
-  RemixButtonStyler flex(FlexStyler value) {
+  ButtonStyler flex(FlexStyler value) {
     return container(FlexBoxStyler().flex(value));
   }
 
   /// Rotates the complete button with a widget modifier.
   ///
-  /// Use [RemixButtonStyler.rotate] for the generated container transform
+  /// Use [ButtonStyler.rotate] for the generated container transform
   /// shortcut.
-  RemixButtonStyler modifierRotate(
-    double radians, {
-    Alignment alignment = .center,
-  }) {
+  ButtonStyler modifierRotate(double radians, {Alignment alignment = .center}) {
     return wrap(.rotate(radians: radians, alignment: alignment));
   }
 
-  RemixButtonStyler transformReset() {
+  ButtonStyler transformReset() {
     return transform(Matrix4.identity());
   }
 }
 
-extension RemixButtonStyleDecorationHelpers on RemixButtonStyler {
-  RemixButtonStyler backgroundColor(Color value) => color(value);
+extension RemixButtonStyleDecorationHelpers on ButtonStyler {
+  ButtonStyler backgroundColor(Color value) => color(value);
 
-  RemixButtonStyler foregroundColor(Color value) {
+  ButtonStyler foregroundColor(Color value) {
     return label(.color(value)).icon(.color(value));
   }
 
-  RemixButtonStyler borderTop({
+  ButtonStyler borderTop({
     Color? color,
     double? width,
     BorderStyle? style,
@@ -266,7 +263,7 @@ extension RemixButtonStyleDecorationHelpers on RemixButtonStyler {
     );
   }
 
-  RemixButtonStyler borderBottom({
+  ButtonStyler borderBottom({
     Color? color,
     double? width,
     BorderStyle? style,
@@ -282,7 +279,7 @@ extension RemixButtonStyleDecorationHelpers on RemixButtonStyler {
     );
   }
 
-  RemixButtonStyler borderLeft({
+  ButtonStyler borderLeft({
     Color? color,
     double? width,
     BorderStyle? style,
@@ -298,7 +295,7 @@ extension RemixButtonStyleDecorationHelpers on RemixButtonStyler {
     );
   }
 
-  RemixButtonStyler borderRight({
+  ButtonStyler borderRight({
     Color? color,
     double? width,
     BorderStyle? style,
@@ -314,7 +311,7 @@ extension RemixButtonStyleDecorationHelpers on RemixButtonStyler {
     );
   }
 
-  RemixButtonStyler borderStart({
+  ButtonStyler borderStart({
     Color? color,
     double? width,
     BorderStyle? style,
@@ -330,7 +327,7 @@ extension RemixButtonStyleDecorationHelpers on RemixButtonStyler {
     );
   }
 
-  RemixButtonStyler borderEnd({
+  ButtonStyler borderEnd({
     Color? color,
     double? width,
     BorderStyle? style,
@@ -346,7 +343,7 @@ extension RemixButtonStyleDecorationHelpers on RemixButtonStyler {
     );
   }
 
-  RemixButtonStyler borderVertical({
+  ButtonStyler borderVertical({
     Color? color,
     double? width,
     BorderStyle? style,
@@ -362,7 +359,7 @@ extension RemixButtonStyleDecorationHelpers on RemixButtonStyler {
     );
   }
 
-  RemixButtonStyler borderHorizontal({
+  ButtonStyler borderHorizontal({
     Color? color,
     double? width,
     BorderStyle? style,
@@ -378,7 +375,7 @@ extension RemixButtonStyleDecorationHelpers on RemixButtonStyler {
     );
   }
 
-  RemixButtonStyler borderAll({
+  ButtonStyler borderAll({
     Color? color,
     double? width,
     BorderStyle? style,
@@ -396,111 +393,111 @@ extension RemixButtonStyleDecorationHelpers on RemixButtonStyler {
     );
   }
 
-  RemixButtonStyler borderRadiusAll(Radius radius) {
+  ButtonStyler borderRadiusAll(Radius radius) {
     return borderRadius(BorderRadiusGeometryMix.all(radius));
   }
 
-  RemixButtonStyler borderRadiusTop(Radius radius) {
+  ButtonStyler borderRadiusTop(Radius radius) {
     return borderRadius(BorderRadiusGeometryMix.top(radius));
   }
 
-  RemixButtonStyler borderRadiusBottom(Radius radius) {
+  ButtonStyler borderRadiusBottom(Radius radius) {
     return borderRadius(BorderRadiusGeometryMix.bottom(radius));
   }
 
-  RemixButtonStyler borderRadiusLeft(Radius radius) {
+  ButtonStyler borderRadiusLeft(Radius radius) {
     return borderRadius(BorderRadiusGeometryMix.left(radius));
   }
 
-  RemixButtonStyler borderRadiusRight(Radius radius) {
+  ButtonStyler borderRadiusRight(Radius radius) {
     return borderRadius(BorderRadiusGeometryMix.right(radius));
   }
 
-  RemixButtonStyler borderRadiusTopLeft(Radius radius) {
+  ButtonStyler borderRadiusTopLeft(Radius radius) {
     return borderRadius(BorderRadiusGeometryMix.topLeft(radius));
   }
 
-  RemixButtonStyler borderRadiusTopRight(Radius radius) {
+  ButtonStyler borderRadiusTopRight(Radius radius) {
     return borderRadius(BorderRadiusGeometryMix.topRight(radius));
   }
 
-  RemixButtonStyler borderRadiusBottomLeft(Radius radius) {
+  ButtonStyler borderRadiusBottomLeft(Radius radius) {
     return borderRadius(BorderRadiusGeometryMix.bottomLeft(radius));
   }
 
-  RemixButtonStyler borderRadiusBottomRight(Radius radius) {
+  ButtonStyler borderRadiusBottomRight(Radius radius) {
     return borderRadius(BorderRadiusGeometryMix.bottomRight(radius));
   }
 
-  RemixButtonStyler borderRadiusTopStart(Radius radius) {
+  ButtonStyler borderRadiusTopStart(Radius radius) {
     return borderRadius(BorderRadiusGeometryMix.topStart(radius));
   }
 
-  RemixButtonStyler borderRadiusTopEnd(Radius radius) {
+  ButtonStyler borderRadiusTopEnd(Radius radius) {
     return borderRadius(BorderRadiusGeometryMix.topEnd(radius));
   }
 
-  RemixButtonStyler borderRadiusBottomStart(Radius radius) {
+  ButtonStyler borderRadiusBottomStart(Radius radius) {
     return borderRadius(BorderRadiusGeometryMix.bottomStart(radius));
   }
 
-  RemixButtonStyler borderRadiusBottomEnd(Radius radius) {
+  ButtonStyler borderRadiusBottomEnd(Radius radius) {
     return borderRadius(BorderRadiusGeometryMix.bottomEnd(radius));
   }
 
-  RemixButtonStyler borderRounded(double radius) {
+  ButtonStyler borderRounded(double radius) {
     return borderRadius(BorderRadiusGeometryMix.circular(radius));
   }
 
-  RemixButtonStyler borderRoundedTop(double radius) {
+  ButtonStyler borderRoundedTop(double radius) {
     return borderRadius(BorderRadiusGeometryMix.top(.circular(radius)));
   }
 
-  RemixButtonStyler borderRoundedBottom(double radius) {
+  ButtonStyler borderRoundedBottom(double radius) {
     return borderRadius(BorderRadiusGeometryMix.bottom(.circular(radius)));
   }
 
-  RemixButtonStyler borderRoundedLeft(double radius) {
+  ButtonStyler borderRoundedLeft(double radius) {
     return borderRadius(BorderRadiusGeometryMix.left(.circular(radius)));
   }
 
-  RemixButtonStyler borderRoundedRight(double radius) {
+  ButtonStyler borderRoundedRight(double radius) {
     return borderRadius(BorderRadiusGeometryMix.right(.circular(radius)));
   }
 
-  RemixButtonStyler borderRoundedTopLeft(double radius) {
+  ButtonStyler borderRoundedTopLeft(double radius) {
     return borderRadius(BorderRadiusGeometryMix.topLeft(.circular(radius)));
   }
 
-  RemixButtonStyler borderRoundedTopRight(double radius) {
+  ButtonStyler borderRoundedTopRight(double radius) {
     return borderRadius(BorderRadiusGeometryMix.topRight(.circular(radius)));
   }
 
-  RemixButtonStyler borderRoundedBottomLeft(double radius) {
+  ButtonStyler borderRoundedBottomLeft(double radius) {
     return borderRadius(BorderRadiusGeometryMix.bottomLeft(.circular(radius)));
   }
 
-  RemixButtonStyler borderRoundedBottomRight(double radius) {
+  ButtonStyler borderRoundedBottomRight(double radius) {
     return borderRadius(BorderRadiusGeometryMix.bottomRight(.circular(radius)));
   }
 
-  RemixButtonStyler borderRoundedTopStart(double radius) {
+  ButtonStyler borderRoundedTopStart(double radius) {
     return borderRadius(BorderRadiusGeometryMix.topStart(.circular(radius)));
   }
 
-  RemixButtonStyler borderRoundedTopEnd(double radius) {
+  ButtonStyler borderRoundedTopEnd(double radius) {
     return borderRadius(BorderRadiusGeometryMix.topEnd(.circular(radius)));
   }
 
-  RemixButtonStyler borderRoundedBottomStart(double radius) {
+  ButtonStyler borderRoundedBottomStart(double radius) {
     return borderRadius(BorderRadiusGeometryMix.bottomStart(.circular(radius)));
   }
 
-  RemixButtonStyler borderRoundedBottomEnd(double radius) {
+  ButtonStyler borderRoundedBottomEnd(double radius) {
     return borderRadius(BorderRadiusGeometryMix.bottomEnd(.circular(radius)));
   }
 
-  RemixButtonStyler shadowOnly({
+  ButtonStyler shadowOnly({
     Color? color,
     Offset? offset,
     double? blurRadius,
@@ -516,23 +513,23 @@ extension RemixButtonStyleDecorationHelpers on RemixButtonStyler {
     );
   }
 
-  RemixButtonStyler boxShadows(List<BoxShadowMix> value) {
+  ButtonStyler boxShadows(List<BoxShadowMix> value) {
     return shadows(value);
   }
 
-  RemixButtonStyler boxElevation(ElevationShadow value) {
+  ButtonStyler boxElevation(ElevationShadow value) {
     return elevation(value);
   }
 
-  RemixButtonStyler shapeCircle({BorderSideMix? side}) {
+  ButtonStyler shapeCircle({BorderSideMix? side}) {
     return shape(CircleBorderMix(side: side));
   }
 
-  RemixButtonStyler shapeStadium({BorderSideMix? side}) {
+  ButtonStyler shapeStadium({BorderSideMix? side}) {
     return shape(StadiumBorderMix(side: side));
   }
 
-  RemixButtonStyler shapeRoundedRectangle({
+  ButtonStyler shapeRoundedRectangle({
     BorderSideMix? side,
     BorderRadiusMix? borderRadius,
   }) {
@@ -541,7 +538,7 @@ extension RemixButtonStyleDecorationHelpers on RemixButtonStyler {
     );
   }
 
-  RemixButtonStyler shapeBeveledRectangle({
+  ButtonStyler shapeBeveledRectangle({
     BorderSideMix? side,
     BorderRadiusMix? borderRadius,
   }) {
@@ -550,7 +547,7 @@ extension RemixButtonStyleDecorationHelpers on RemixButtonStyler {
     );
   }
 
-  RemixButtonStyler shapeContinuousRectangle({
+  ButtonStyler shapeContinuousRectangle({
     BorderSideMix? side,
     BorderRadiusMix? borderRadius,
   }) {
@@ -559,7 +556,7 @@ extension RemixButtonStyleDecorationHelpers on RemixButtonStyler {
     );
   }
 
-  RemixButtonStyler shapeStar({
+  ButtonStyler shapeStar({
     BorderSideMix? side,
     double? points,
     double? innerRadiusRatio,
@@ -581,7 +578,7 @@ extension RemixButtonStyleDecorationHelpers on RemixButtonStyler {
     );
   }
 
-  RemixButtonStyler shapeLinear({
+  ButtonStyler shapeLinear({
     BorderSideMix? side,
     LinearBorderEdgeMix? start,
     LinearBorderEdgeMix? end,
@@ -599,7 +596,7 @@ extension RemixButtonStyleDecorationHelpers on RemixButtonStyler {
     );
   }
 
-  RemixButtonStyler shapeSuperellipse({
+  ButtonStyler shapeSuperellipse({
     BorderSideMix? side,
     BorderRadiusMix? borderRadius,
   }) {

--- a/packages/remix/lib/src/components/button/button_widget.dart
+++ b/packages/remix/lib/src/components/button/button_widget.dart
@@ -80,7 +80,7 @@ class RemixButton extends StatelessWidget {
     this.semanticHint,
     this.excludeSemantics = false,
     this.mouseCursor = SystemMouseCursors.click,
-    this.style = const RemixButtonStyler.create(),
+    this.style = const ButtonStyler.create(),
     this.styleSpec,
   });
 
@@ -88,10 +88,10 @@ class RemixButton extends StatelessWidget {
   ///
   /// Protocol and inspection tooling should project this effective style so
   /// it observes the same layout defaults as [build].
-  static RemixButtonStyler composeStyle(RemixButtonStyler style) =>
+  static ButtonStyler composeStyle(ButtonStyler style) =>
       .mainAxisSize(.min).merge(style);
 
-  static final styleFrom = RemixButtonStyler.new;
+  static final styleFrom = ButtonStyler.new;
 
   /// Whether the button is in a loading state.
   ///
@@ -170,14 +170,14 @@ class RemixButton extends StatelessWidget {
   final MouseCursor mouseCursor;
 
   /// The style configuration for the button.
-  final RemixButtonStyler style;
+  final ButtonStyler style;
 
   /// Optional raw style spec that bypasses fluent style resolution.
   final RemixButtonSpec? styleSpec;
 
   bool get _isEnabled => enabled && !loading && onPressed != null;
 
-  RemixButtonStyler _buildStyle() => composeStyle(style);
+  ButtonStyler _buildStyle() => composeStyle(style);
 
   Widget _buildContent(BuildContext context, RemixButtonSpec spec) {
     Widget? leadingIconWidget;

--- a/packages/remix/lib/src/components/button/fortal_button_styles.dart
+++ b/packages/remix/lib/src/components/button/fortal_button_styles.dart
@@ -34,7 +34,7 @@ enum FortalButtonVariant {
 }
 
 /// Fortal-themed button style and widget presets.
-RemixButtonStyler fortalButtonStyler({
+ButtonStyler fortalButtonStyler({
   FortalButtonVariant variant = .solid,
   FortalButtonSize size = .size2,
 }) {
@@ -47,8 +47,8 @@ RemixButtonStyler fortalButtonStyler({
   };
 }
 
-RemixButtonStyler _fortalButtonBaseStyler(FortalButtonSize size) {
-  return RemixButtonStyler()
+ButtonStyler _fortalButtonBaseStyler(FortalButtonSize size) {
+  return ButtonStyler()
       .label(TextStyler().fontWeight(FortalTokens.fontWeightMedium()))
       .spinner(
         .strokeWidth(
@@ -56,7 +56,7 @@ RemixButtonStyler _fortalButtonBaseStyler(FortalButtonSize size) {
         ).duration(const Duration(milliseconds: 800)),
       )
       .onFocused(
-        RemixButtonStyler().borderAll(
+        ButtonStyler().borderAll(
           color: FortalTokens.focusA8(),
           width: FortalTokens.focusRingWidth(),
         ),
@@ -64,15 +64,15 @@ RemixButtonStyler _fortalButtonBaseStyler(FortalButtonSize size) {
       .merge(_fortalButtonSizeStyler(size));
 }
 
-RemixButtonStyler _fortalButtonSolidStyler([FortalButtonSize size = .size2]) {
+ButtonStyler _fortalButtonSolidStyler([FortalButtonSize size = .size2]) {
   return _fortalButtonBaseStyler(size)
       .backgroundColor(FortalTokens.accent9())
       .foregroundColor(FortalTokens.accentContrast())
       .spinner(.indicatorColor(FortalTokens.accentContrast()))
-      .onHovered(RemixButtonStyler().backgroundColor(FortalTokens.accent10()))
-      .onPressed(RemixButtonStyler().backgroundColor(FortalTokens.accent10()))
+      .onHovered(ButtonStyler().backgroundColor(FortalTokens.accent10()))
+      .onPressed(ButtonStyler().backgroundColor(FortalTokens.accent10()))
       .onDisabled(
-        RemixButtonStyler()
+        ButtonStyler()
             .backgroundColor(FortalTokens.grayA3())
             .foregroundColor(FortalTokens.gray8())
             .spinner(
@@ -83,15 +83,15 @@ RemixButtonStyler _fortalButtonSolidStyler([FortalButtonSize size = .size2]) {
       );
 }
 
-RemixButtonStyler _fortalButtonSoftStyler([FortalButtonSize size = .size2]) {
+ButtonStyler _fortalButtonSoftStyler([FortalButtonSize size = .size2]) {
   return _fortalButtonBaseStyler(size)
       .backgroundColor(FortalTokens.accent3())
       .foregroundColor(FortalTokens.accent11())
       .spinner(.indicatorColor(FortalTokens.accent11()))
-      .onHovered(RemixButtonStyler().backgroundColor(FortalTokens.accent4()))
-      .onPressed(RemixButtonStyler().backgroundColor(FortalTokens.accent5()))
+      .onHovered(ButtonStyler().backgroundColor(FortalTokens.accent4()))
+      .onPressed(ButtonStyler().backgroundColor(FortalTokens.accent5()))
       .onDisabled(
-        RemixButtonStyler()
+        ButtonStyler()
             .backgroundColor(FortalTokens.grayA3())
             .foregroundColor(FortalTokens.gray8())
             .spinner(
@@ -102,7 +102,7 @@ RemixButtonStyler _fortalButtonSoftStyler([FortalButtonSize size = .size2]) {
       );
 }
 
-RemixButtonStyler _fortalButtonSurfaceStyler([FortalButtonSize size = .size2]) {
+ButtonStyler _fortalButtonSurfaceStyler([FortalButtonSize size = .size2]) {
   return _fortalButtonBaseStyler(size)
       .backgroundColor(FortalTokens.accentA2())
       .borderAll(
@@ -112,13 +112,13 @@ RemixButtonStyler _fortalButtonSurfaceStyler([FortalButtonSize size = .size2]) {
       .foregroundColor(FortalTokens.accent11())
       .spinner(.indicatorColor(FortalTokens.accent11()))
       .onHovered(
-        RemixButtonStyler().borderAll(
+        ButtonStyler().borderAll(
           color: FortalTokens.accent8(),
           width: FortalTokens.borderWidth1(),
         ),
       )
       .onDisabled(
-        RemixButtonStyler()
+        ButtonStyler()
             .backgroundColor(FortalTokens.grayA2())
             .foregroundColor(FortalTokens.gray8())
             .borderAll(
@@ -133,7 +133,7 @@ RemixButtonStyler _fortalButtonSurfaceStyler([FortalButtonSize size = .size2]) {
       );
 }
 
-RemixButtonStyler _fortalButtonOutlineStyler([FortalButtonSize size = .size2]) {
+ButtonStyler _fortalButtonOutlineStyler([FortalButtonSize size = .size2]) {
   return _fortalButtonBaseStyler(size)
       .backgroundColor(Colors.transparent)
       .borderAll(
@@ -143,7 +143,7 @@ RemixButtonStyler _fortalButtonOutlineStyler([FortalButtonSize size = .size2]) {
       .foregroundColor(FortalTokens.accent11())
       .spinner(.indicatorColor(FortalTokens.accent11()))
       .onHovered(
-        RemixButtonStyler()
+        ButtonStyler()
             .backgroundColor(FortalTokens.accentA2())
             .borderAll(
               color: FortalTokens.accent8(),
@@ -151,7 +151,7 @@ RemixButtonStyler _fortalButtonOutlineStyler([FortalButtonSize size = .size2]) {
             ),
       )
       .onDisabled(
-        RemixButtonStyler()
+        ButtonStyler()
             .foregroundColor(FortalTokens.gray8())
             .borderAll(color: FortalTokens.gray5())
             .spinner(
@@ -162,15 +162,15 @@ RemixButtonStyler _fortalButtonOutlineStyler([FortalButtonSize size = .size2]) {
       );
 }
 
-RemixButtonStyler _fortalButtonGhostStyler([FortalButtonSize size = .size2]) {
+ButtonStyler _fortalButtonGhostStyler([FortalButtonSize size = .size2]) {
   return _fortalButtonBaseStyler(size)
       .backgroundColor(Colors.transparent)
       .foregroundColor(FortalTokens.accent11())
       .spinner(.indicatorColor(FortalTokens.accent11()))
-      .onHovered(RemixButtonStyler().backgroundColor(FortalTokens.accentA3()))
-      .onPressed(RemixButtonStyler().backgroundColor(FortalTokens.accentA4()))
+      .onHovered(ButtonStyler().backgroundColor(FortalTokens.accentA3()))
+      .onPressed(ButtonStyler().backgroundColor(FortalTokens.accentA4()))
       .onDisabled(
-        RemixButtonStyler()
+        ButtonStyler()
             .foregroundColor(FortalTokens.gray8())
             .spinner(
               .indicatorColor(
@@ -180,8 +180,8 @@ RemixButtonStyler _fortalButtonGhostStyler([FortalButtonSize size = .size2]) {
       );
 }
 
-RemixButtonStyler _fortalButtonSizeStyler(FortalButtonSize size) {
-  final style = RemixButtonStyler();
+ButtonStyler _fortalButtonSizeStyler(FortalButtonSize size) {
+  final style = ButtonStyler();
 
   return switch (size) {
     .size1 =>

--- a/packages/remix/test/components/button/button_style_test.dart
+++ b/packages/remix/test/components/button/button_style_test.dart
@@ -6,13 +6,13 @@ import '../../helpers/test_helpers.dart';
 import '../../helpers/test_methods.dart';
 
 void main() {
-  group('RemixButtonStyler', () {
+  group('ButtonStyler', () {
     group('Constructors', () {
       test('default constructor creates valid instance', () {
-        final style = RemixButtonStyler();
+        final style = ButtonStyler();
 
         expect(style, isNotNull);
-        expect(style, isA<RemixButtonStyler>());
+        expect(style, isA<ButtonStyler>());
       });
 
       test('create constructor with all parameters', () {
@@ -22,7 +22,7 @@ void main() {
         final spinner = Prop.maybeMix(RemixSpinnerStyler());
         final variants = <VariantStyle<RemixButtonSpec>>[];
 
-        final style = RemixButtonStyler.create(
+        final style = ButtonStyler.create(
           container: container,
           label: label,
           icon: icon,
@@ -44,7 +44,7 @@ void main() {
         final iconStyler = IconStyler();
         final spinnerStyle = RemixSpinnerStyler();
 
-        final style = RemixButtonStyler()
+        final style = ButtonStyler()
             .container(containerStyler)
             .label(labelStyler)
             .icon(iconStyler)
@@ -59,16 +59,16 @@ void main() {
 
       test('shadow factory applies shadow style', () {
         final shadow = BoxShadowMix().color(Colors.black).blurRadius(4.0);
-        final style = RemixButtonStyler().shadow(shadow);
+        final style = ButtonStyler().shadow(shadow);
 
-        expect(style, equals(RemixButtonStyler.shadow(shadow)));
+        expect(style, equals(ButtonStyler.shadow(shadow)));
       });
     });
 
     group('Style Methods', () {
       styleMethodTest(
         'label',
-        initial: RemixButtonStyler(),
+        initial: ButtonStyler(),
         modify: (style) => style.label(TextStyler()),
         expect: (style) {
           expect(style.$label, Prop.maybeMix(TextStyler()));
@@ -77,7 +77,7 @@ void main() {
 
       styleMethodTest(
         'icon',
-        initial: RemixButtonStyler(),
+        initial: ButtonStyler(),
         modify: (style) => style.icon(IconStyler()),
         expect: (style) {
           expect(style.$icon, equals(Prop.maybeMix(IconStyler())));
@@ -86,7 +86,7 @@ void main() {
 
       styleMethodTest(
         'spinner',
-        initial: RemixButtonStyler(),
+        initial: ButtonStyler(),
         modify: (style) => style.spinner(RemixSpinnerStyler()),
         expect: (style) {
           expect(style.$spinner, equals(Prop.maybeMix(RemixSpinnerStyler())));
@@ -95,31 +95,31 @@ void main() {
 
       styleMethodTest(
         'padding',
-        initial: RemixButtonStyler(),
+        initial: ButtonStyler(),
         modify: (style) => style.padding(EdgeInsetsGeometryMix.all(16.0)),
         expect: (style) {
           expect(
             style,
-            equals(RemixButtonStyler.padding(EdgeInsetsGeometryMix.all(16.0))),
+            equals(ButtonStyler.padding(EdgeInsetsGeometryMix.all(16.0))),
           );
         },
       );
 
       styleMethodTest(
         'margin',
-        initial: RemixButtonStyler(),
+        initial: ButtonStyler(),
         modify: (style) => style.margin(EdgeInsetsGeometryMix.all(8.0)),
         expect: (style) {
           expect(
             style,
-            equals(RemixButtonStyler.margin(EdgeInsetsGeometryMix.all(8.0))),
+            equals(ButtonStyler.margin(EdgeInsetsGeometryMix.all(8.0))),
           );
         },
       );
 
       styleMethodTest(
         'decoration',
-        initial: RemixButtonStyler(),
+        initial: ButtonStyler(),
         modify: (style) => style.decoration(
           BoxDecorationMix(
             color: Colors.blue,
@@ -130,7 +130,7 @@ void main() {
           expect(
             style,
             equals(
-              RemixButtonStyler.decoration(
+              ButtonStyler.decoration(
                 BoxDecorationMix(
                   color: Colors.blue,
                   borderRadius: BorderRadiusMix.circular(8.0),
@@ -143,28 +143,25 @@ void main() {
 
       styleMethodTest(
         'alignment',
-        initial: RemixButtonStyler(),
+        initial: ButtonStyler(),
         modify: (style) => style.alignment(Alignment.centerLeft),
         expect: (style) {
-          expect(
-            style,
-            equals(RemixButtonStyler.alignment(Alignment.centerLeft)),
-          );
+          expect(style, equals(ButtonStyler.alignment(Alignment.centerLeft)));
         },
       );
 
       styleMethodTest(
         'spacing',
-        initial: RemixButtonStyler(),
+        initial: ButtonStyler(),
         modify: (style) => style.spacing(12.0),
         expect: (style) {
-          expect(style, equals(RemixButtonStyler.spacing(12.0)));
+          expect(style, equals(ButtonStyler.spacing(12.0)));
         },
       );
 
       styleMethodTest(
         'constraints',
-        initial: RemixButtonStyler(),
+        initial: ButtonStyler(),
         modify: (style) => style.constraints(
           BoxConstraintsMix(minWidth: 100.0, minHeight: 40.0),
         ),
@@ -172,7 +169,7 @@ void main() {
           expect(
             style,
             equals(
-              RemixButtonStyler.constraints(
+              ButtonStyler.constraints(
                 BoxConstraintsMix(minWidth: 100.0, minHeight: 40.0),
               ),
             ),
@@ -182,7 +179,7 @@ void main() {
 
       styleMethodTest(
         'variants',
-        initial: RemixButtonStyler(),
+        initial: ButtonStyler(),
         modify: (style) => style.variants(<VariantStyle<RemixButtonSpec>>[]),
         expect: (style) {
           expect(style.$variants, equals(<VariantStyle<RemixButtonSpec>>[]));
@@ -190,7 +187,7 @@ void main() {
       );
       styleMethodTest(
         'flex',
-        initial: RemixButtonStyler(),
+        initial: ButtonStyler(),
         modify: (style) => style.flex(FlexStyler()),
         expect: (style) {
           expect(
@@ -202,7 +199,7 @@ void main() {
 
       styleMethodTest(
         'foregroundDecoration',
-        initial: RemixButtonStyler(),
+        initial: ButtonStyler(),
         modify: (style) => style.foregroundDecoration(
           BoxDecorationMix(
             border: BoxBorderMix.all(BorderSideMix(color: Colors.red)),
@@ -212,7 +209,7 @@ void main() {
           expect(
             style,
             equals(
-              RemixButtonStyler.foregroundDecoration(
+              ButtonStyler.foregroundDecoration(
                 BoxDecorationMix(
                   border: BoxBorderMix.all(BorderSideMix(color: Colors.red)),
                 ),
@@ -224,14 +221,14 @@ void main() {
 
       styleMethodTest(
         'transform',
-        initial: RemixButtonStyler(),
+        initial: ButtonStyler(),
         modify: (style) =>
             style.transform(Matrix4.identity(), alignment: Alignment.topLeft),
         expect: (style) {
           expect(
             style,
             equals(
-              RemixButtonStyler.transform(
+              ButtonStyler.transform(
                 Matrix4.identity(),
                 alignment: Alignment.topLeft,
               ),
@@ -242,7 +239,7 @@ void main() {
 
       styleMethodTest(
         'modifierRotate',
-        initial: RemixButtonStyler(),
+        initial: ButtonStyler(),
         modify: (style) =>
             style.modifierRotate(0.5, alignment: Alignment.topLeft),
         expect: (style) {
@@ -260,37 +257,37 @@ void main() {
 
       styleMethodTest(
         'scale',
-        initial: RemixButtonStyler(),
+        initial: ButtonStyler(),
         modify: (style) => style.scale(1.2, alignment: Alignment.topLeft),
         expect: (style) {
           expect(
             style,
-            equals(RemixButtonStyler.scale(1.2, alignment: Alignment.topLeft)),
+            equals(ButtonStyler.scale(1.2, alignment: Alignment.topLeft)),
           );
         },
       );
 
       styleMethodTest(
         'translate',
-        initial: RemixButtonStyler(),
+        initial: ButtonStyler(),
         modify: (style) => style.translate(1.0, 2.0, 3.0),
         expect: (style) {
-          expect(style, equals(RemixButtonStyler.translate(1.0, 2.0, 3.0)));
+          expect(style, equals(ButtonStyler.translate(1.0, 2.0, 3.0)));
         },
       );
 
       styleMethodTest(
         'skew',
-        initial: RemixButtonStyler(),
+        initial: ButtonStyler(),
         modify: (style) => style.skew(0.1, 0.2),
         expect: (style) {
-          expect(style, equals(RemixButtonStyler.skew(0.1, 0.2)));
+          expect(style, equals(ButtonStyler.skew(0.1, 0.2)));
         },
       );
 
       styleMethodTest(
         'transformReset',
-        initial: RemixButtonStyler(),
+        initial: ButtonStyler(),
         modify: (style) => style.transformReset(),
         expect: (style) {
           expect(style.$container, isNotNull);
@@ -302,7 +299,7 @@ void main() {
       ) async {
         final scaleBox = await _resolveContainerBoxSpec(
           tester,
-          RemixButtonStyler().scale(1.2, alignment: Alignment.topLeft),
+          ButtonStyler().scale(1.2, alignment: Alignment.topLeft),
         );
         expect(
           scaleBox.transform?.storage,
@@ -312,7 +309,7 @@ void main() {
 
         final translateBox = await _resolveContainerBoxSpec(
           tester,
-          RemixButtonStyler().translate(1.0, 2.0, 3.0),
+          ButtonStyler().translate(1.0, 2.0, 3.0),
         );
         expect(
           translateBox.transform?.storage,
@@ -324,13 +321,13 @@ void main() {
           ..setEntry(1, 0, 0.2);
         final skewBox = await _resolveContainerBoxSpec(
           tester,
-          RemixButtonStyler().skew(0.1, 0.2),
+          ButtonStyler().skew(0.1, 0.2),
         );
         expect(skewBox.transform?.storage, orderedEquals(skewMatrix.storage));
 
         final resetBox = await _resolveContainerBoxSpec(
           tester,
-          RemixButtonStyler().transformReset(),
+          ButtonStyler().transformReset(),
         );
         expect(
           resetBox.transform?.storage,
@@ -340,16 +337,16 @@ void main() {
 
       styleMethodTest(
         'color',
-        initial: RemixButtonStyler(),
+        initial: ButtonStyler(),
         modify: (style) => style.color(Colors.blue),
         expect: (style) {
-          expect(style, equals(RemixButtonStyler.color(Colors.blue)));
+          expect(style, equals(ButtonStyler.color(Colors.blue)));
         },
       );
 
       styleMethodTest(
         'wrap',
-        initial: RemixButtonStyler(),
+        initial: ButtonStyler(),
         modify: (style) => style.wrap(.clipOval()),
         expect: (style) {
           expect(style.$modifier, equals(WidgetModifierConfig.clipOval()));
@@ -358,7 +355,7 @@ void main() {
 
       styleMethodTest(
         'inherited spacing helpers',
-        initial: RemixButtonStyler(),
+        initial: ButtonStyler(),
         modify: (style) => style.paddingStart(4.0).marginEnd(8.0),
         expect: (style) {
           expect(style.$container, isNotNull);
@@ -367,7 +364,7 @@ void main() {
 
       styleMethodTest(
         'inherited border helpers',
-        initial: RemixButtonStyler(),
+        initial: ButtonStyler(),
         modify: (style) => style.borderTop(color: Colors.red, width: 2.0),
         expect: (style) {
           expect(
@@ -383,7 +380,7 @@ void main() {
 
       styleMethodTest(
         'inherited shape and constraint helpers',
-        initial: RemixButtonStyler(),
+        initial: ButtonStyler(),
         modify: (style) => style.shapeStadium().minHeight(32.0),
         expect: (style) {
           expect(style.$container, isNotNull);
@@ -393,7 +390,7 @@ void main() {
 
     group('Call Method', () {
       test('call method creates RemixButton with minimal parameters', () {
-        final style = RemixButtonStyler();
+        final style = ButtonStyler();
 
         final button = style.call(label: 'Test Button');
 
@@ -403,7 +400,7 @@ void main() {
       });
 
       test('call method creates RemixButton with all parameters', () {
-        final style = RemixButtonStyler();
+        final style = ButtonStyler();
         final focusNode = FocusNode();
 
         final button = style.call(
@@ -431,7 +428,7 @@ void main() {
       testWidgets('resolve method returns StyleSpec', (
         WidgetTester tester,
       ) async {
-        final style = RemixButtonStyler();
+        final style = ButtonStyler();
 
         await tester.pumpWidget(
           MaterialApp(
@@ -454,7 +451,7 @@ void main() {
       });
 
       test('merge with null returns style equal to original', () {
-        final originalStyle = RemixButtonStyler();
+        final originalStyle = ButtonStyler();
 
         final mergedStyle = originalStyle.merge(null);
 
@@ -464,20 +461,16 @@ void main() {
 
     group('Equality', () {
       test('identical styles are equal', () {
-        final style1 = RemixButtonStyler();
-        final style2 = RemixButtonStyler();
+        final style1 = ButtonStyler();
+        final style2 = ButtonStyler();
 
         expect(style1, equals(style2));
         expect(style1.hashCode, equals(style2.hashCode));
       });
 
       test('styles with different properties are not equal', () {
-        final style1 = RemixButtonStyler().padding(
-          EdgeInsetsGeometryMix.all(16.0),
-        );
-        final style2 = RemixButtonStyler().padding(
-          EdgeInsetsGeometryMix.all(8.0),
-        );
+        final style1 = ButtonStyler().padding(EdgeInsetsGeometryMix.all(16.0));
+        final style2 = ButtonStyler().padding(EdgeInsetsGeometryMix.all(8.0));
 
         expect(style1, isNot(equals(style2)));
       });
@@ -529,7 +522,7 @@ void main() {
 
 Future<StyleSpec<RemixButtonSpec>> _resolveFortalButtonStyle(
   WidgetTester tester,
-  RemixButtonStyler style,
+  ButtonStyler style,
 ) async {
   late final StyleSpec<RemixButtonSpec> resolved;
 
@@ -548,7 +541,7 @@ Future<StyleSpec<RemixButtonSpec>> _resolveFortalButtonStyle(
 
 Future<BoxSpec> _resolveContainerBoxSpec(
   WidgetTester tester,
-  RemixButtonStyler style,
+  ButtonStyler style,
 ) async {
   final resolved = await _resolveFortalButtonStyle(tester, style);
 

--- a/packages/remix/test/components/button/button_styler_compatibility_test.dart
+++ b/packages/remix/test/components/button/button_styler_compatibility_test.dart
@@ -12,10 +12,14 @@ void main() {
     final legacyFactory = RemixButtonStyler.color(Colors.blue);
 
     final ButtonStyler canonical = legacy;
+    final legacyWidget = RemixButtonStylerRemixHelpers(
+      legacy,
+    ).call(label: 'Legacy button');
 
     expect(canonical, same(legacy));
     expect(legacy.merge(emptyLegacy), isA<ButtonStyler>());
     expect(legacyFactory, isA<ButtonStyler>());
+    expect(legacyWidget, isA<RemixButton>());
     expect(legacy.runtimeType, ButtonStyler);
   });
 }

--- a/packages/remix/test/components/button/button_styler_compatibility_test.dart
+++ b/packages/remix/test/components/button/button_styler_compatibility_test.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:remix/remix.dart';
+
+void main() {
+  test('keeps RemixButtonStyler source-compatible during migration', () {
+    // ignore: deprecated_member_use
+    final RemixButtonStyler legacy = RemixButtonStyler().paddingX(12);
+    // ignore: deprecated_member_use
+    const emptyLegacy = RemixButtonStyler.create();
+    // ignore: deprecated_member_use
+    final legacyFactory = RemixButtonStyler.color(Colors.blue);
+
+    final ButtonStyler canonical = legacy;
+
+    expect(canonical, same(legacy));
+    expect(legacy.merge(emptyLegacy), isA<ButtonStyler>());
+    expect(legacyFactory, isA<ButtonStyler>());
+    expect(legacy.runtimeType, ButtonStyler);
+  });
+}

--- a/packages/remix/test/components/button/button_widget_test.dart
+++ b/packages/remix/test/components/button/button_widget_test.dart
@@ -38,7 +38,7 @@ void main() {
           RemixButton(
             label: 'Continue',
             leadingIcon: Icons.arrow_forward,
-            style: RemixButtonStyler().iconAlignment(.end),
+            style: ButtonStyler().iconAlignment(.end),
             onPressed: () {},
           ),
         );
@@ -56,7 +56,7 @@ void main() {
             label: 'Continue',
             leadingIcon: Icons.arrow_back,
             trailingIcon: Icons.arrow_forward,
-            style: RemixButtonStyler().iconAlignment(.end),
+            style: ButtonStyler().iconAlignment(.end),
             onPressed: () {},
           ),
         );

--- a/packages/remix/test/components/styler_factory_shorthand_test.dart
+++ b/packages/remix/test/components/styler_factory_shorthand_test.dart
@@ -5,7 +5,7 @@ import 'package:remix/remix.dart';
 void main() {
   group('generated Remix styler factories', () {
     test('support contextual shorthand for widget-state variants', () {
-      final style = RemixButtonStyler()
+      final style = ButtonStyler()
           .onHovered(.color(Colors.green))
           .onPressed(.scale(0.97));
 
@@ -18,7 +18,7 @@ void main() {
         RemixCardStyler().color(Colors.blue),
       );
       expect(RemixSpinnerStyler.size(20), RemixSpinnerStyler().size(20));
-      expect(RemixButtonStyler.rotate(0.25), RemixButtonStyler().rotate(0.25));
+      expect(ButtonStyler.rotate(0.25), ButtonStyler().rotate(0.25));
       expect(
         RemixToggleGroupStyler.color(Colors.blue),
         RemixToggleGroupStyler().color(Colors.blue),
@@ -148,8 +148,8 @@ void main() {
         ),
       );
       expectSameSpec(
-        RemixButtonStyler().padding(padding).color(Colors.blue).spacing(8),
-        RemixButtonStyler(
+        ButtonStyler().padding(padding).color(Colors.blue).spacing(8),
+        ButtonStyler(
           container: FlexBoxStyler(
             padding: padding,
             decoration: BoxDecorationMix(color: Colors.blue),

--- a/packages/remix/test/utilities/spinner_style_mixin_test.dart
+++ b/packages/remix/test/utilities/spinner_style_mixin_test.dart
@@ -3,10 +3,10 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:remix/remix.dart';
 
 void main() {
-  group('RemixButtonStyler spinner nesting', () {
+  group('ButtonStyler spinner nesting', () {
     test('spinner indicator color can be set through nested shorthand', () {
       const testColor = Colors.red;
-      final originalStyle = RemixButtonStyler();
+      final originalStyle = ButtonStyler();
       final modifiedStyle = originalStyle.spinner(.indicatorColor(testColor));
 
       final expectedSpinner = Prop.maybeMix(
@@ -19,7 +19,7 @@ void main() {
 
     test('spinner track color can be set through nested shorthand', () {
       const testColor = Colors.blue;
-      final originalStyle = RemixButtonStyler();
+      final originalStyle = ButtonStyler();
       final modifiedStyle = originalStyle.spinner(.trackColor(testColor));
 
       final expectedSpinner = Prop.maybeMix(
@@ -32,7 +32,7 @@ void main() {
 
     test('spinner size can be set through nested shorthand', () {
       const testSize = 32.0;
-      final originalStyle = RemixButtonStyler();
+      final originalStyle = ButtonStyler();
       final modifiedStyle = originalStyle.spinner(.size(testSize));
 
       final expectedSpinner = Prop.maybeMix(RemixSpinnerStyler(size: testSize));
@@ -43,7 +43,7 @@ void main() {
 
     test('spinner stroke width can be set through nested shorthand', () {
       const testWidth = 3.0;
-      final originalStyle = RemixButtonStyler();
+      final originalStyle = ButtonStyler();
       final modifiedStyle = originalStyle.spinner(.strokeWidth(testWidth));
 
       final expectedSpinner = Prop.maybeMix(
@@ -56,7 +56,7 @@ void main() {
 
     test('spinner track stroke width can be set through nested shorthand', () {
       const testWidth = 2.5;
-      final originalStyle = RemixButtonStyler();
+      final originalStyle = ButtonStyler();
       final modifiedStyle = originalStyle.spinner(.trackStrokeWidth(testWidth));
 
       final expectedSpinner = Prop.maybeMix(
@@ -69,7 +69,7 @@ void main() {
 
     test('spinner duration can be set through nested shorthand', () {
       const testDuration = Duration(milliseconds: 800);
-      final originalStyle = RemixButtonStyler();
+      final originalStyle = ButtonStyler();
       final modifiedStyle = originalStyle.spinner(.duration(testDuration));
 
       final expectedSpinner = Prop.maybeMix(
@@ -81,7 +81,7 @@ void main() {
     });
 
     testWidgets('spinner styles can be chained together', (tester) async {
-      final originalStyle = RemixButtonStyler();
+      final originalStyle = ButtonStyler();
       final chainedStyle = originalStyle
           .spinner(.indicatorColor(Colors.blue))
           .spinner(.trackColor(Colors.blue.withValues(alpha: 0.2)))
@@ -114,7 +114,7 @@ void main() {
     });
 
     test('spinner nesting can be chained with label and icon nesting', () {
-      final combinedStyle = RemixButtonStyler()
+      final combinedStyle = ButtonStyler()
           .label(.color(Colors.white))
           .icon(.color(Colors.white))
           .spinner(.indicatorColor(Colors.white))

--- a/skills/building-remix-design-system/SKILL.md
+++ b/skills/building-remix-design-system/SKILL.md
@@ -37,7 +37,7 @@ naked_ui        interaction primitives (focus, press, semantics, keyboard)
    ↑
 mix             styling engine, tokens, MixScope, variants
    ↑
-remix           reusable component machinery (RemixButtonStyler, specs, widgets)
+remix           reusable component machinery (ButtonStyler, specs, widgets)
    ↑
 <your package>  generated tokens + <System>Scope + component recipes/facades
                 exposes ONLY <System>* widgets and tokens publicly
@@ -189,7 +189,7 @@ Per component:
    when the target system's anatomy matches the Remix component, the public
    API reads in the target vocabulary, and no Remix-only types leak. Otherwise
    write a hand-written facade (a `StatelessWidget` that builds a
-   `Remix*Styler` recipe and calls it).
+   `*Styler` recipe and calls it).
 3. Style **through tokens, never copied values**: `token()` inside styler
    chains, `TextStyler().style(textToken.mix())` for text styles,
    `token.resolve(context)` for direct widget use. A hand-copied measurement

--- a/skills/building-remix-design-system/references/component-playbook.md
+++ b/skills/building-remix-design-system/references/component-playbook.md
@@ -46,7 +46,7 @@ Use a generated `@MixWidget` wrapper **only if all of**:
 - semantics/keyboard behavior match.
 
 Otherwise write a **hand-written facade**: a `StatelessWidget` in the target
-vocabulary that builds a `Remix*Styler` recipe and invokes its `.call(...)`.
+vocabulary that builds a `*Styler` recipe and invokes its `.call(...)`.
 
 With `mix_generator` 2.1.2 or newer, a generic `call<T>()` target is not by
 itself a reason to hand-write the facade. `@MixWidget` copies the styler
@@ -117,14 +117,14 @@ the wrapper in the public API.
 ## 3. Recipe shape
 
 This Button recipe is for a hand-written facade: its `loading` styling input
-collides with `RemixButtonStyler.call(loading: ...)`, so it cannot be exposed
+collides with `ButtonStyler.call(loading: ...)`, so it cannot be exposed
 unchanged through `@MixWidget`.
 
 ```dart
 // Pure function of a few enums → memoize; stylers are immutable value objects.
-final Map<(Kind, Size, bool), RemixButtonStyler> _styleCache = {};
+final Map<(Kind, Size, bool), ButtonStyler> _styleCache = {};
 
-RemixButtonStyler acmeButtonStyle({Kind kind, Size size, bool loading = false}) {
+ButtonStyler acmeButtonStyle({Kind kind, Size size, bool loading = false}) {
   final clamped = size.clampTo(Size.sm, Size.x2l);   // worksheet's supported range
   return _styleCache.putIfAbsent((kind, clamped, loading), () {
     final base = _baseStyle(clamped);                 // shared height/padding/label/focus
@@ -154,7 +154,7 @@ the disabled variant accordingly:
 
 ```dart
 final disabledStyle = loading
-    ? RemixButtonStyler().color(fill()).spinner(...)   // keep kind visuals
+    ? ButtonStyler().color(fill()).spinner(...)   // keep kind visuals
     : _disabledTreatment();                            // real disabled gray
 ```
 
@@ -168,7 +168,7 @@ Flutter containers pad by border width, **shifts layout on focus**. Paint the
 ring over the content instead — no layout change, base border intact:
 
 ```dart
-.onFocused(RemixButtonStyler().foregroundDecoration(BoxDecorationMix(
+.onFocused(ButtonStyler().foregroundDecoration(BoxDecorationMix(
   border: BoxBorderMix.all(BorderSideMix(color: AcmeTokens.focus(), width: 2.0)),
 )))
 ```
@@ -190,7 +190,7 @@ specifies it, and don't fight the min-size default.
 
 ### One-icon alignment is style-driven
 
-`RemixButtonStyler.iconAlignment(IconAlignment.start|end)` controls which
+`ButtonStyler.iconAlignment(IconAlignment.start|end)` controls which
 side of the label a **single** icon occupies. It applies regardless of whether
 the caller supplied `leadingIcon` or `trailingIcon`. When both icons are
 present, Remix deliberately preserves leading → label → trailing order. Test

--- a/skills/using-remix/SKILL.md
+++ b/skills/using-remix/SKILL.md
@@ -55,7 +55,7 @@ to resolve tokens.
 1. **Fortal preset widgets** — `FortalButton.soft(size: .size2)`.
    Fastest path; consistent by construction. Use for standard UI.
 2. **Fortal styler + overrides** — `fortal*Styler()` returns the component's
-   `Remix*Styler`; chain custom modifications and pass it to the `Remix*`
+   `*Styler`; chain custom modifications and pass it to the `Remix*`
    widget's `style:`:
 
    ```dart
@@ -65,17 +65,17 @@ to resolve tokens.
      style: fortalButtonStyler(variant: .solid)
          .borderRadiusAll(const Radius.circular(8))
          .paddingX(32)
-         .onHovered(RemixButtonStyler().wrap(.scale(x: 1.05, y: 1.05))),
+         .onHovered(ButtonStyler().wrap(.scale(x: 1.05, y: 1.05))),
    )
    ```
 
-3. **Fully custom styler** — build a `Remix*Styler` from scratch with the
+3. **Fully custom styler** — build a `*Styler` from scratch with the
    fluent API (below). Use for bespoke designs that don't start from Fortal.
 
 ## Component Catalog
 
 Remix ships 21 components. Each styled leaf widget accepts `style` (a
-`Remix*Styler`) and has a `Fortal*` preset counterpart. Behavioral roots and
+`*Styler`) and has a `Fortal*` preset counterpart. Behavioral roots and
 groups (`RemixTabs`, `RemixRadioGroup`, and `RemixAccordionGroup`) intentionally
 have neither a styler nor a Fortal wrapper.
 
@@ -258,10 +258,10 @@ FortalDivider()
 
 ## Custom Styling with Stylers
 
-Every component's style is a chainable, immutable `Remix*Styler`:
+Every component's style is a chainable, immutable `*Styler`:
 
 ```dart
-RemixButtonStyler()
+ButtonStyler()
     .color(Colors.blue)          // container fill (universal primitive)
     .borderRounded(12)           // circular radius shortcut
     .paddingX(24)
@@ -293,13 +293,13 @@ available and check the per-component reference for exact surface area.
 State variants take a styler of the same type and merge it over the base:
 
 ```dart
-RemixButtonStyler()
+ButtonStyler()
     .color(Colors.blue)
     .labelColor(Colors.white)
-    .onHovered(RemixButtonStyler().color(Colors.blue.shade700))
-    .onPressed(RemixButtonStyler().scale(0.97))
-    .onFocused(RemixButtonStyler().borderAll(color: Colors.white, width: 2))
-    .onDisabled(RemixButtonStyler().color(Colors.grey))
+    .onHovered(ButtonStyler().color(Colors.blue.shade700))
+    .onPressed(ButtonStyler().scale(0.97))
+    .onFocused(ButtonStyler().borderAll(color: Colors.white, width: 2))
+    .onDisabled(ButtonStyler().color(Colors.grey))
 ```
 
 `.onSelected()` exists on the selection components only — Checkbox, Radio,
@@ -316,10 +316,10 @@ RemixCheckboxStyler()
 Respond to platform, brightness, and form factor:
 
 ```dart
-RemixButtonStyler()
+ButtonStyler()
     .paddingX(24)
-    .onMobile(RemixButtonStyler().paddingX(16).labelFontSize(14))
-    .onDark(RemixButtonStyler().color(Colors.blue.shade800))
+    .onMobile(ButtonStyler().paddingX(16).labelFontSize(14))
+    .onDark(ButtonStyler().color(Colors.blue.shade800))
 ```
 
 Available: `.onDark()`, `.onLight()`, `.onMobile()`, `.onTablet()`,
@@ -332,9 +332,9 @@ Available: `.onDark()`, `.onLight()`, `.onMobile()`, `.onTablet()`,
 Add transitions between states with `.animate(AnimationConfig)`:
 
 ```dart
-RemixButtonStyler()
+ButtonStyler()
     .color(Colors.blue)
-    .onHovered(RemixButtonStyler().color(Colors.blue.shade800))
+    .onHovered(ButtonStyler().color(Colors.blue.shade800))
     .animate(AnimationConfig.spring(300.ms))
 ```
 
@@ -349,7 +349,7 @@ Every leaf component styler has a `call()` method that builds the widget
 directly:
 
 ```dart
-final primaryButton = RemixButtonStyler()
+final primaryButton = ButtonStyler()
     .color(Colors.blue)
     .labelColor(Colors.white)
     .paddingX(24)
@@ -371,7 +371,7 @@ Call the token inside styler chains; `.mix()` for text-style tokens;
 `.resolve(context)` for direct values in widget code:
 
 ```dart
-RemixButtonStyler()
+ButtonStyler()
     .color(FortalTokens.accent9())
     .paddingAll(FortalTokens.space4())
     .borderRadiusAll(FortalTokens.radius3())
@@ -392,12 +392,12 @@ transition durations. Full catalog: `references/fortal-reference.md`.
 
 ```dart
 class AppStyles {
-  static RemixButtonStyler get primaryButton => fortalButtonStyler(variant: .solid)
+  static ButtonStyler get primaryButton => fortalButtonStyler(variant: .solid)
       .animate(AnimationConfig.spring(200.ms));
 
-  static RemixButtonStyler get dangerButton => fortalButtonStyler(variant: .solid)
+  static ButtonStyler get dangerButton => fortalButtonStyler(variant: .solid)
       .color(Colors.red)
-      .onHovered(RemixButtonStyler().color(Colors.red.shade700))
+      .onHovered(ButtonStyler().color(Colors.red.shade700))
       .animate(AnimationConfig.spring(200.ms));
 }
 

--- a/skills/using-remix/evals/evals.json
+++ b/skills/using-remix/evals/evals.json
@@ -10,7 +10,7 @@
     {
       "id": 2,
       "prompt": "Create a custom-styled button that has a gradient background, rounded corners, scales down on press, and glows on hover. Don't use Fortal — build a fully custom style from scratch using the Remix fluent API. Show me the complete code.",
-      "expected_output": "A RemixButton with a fully custom RemixButtonStyler using the fluent API — gradient, borderRounded, .onPressed with scale, .onHovered with shadow/glow, .animate(AnimationConfig...) for transitions. Uses RemixButtonStyler (not the removed RemixButtonStyle) throughout.",
+      "expected_output": "A RemixButton with a fully custom ButtonStyler using the fluent API — gradient, borderRounded, .onPressed with scale, .onHovered with shadow/glow, .animate(AnimationConfig...) for transitions. Uses ButtonStyler (not the removed RemixButtonStyle) throughout.",
       "files": []
     },
     {
@@ -22,7 +22,7 @@
     {
       "id": 4,
       "prompt": "I have a RemixButton with one icon and need the icon after the label without changing the widget arguments. Can styling do that? What happens if the button later gets both a leading and trailing icon?",
-      "expected_output": "Uses RemixButtonStyler().iconAlignment(IconAlignment.end) and explains that the style controls placement whenever exactly one icon exists, regardless of which icon argument supplied it. Explains that with both icons Remix preserves leading -> label -> trailing order instead of allowing the alignment override to collapse or reorder the pair.",
+      "expected_output": "Uses ButtonStyler().iconAlignment(IconAlignment.end) and explains that the style controls placement whenever exactly one icon exists, regardless of which icon argument supplied it. Explains that with both icons Remix preserves leading -> label -> trailing order instead of allowing the alignment override to collapse or reorder the pair.",
       "files": []
     },
     {

--- a/skills/using-remix/references/components.md
+++ b/skills/using-remix/references/components.md
@@ -5,9 +5,9 @@ Constructor parameters for every Remix component, verified against
 
 Shared contract for every leaf `Remix*` widget:
 
-- `style` — a `Remix*Styler` (defaults to `const Remix*Styler.create()`).
+- `style` — a `*Styler` (defaults to `const *Styler.create()`).
 - `styleSpec` — an optional raw `Remix*Spec?` that bypasses style resolution.
-- `static final styleFrom = Remix*Styler.new` — tear-off convenience for
+- `static final styleFrom = *Styler.new` — tear-off convenience for
   building a styler.
 
 The tables below list the component-specific parameters; `style`/`styleSpec`
@@ -58,7 +58,7 @@ loading, content stays laid out (invisible) with a spinner overlay to prevent
 layout shift.
 
 Icon placement is style-driven when exactly one icon is present:
-`RemixButtonStyler().iconAlignment(IconAlignment.end)` places it after the
+`ButtonStyler().iconAlignment(IconAlignment.end)` places it after the
 label, regardless of whether the value came from `leadingIcon` or
 `trailingIcon`. With both icons present, Remix preserves
 leading → label → trailing order.

--- a/skills/using-remix/references/fortal-reference.md
+++ b/skills/using-remix/references/fortal-reference.md
@@ -6,19 +6,19 @@ system: preset widgets, variants, sizes, and tokens.
 ## How Fortal presets work
 
 Each component ships a `fortal<Name>Styler(...)` function that returns the
-component's `Remix*Styler`, plus a `Fortal<Name>` preset widget that applies
+component's `*Styler`, plus a `Fortal<Name>` preset widget that applies
 it. Two equivalent ways to use a preset:
 
 ```dart
 // 1. Preset widget — Remix widget params + fixed variant/size
 FortalButton.soft(label: 'Save', onPressed: save, size: .size3)
 
-// 2. Styler function — returns a RemixButtonStyler to extend
+// 2. Styler function — returns a ButtonStyler to extend
 RemixButton(
   label: 'Save',
   onPressed: save,
   style: fortalButtonStyler(variant: .soft, size: .size3)
-      .onHovered(RemixButtonStyler().scale(1.02)),
+      .onHovered(ButtonStyler().scale(1.02)),
 )
 ```
 
@@ -121,7 +121,7 @@ widgets, resolve against context:
 
 ```dart
 // In a styler chain:
-RemixButtonStyler()
+ButtonStyler()
     .backgroundColor(FortalTokens.accent9())
     .borderRadiusAll(FortalTokens.radius3())
 


### PR DESCRIPTION
## Description

Renames `RemixButtonStyler` to `ButtonStyler` across the package API, generated sources, Fortal artifacts, examples, and documentation.

Keeps `RemixButtonStyler` as a deprecated compatibility alias throughout the beta releases. The alias will be removed in `1.0.0`.

## Validation

- `fvm dart analyze` — passed
- `fvm flutter test packages/remix/test --reporter=failures-only` — 1,884 tests passed
- `fvm flutter test packages/remix/test/components/button/button_styler_compatibility_test.dart` — passed

## Related Issues

None.

---

## Checklist

**Note**: Updating the `pubspec.yaml` and `CHANGELOG.md` is not required. These are handled automatically during the release process.

- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors.
- [x] I have updated or added relevant documentation (doc comments with `///`).
- [ ] I am prepared to follow up on review comments in a timely manner.

## Breaking Change

Does this PR require users of the package to manually update their code?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.
