### PR TITLE
fix(remix): correct component accessibility and bounded layout

### DIFF
--- a/packages/remix/lib/src/components/badge/fortal_badge_styles.dart
+++ b/packages/remix/lib/src/components/badge/fortal_badge_styles.dart
@@ -32,7 +32,7 @@ RemixBadgeStyler _fortalBadgeSolidStyler([FortalBadgeSize size = .size2]) {
 RemixBadgeStyler _fortalBadgeSoftStyler([FortalBadgeSize size = .size2]) {
   return _fortalBadgeBaseStyler(size)
       .backgroundColor(FortalTokens.accentA3())
-      .foregroundColor(FortalTokens.accentA10());
+      .foregroundColor(FortalTokens.accent12());
 }
 
 RemixBadgeStyler _fortalBadgeSurfaceStyler([FortalBadgeSize size = .size2]) {
@@ -42,7 +42,7 @@ RemixBadgeStyler _fortalBadgeSurfaceStyler([FortalBadgeSize size = .size2]) {
         color: FortalTokens.accent6(),
         width: FortalTokens.borderWidth1(),
       )
-      .foregroundColor(FortalTokens.accentA10());
+      .foregroundColor(FortalTokens.accent12());
 }
 
 RemixBadgeStyler _fortalBadgeOutlineStyler([FortalBadgeSize size = .size2]) {
@@ -52,7 +52,7 @@ RemixBadgeStyler _fortalBadgeOutlineStyler([FortalBadgeSize size = .size2]) {
         color: FortalTokens.accent7(),
         width: FortalTokens.borderWidth1(),
       )
-      .foregroundColor(FortalTokens.accentA10());
+      .foregroundColor(FortalTokens.accent12());
 }
 
 RemixBadgeStyler _fortalBadgeSizeStyler(FortalBadgeSize size) {

--- a/packages/remix/lib/src/components/button/button_widget.dart
+++ b/packages/remix/lib/src/components/button/button_widget.dart
@@ -280,7 +280,7 @@ class RemixButton extends StatelessWidget {
       enableFeedback: enableFeedback,
       focusNode: focusNode,
       autofocus: autofocus,
-      semanticLabel: semanticLabel,
+      semanticLabel: semanticLabel ?? label,
       builder: (context, _, _) {
         return RemixStyleSpecBuilder<RemixButtonSpec>(
           style: _buildStyle(),

--- a/packages/remix/lib/src/components/callout/callout_widget.dart
+++ b/packages/remix/lib/src/components/callout/callout_widget.dart
@@ -52,7 +52,15 @@ class RemixCallout extends StatelessWidget {
       builder: (context, spec) {
         // For raw constructor, use provided child directly
         if (child != null) {
-          return RowBox(styleSpec: spec.container, children: [child!]);
+          return RowBox(
+            styleSpec: spec.container,
+            children: [
+              // RowBox resolves to a Flex. A loose fit gives custom content a
+              // bounded maximum width without forcing it to fill the callout.
+              // ignore: avoid-flexible-outside-flex
+              Flexible(child: child!),
+            ],
+          );
         }
 
         // Build the callout content with text and optional icon
@@ -65,7 +73,12 @@ class RemixCallout extends StatelessWidget {
 
         // Add text if present
         if (text?.isNotEmpty == true) {
-          children.add(StyledText(text!, styleSpec: spec.text));
+          children.add(
+            // RowBox resolves to a Flex. A loose fit lets text wrap while
+            // preserving its intrinsic width for short messages.
+            // ignore: avoid-flexible-outside-flex
+            Flexible(child: StyledText(text!, styleSpec: spec.text)),
+          );
         }
 
         return RowBox(styleSpec: spec.container, children: children);

--- a/packages/remix/lib/src/components/textfield/fortal_textfield_styles.dart
+++ b/packages/remix/lib/src/components/textfield/fortal_textfield_styles.dart
@@ -79,7 +79,7 @@ RemixTextFieldStyler _fortalTextFieldSurfaceStyler([
         width: FortalTokens.borderWidth1(),
         strokeAlign: BorderSide.strokeAlignOutside,
       )
-      .color(FortalTokens.gray12())
+      .textColor(FortalTokens.gray12())
       .onFocused(
         RemixTextFieldStyler().borderAll(
           color: FortalTokens.accent7(),
@@ -118,7 +118,7 @@ RemixTextFieldStyler _fortalTextFieldSoftStyler([
               .fontWeight(FortalTokens.fontWeightMedium()),
         ),
       )
-      .color(FortalTokens.accent12())
+      .textColor(FortalTokens.accent12())
       .wrap(.iconTheme(color: FortalTokens.accent10()))
       .backgroundColor(FortalTokens.accent3())
       .borderAll(

--- a/packages/remix/test/components/button/button_widget_test.dart
+++ b/packages/remix/test/components/button/button_widget_test.dart
@@ -616,13 +616,8 @@ void main() {
 
         await tester.pumpAndSettle();
 
-        // Verify semantics widget is present
-        expect(find.byType(Semantics), findsAtLeastNWidgets(1));
-
-        // Test that the default label is used by checking accessibility
         final semantics = tester.getSemantics(find.byType(RemixButton));
-        // Note: The label might not be applied as expected, so we'll just verify the button renders
-        expect(semantics, isNotNull);
+        expect(semantics.label, equals('Default Label'));
       });
     });
 

--- a/packages/remix/test/components/callout/callout_widget_test.dart
+++ b/packages/remix/test/components/callout/callout_widget_test.dart
@@ -42,6 +42,51 @@ void main() {
         expect(find.byIcon(Icons.star), findsOneWidget);
       });
 
+      testWidgets('constrains flexible custom content to the callout width', (
+        tester,
+      ) async {
+        await tester.pumpRemixApp(
+          SizedBox(
+            width: 320,
+            child: RemixCallout(
+              child: Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      'A detailed capture failure that should wrap in place.',
+                    ),
+                  ),
+                  TextButton(onPressed: () {}, child: Text('Retry')),
+                ],
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(tester.takeException(), isNull);
+        expect(find.text('Retry'), findsOneWidget);
+      });
+
+      testWidgets('wraps long text beside its icon at a bounded width', (
+        tester,
+      ) async {
+        await tester.pumpRemixApp(
+          SizedBox(
+            width: 320,
+            child: RemixCallout(
+              icon: Icons.info,
+              text:
+                  'A detailed capture failure that should wrap without '
+                  'overflowing the callout.',
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(tester.takeException(), isNull);
+      });
+
       testWidgets('renders callout with all props', (tester) async {
         await tester.pumpRemixApp(
           RemixCallout(

--- a/packages/remix/test/components/fortal_widget_test.dart
+++ b/packages/remix/test/components/fortal_widget_test.dart
@@ -60,6 +60,53 @@ void main() {
       expect(find.byType(RemixBadge), findsOneWidget);
     });
 
+    testWidgets('non-solid FortalBadge variants use accessible accent text', (
+      tester,
+    ) async {
+      final colors = resolveFortalTokens(const FortalThemeConfig());
+
+      for (final variant in [
+        FortalBadgeVariant.soft,
+        FortalBadgeVariant.surface,
+        FortalBadgeVariant.outline,
+      ]) {
+        await tester.pumpRemixApp(
+          FortalBadge(label: variant.name, variant: variant),
+        );
+        await tester.pumpAndSettle();
+
+        final label = tester.widget<Text>(find.text(variant.name));
+        expect(
+          label.style?.color,
+          colors.accent.scale.step(12),
+          reason: '${variant.name} badges use the accent text step',
+        );
+      }
+    });
+
+    test('accent text step meets WCAG AA over soft badge backgrounds', () {
+      for (final brightness in Brightness.values) {
+        for (final accent in FortalAccentColor.values) {
+          final colors = resolveFortalTokens(
+            FortalThemeConfig(accent: accent, brightness: brightness),
+          );
+          final background = Color.alphaBlend(
+            colors.accent.scale.alphaStep(3),
+            colors.colorBackground,
+          );
+          final foreground = colors.accent.scale.step(12);
+
+          expect(
+            _contrastRatio(foreground, background),
+            greaterThanOrEqualTo(4.5),
+            reason:
+                '${accent.name}/${brightness.name} soft badges must meet '
+                'WCAG AA contrast',
+          );
+        }
+      }
+    });
+
     testWidgets('renders FortalButton', (tester) async {
       await tester.pumpRemixApp(const FortalButton(label: 'Save'));
 
@@ -238,4 +285,17 @@ void main() {
       expect(find.byType(FortalTabView), findsNWidgets(2));
     });
   });
+}
+
+double _contrastRatio(Color first, Color second) {
+  final firstLuminance = first.computeLuminance();
+  final secondLuminance = second.computeLuminance();
+  final lighter = firstLuminance > secondLuminance
+      ? firstLuminance
+      : secondLuminance;
+  final darker = firstLuminance > secondLuminance
+      ? secondLuminance
+      : firstLuminance;
+
+  return (lighter + 0.05) / (darker + 0.05);
 }

--- a/packages/remix/test/components/textfield/textfield_widget_test.dart
+++ b/packages/remix/test/components/textfield/textfield_widget_test.dart
@@ -10,6 +10,33 @@ import '../../helpers/test_helpers.dart';
 
 void main() {
   group('RemixTextField', () {
+    testWidgets('Fortal variants keep text and container colors separate', (
+      tester,
+    ) async {
+      await tester.pumpRemixApp(const FortalTextField.surface());
+      var context = tester.element(find.byType(FortalTextField));
+      var colors = resolveFortalTokens(const FortalThemeConfig());
+      var spec = fortalTextFieldStyler(
+        variant: FortalTextFieldVariant.surface,
+      ).resolve(context).spec;
+      var decoration =
+          spec.container.spec.box!.spec.decoration! as BoxDecoration;
+
+      expect(spec.text.spec.style?.color, colors.gray.scale.step(12));
+      expect(decoration.color, isNull);
+
+      await tester.pumpRemixApp(const FortalTextField.soft());
+      context = tester.element(find.byType(FortalTextField));
+      colors = resolveFortalTokens(const FortalThemeConfig());
+      spec = fortalTextFieldStyler(
+        variant: FortalTextFieldVariant.soft,
+      ).resolve(context).spec;
+      decoration = spec.container.spec.box!.spec.decoration! as BoxDecoration;
+
+      expect(spec.text.spec.style?.color, colors.accent.scale.step(12));
+      expect(decoration.color, colors.accent.scale.step(3));
+    });
+
     group('Basic Rendering', () {
       testWidgets('renders with default style', (tester) async {
         await tester.pumpRemixApp(const RemixTextField());


### PR DESCRIPTION
## Summary

- give `NakedButton` the visible button label when no explicit semantic label is supplied
- constrain callout text and custom content with a loose flex fit so bounded callouts wrap without forcing intrinsic content to fill the row
- use the opaque accent text step for non-solid Fortal badges and verify WCAG AA contrast across every supported accent and both brightness modes
- apply Fortal text-field foreground colors through `textColor`, keeping editable text styling separate from container decoration

## Why

The Muse Studio integration exposed four generic Remix behaviors that had diverged on a retired feature branch. This PR fixes the underlying component contracts in the canonical Remix source instead of preserving a second vendored implementation.

## Validation

- focused regression suite: 133 tests passed
- `fvm dart analyze packages/remix`
- `fvm dart run melos run ci --no-select`
  - generated sources unchanged
  - demo: 15 tests passed
  - remix: 1,889 tests passed
