### PR TITLE
ci(remix): validate hosted Mix resolution

### DIFF
--- a/packages/demo/pubspec.yaml
+++ b/packages/demo/pubspec.yaml
@@ -9,13 +9,6 @@ environment:
 
 dependency_overrides:
   accessibility_tools: ^2.8.0
-  # Keep Mix on the compatible revision while the generator and annotation
-  # packages use their published beta through Remix.
-  mix:
-    git:
-      url: https://github.com/btwld/mix.git
-      ref: 07dafe904e56a9b60a172f4ef1863cf45564603a
-      path: packages/mix
 
 dependencies:
   flutter:
@@ -30,11 +23,6 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mix_protocol:
-    git:
-      url: https://github.com/btwld/mix.git
-      ref: 07dafe904e56a9b60a172f4ef1863cf45564603a
-      path: packages/mix_protocol
   widgetbook_generator: ^3.24.0
 
 flutter:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -17,14 +17,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.8.0"
-  ack:
-    dependency: transitive
-    description:
-      name: ack
-      sha256: "1d9c3f8727cd2b2e04804b6b2d5e42953738f97239eee4e20dc7ef584f1775e4"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.1.0"
   analyzer:
     dependency: transitive
     description:
@@ -425,14 +417,13 @@ packages:
     source: hosted
     version: "2.0.0"
   mix:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
-      path: "packages/mix"
-      ref: "07dafe904e56a9b60a172f4ef1863cf45564603a"
-      resolved-ref: "07dafe904e56a9b60a172f4ef1863cf45564603a"
-      url: "https://github.com/btwld/mix.git"
-    source: git
-    version: "2.1.0"
+      name: mix
+      sha256: "69c94d5b14686ff5add0f59d7d54b302453f7b342c76750d67caf76a0827e88e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.0-beta.1"
   mix_annotations:
     dependency: transitive
     description:
@@ -449,15 +440,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0-beta.2"
-  mix_protocol:
-    dependency: transitive
-    description:
-      path: "packages/mix_protocol"
-      ref: "07dafe904e56a9b60a172f4ef1863cf45564603a"
-      resolved-ref: "07dafe904e56a9b60a172f4ef1863cf45564603a"
-      url: "https://github.com/btwld/mix.git"
-    source: git
-    version: "1.0.0"
   mustache_template:
     dependency: transitive
     description:
@@ -547,7 +529,7 @@ packages:
     source: hosted
     version: "2.0.0"
   pub_semver:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: pub_semver
       sha256: "5bfcf68ca79ef689f8990d1160781b4bad40a3bd5e5218ad4076ddb7f4081585"
@@ -816,7 +798,7 @@ packages:
     source: hosted
     version: "7.0.1"
   yaml:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: yaml
       sha256: b9da305ac7c39faa3f030eccd175340f968459dae4af175130b3fc47e40d76ce

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,6 +7,8 @@ dev_dependencies:
   melos: ^7.1.1
   flutter_lints: ^6.0.0
   build_runner: ^2.10.1
+  pub_semver: ^2.2.0
+  yaml: ^3.1.3
 
 workspace:
   - packages/demo
@@ -43,8 +45,13 @@ melos:
       packageFilters:
         dirExists: test
 
+    mix:consumer:check:
+      run: dart run tool/check_consumer_mix.dart
+      description: Verify consumer tests resolve the declared hosted Mix release
+
     ci:
       steps:
+        - mix:consumer:check
         - generate:check
         - docs:check
         - fortal:parity:check

--- a/tool/check_consumer_mix.dart
+++ b/tool/check_consumer_mix.dart
@@ -1,0 +1,49 @@
+import 'dart:io';
+
+import 'package:pub_semver/pub_semver.dart';
+import 'package:yaml/yaml.dart';
+
+void main() {
+  final workspaceRoot = Directory.current.absolute;
+  final remixPubspec = File(
+    '${workspaceRoot.path}/packages/remix/pubspec.yaml',
+  );
+  final lockfile = File('${workspaceRoot.path}/pubspec.lock');
+  if (!remixPubspec.existsSync() || !lockfile.existsSync()) {
+    stderr.writeln('Run this checker from the Remix workspace root.');
+    exitCode = 64;
+    return;
+  }
+
+  final pubspec = loadYaml(remixPubspec.readAsStringSync()) as YamlMap;
+  final lock = loadYaml(lockfile.readAsStringSync()) as YamlMap;
+  final declared = (pubspec['dependencies'] as YamlMap)['mix'] as String;
+  final resolved = (lock['packages'] as YamlMap)['mix'] as YamlMap;
+  final constraint = VersionConstraint.parse(declared);
+  final source = resolved['source'] as String;
+  final dependency = resolved['dependency'] as String;
+  final version = Version.parse(resolved['version'] as String);
+  final failures = <String>[];
+
+  if (source != 'hosted') {
+    failures.add('expected a hosted source, found $source');
+  }
+  if (dependency.contains('overridden')) {
+    failures.add('the workspace overrides the consumer dependency');
+  }
+  if (!constraint.allows(version)) {
+    failures.add('$version does not satisfy the declared $constraint');
+  }
+
+  stdout.writeln(
+    'Mix consumer resolution: $source $version ($dependency); '
+    'declared $constraint.',
+  );
+  if (failures.isEmpty) return;
+
+  stderr.writeln('Mix consumer validation failed:');
+  for (final failure in failures) {
+    stderr.writeln('- $failure');
+  }
+  exitCode = 1;
+}


### PR DESCRIPTION
## Description

Removes the demo's unused Git Mix and `mix_protocol` pins so workspace tests
resolve Remix's declared hosted Mix range. CI now prints that resolution and
rejects overrides or out-of-range versions before running the existing suite.

Validation: `fvm dart run melos ci` (2,091 tests), plus
`fvm flutter analyze packages/remix` and `packages/demo`.

## Related Issues

Related to #91. Stacked on #80.

---

## Checklist

- [x] My PR includes tests for all changed behavior.
- [x] Documentation is not required for this CI-only change.
- [x] I am prepared to follow up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.
