### PR TITLE
fix(dashboard): keep toast theme state live

### DIFF
--- a/packages/dashboard/lib/widgets/toast.dart
+++ b/packages/dashboard/lib/widgets/toast.dart
@@ -10,13 +10,15 @@ void showToast(
   String? actionLabel,
   VoidCallback? onAction,
 }) {
+  // DashboardApp places its caller-owned Overlay below FortalScope, so entries
+  // inherit live Fortal and Mix state without snapshots.
   final overlay = Overlay.of(context);
-  final mixScope = MixScope.maybeOf(context);
-  final fortalTheme = FortalTheme.maybeOf(context);
   late final OverlayEntry entry;
   entry = OverlayEntry(
-    builder: (_) {
-      Widget child = _ToastBody(
+    builder: (_) => Positioned(
+      right: 24,
+      bottom: 24,
+      child: _ToastBody(
         message: message,
         icon: icon,
         actionLabel: actionLabel,
@@ -24,19 +26,8 @@ void showToast(
           onAction?.call();
           if (entry.mounted) entry.remove();
         },
-      );
-      if (mixScope != null) {
-        child = MixScope(
-          tokens: mixScope.tokens,
-          orderOfModifiers: mixScope.orderOfModifiers,
-          child: child,
-        );
-      }
-      if (fortalTheme != null) {
-        child = FortalTheme(data: fortalTheme, child: child);
-      }
-      return Positioned(right: 24, bottom: 24, child: child);
-    },
+      ),
+    ),
   );
   overlay.insert(entry);
   Timer(const Duration(seconds: 4), () {

--- a/packages/dashboard/test/toast_test.dart
+++ b/packages/dashboard/test/toast_test.dart
@@ -1,0 +1,94 @@
+import 'package:dashboard/main.dart';
+import 'package:dashboard/shell/dashboard_shell.dart';
+import 'package:dashboard/theme/theme_scope.dart';
+import 'package:dashboard/theme/theme_settings.dart';
+import 'package:dashboard/widgets/toast.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:remix/remix.dart';
+
+void main() {
+  testWidgets('visible toast follows live Fortal theme changes', (
+    tester,
+  ) async {
+    final context = await _pumpDashboard(tester);
+
+    showToast(context, message: 'Saved');
+    await tester.pump();
+
+    final before = tester
+        .widget<Icon>(find.byIcon(Icons.check_circle_outline))
+        .color;
+
+    final themeScope = tester.widget<ThemeScope>(find.byType(ThemeScope));
+    themeScope.onChanged(
+      themeScope.settings.copyWith(accentColor: FortalAccentColor.green),
+    );
+    await tester.pump();
+
+    final after = tester
+        .widget<Icon>(find.byIcon(Icons.check_circle_outline))
+        .color;
+    final expected = MixScope.tokenOf(
+      FortalTokens.accent11,
+      tester.element(find.byType(DashboardShell)),
+    );
+
+    await tester.pump(const Duration(seconds: 4));
+
+    expect(after, isNot(before));
+    expect(after, expected);
+  });
+
+  testWidgets('toast action invokes its callback and dismisses the toast', (
+    tester,
+  ) async {
+    final context = await _pumpDashboard(tester);
+    var actionCount = 0;
+
+    showToast(
+      context,
+      message: 'Customer archived',
+      actionLabel: 'Undo',
+      onAction: () => actionCount++,
+    );
+    await tester.pump();
+
+    await tester.tap(find.text('Undo'));
+    await tester.pump();
+
+    expect(actionCount, 1);
+    expect(find.text('Customer archived'), findsNothing);
+
+    await tester.pump(const Duration(seconds: 4));
+  });
+
+  testWidgets('toast dismisses automatically after four seconds', (
+    tester,
+  ) async {
+    final context = await _pumpDashboard(tester);
+
+    showToast(context, message: 'Saved');
+    await tester.pump();
+
+    expect(find.text('Saved'), findsOneWidget);
+
+    await tester.pump(const Duration(milliseconds: 3999));
+    expect(find.text('Saved'), findsOneWidget);
+
+    await tester.pump(const Duration(milliseconds: 1));
+    expect(find.text('Saved'), findsNothing);
+  });
+}
+
+Future<BuildContext> _pumpDashboard(WidgetTester tester) async {
+  await tester.pumpWidget(
+    const DashboardApp(
+      initialSettings: ThemeSettings(
+        appearance: ThemeMode.light,
+        accentColor: FortalAccentColor.blue,
+      ),
+    ),
+  );
+  return tester.element(find.byType(DashboardShell));
+}


### PR DESCRIPTION
## Description

The dashboard toast previously copied the current `MixScope` and `FortalTheme` into its `OverlayEntry`, freezing those values for the lifetime of a visible toast.

This change removes those snapshots so the existing caller-owned Flutter overlay resolves live app-level Fortal state. It adds regression coverage for the exact active accent token, action dismissal, and the four-second automatic timeout.

No Remix application, overlay-host, navigation, or toast API is introduced.

## Related Issues

Closes #97.

---

## Validation

- [x] `fvm flutter test test/toast_test.dart` — 3 tests passed
- [x] `fvm flutter analyze` — no issues
- [x] `fvm flutter test` — 20 tests passed
- [x] `fvm dart run melos run ci` — generation, docs, Fortal parity, 20 dashboard tests, and 2109 Remix tests passed
- [x] `git diff --cached --check`

## Checklist

- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors.
- [x] I have updated or added relevant documentation (the dashboard-private host invariant is documented inline).
- [x] I am prepared to follow up on review comments in a timely manner.

## Breaking Change

Does this PR require users of the package to manually update their code?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.