### PR TITLE
docs(remix): define host capability contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,13 +94,12 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      home: Scaffold(
-        body: Center(
-          child: button(
-            label: 'Click Me',
-            onPressed: () => debugPrint('Button pressed!'),
-          ),
+    return WidgetsApp(
+      color: Colors.blue,
+      builder: (_, _) => Center(
+        child: button(
+          label: 'Click Me',
+          onPressed: () => debugPrint('Button pressed!'),
         ),
       ),
     );
@@ -176,14 +175,13 @@ import 'package:remix/remix.dart';
 class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      home: Scaffold(
-        body: FortalScope(
-          child: Center(
-            child: FortalButton.solid(
-              onPressed: () {},
-              label: 'Fortal Button',
-            ),
+    return FortalScope(
+      child: WidgetsApp(
+        color: Colors.white,
+        builder: (_, _) => Center(
+          child: FortalButton.solid(
+            onPressed: () {},
+            label: 'Fortal Button',
           ),
         ),
       ),
@@ -191,6 +189,47 @@ class MyApp extends StatelessWidget {
   }
 }
 ```
+
+### Host Capabilities
+
+Remix composes inside your existing Flutter host. It does not require a
+`MaterialApp`, `Scaffold`, or Remix-owned application wrapper.
+
+| UI | Caller provides | Compatible hosts |
+|----|-----------------|------------------|
+| Ordinary `Remix*` widgets | The inherited Flutter services used by the widget subtree | Material, Cupertino, Widgets, and router-based hosts |
+| `Fortal*` widgets and recipes | `FortalScope`, in addition to the widget's normal Flutter services | Any Flutter host |
+| Menu, select, popover, and tooltip | An `Overlay` | Any host exposing an overlay; use `Overlay.wrap` when no `Navigator` is needed |
+| `showRemixDialog` and `showRemixAlertDialog` | A `Navigator` | Any host with a caller-owned navigator |
+
+For a portal-based interface without routing, provide only an overlay:
+
+```dart
+import 'package:flutter/widgets.dart';
+import 'package:remix/remix.dart';
+
+Widget buildPortalHost() {
+  return FortalScope(
+    child: WidgetsApp(
+      color: const Color(0xFFFFFFFF),
+      builder: (_, _) => Overlay.wrap(
+        child: Center(
+          child: FortalMenu<String>.soft(
+            trigger: const RemixMenuTrigger(label: 'Actions'),
+            items: const [
+              RemixMenuItem(value: 'share', label: 'Share'),
+            ],
+          ),
+        ),
+      ),
+    ),
+  );
+}
+```
+
+A `MaterialApp`, `CupertinoApp`, `WidgetsApp`, or router with routing configured
+commonly provides a `Navigator` and its overlay already. Dialog helpers push
+routes, so their calling context must be below that caller-owned `Navigator`.
 
 ### Customizing Fortal Styles
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -102,13 +102,12 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      home: Scaffold(
-        body: Center(
-          child: button(
-            label: 'Click Me',
-            onPressed: () => debugPrint('Button pressed!'),
-          ),
+    return WidgetsApp(
+      color: Colors.blue,
+      builder: (_, _) => Center(
+        child: button(
+          label: 'Click Me',
+          onPressed: () => debugPrint('Button pressed!'),
         ),
       ),
     );
@@ -185,13 +184,12 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return FortalScope(
-      child: MaterialApp(
-        home: Scaffold(
-          body: Center(
-            child: FortalButton.solid(
-              onPressed: () {},
-              label: 'Fortal Button',
-            ),
+      child: WidgetsApp(
+        color: Colors.white,
+        builder: (_, _) => Center(
+          child: FortalButton.solid(
+            onPressed: () {},
+            label: 'Fortal Button',
           ),
         ),
       ),
@@ -199,6 +197,47 @@ class MyApp extends StatelessWidget {
   }
 }
 ```
+
+### Host Capabilities
+
+Remix composes inside your existing Flutter host. It does not require a
+`MaterialApp`, `Scaffold`, or Remix-owned application wrapper.
+
+| UI | Caller provides | Compatible hosts |
+|----|-----------------|------------------|
+| Ordinary `Remix*` widgets | The inherited Flutter services used by the widget subtree | Material, Cupertino, Widgets, and router-based hosts |
+| `Fortal*` widgets and recipes | `FortalScope`, in addition to the widget's normal Flutter services | Any Flutter host |
+| Menu, select, popover, and tooltip | An `Overlay` | Any host exposing an overlay; use `Overlay.wrap` when no `Navigator` is needed |
+| `showRemixDialog` and `showRemixAlertDialog` | A `Navigator` | Any host with a caller-owned navigator |
+
+For a portal-based interface without routing, provide only an overlay:
+
+```dart
+import 'package:flutter/widgets.dart';
+import 'package:remix/remix.dart';
+
+Widget buildPortalHost() {
+  return FortalScope(
+    child: WidgetsApp(
+      color: const Color(0xFFFFFFFF),
+      builder: (_, _) => Overlay.wrap(
+        child: Center(
+          child: FortalMenu<String>.soft(
+            trigger: const RemixMenuTrigger(label: 'Actions'),
+            items: const [
+              RemixMenuItem(value: 'share', label: 'Share'),
+            ],
+          ),
+        ),
+      ),
+    ),
+  );
+}
+```
+
+A `MaterialApp`, `CupertinoApp`, `WidgetsApp`, or router with routing configured
+commonly provides a `Navigator` and its overlay already. Dialog helpers push
+routes, so their calling context must be below that caller-owned `Navigator`.
 
 ### Customizing Fortal Styles
 

--- a/packages/remix/README.md
+++ b/packages/remix/README.md
@@ -94,13 +94,12 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      home: Scaffold(
-        body: Center(
-          child: button(
-            label: 'Click Me',
-            onPressed: () => debugPrint('Button pressed!'),
-          ),
+    return WidgetsApp(
+      color: Colors.blue,
+      builder: (_, _) => Center(
+        child: button(
+          label: 'Click Me',
+          onPressed: () => debugPrint('Button pressed!'),
         ),
       ),
     );
@@ -176,14 +175,13 @@ import 'package:remix/remix.dart';
 class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      home: Scaffold(
-        body: FortalScope(
-          child: Center(
-            child: FortalButton.solid(
-              onPressed: () {},
-              label: 'Fortal Button',
-            ),
+    return FortalScope(
+      child: WidgetsApp(
+        color: Colors.white,
+        builder: (_, _) => Center(
+          child: FortalButton.solid(
+            onPressed: () {},
+            label: 'Fortal Button',
           ),
         ),
       ),
@@ -191,6 +189,47 @@ class MyApp extends StatelessWidget {
   }
 }
 ```
+
+### Host Capabilities
+
+Remix composes inside your existing Flutter host. It does not require a
+`MaterialApp`, `Scaffold`, or Remix-owned application wrapper.
+
+| UI | Caller provides | Compatible hosts |
+|----|-----------------|------------------|
+| Ordinary `Remix*` widgets | The inherited Flutter services used by the widget subtree | Material, Cupertino, Widgets, and router-based hosts |
+| `Fortal*` widgets and recipes | `FortalScope`, in addition to the widget's normal Flutter services | Any Flutter host |
+| Menu, select, popover, and tooltip | An `Overlay` | Any host exposing an overlay; use `Overlay.wrap` when no `Navigator` is needed |
+| `showRemixDialog` and `showRemixAlertDialog` | A `Navigator` | Any host with a caller-owned navigator |
+
+For a portal-based interface without routing, provide only an overlay:
+
+```dart
+import 'package:flutter/widgets.dart';
+import 'package:remix/remix.dart';
+
+Widget buildPortalHost() {
+  return FortalScope(
+    child: WidgetsApp(
+      color: const Color(0xFFFFFFFF),
+      builder: (_, _) => Overlay.wrap(
+        child: Center(
+          child: FortalMenu<String>.soft(
+            trigger: const RemixMenuTrigger(label: 'Actions'),
+            items: const [
+              RemixMenuItem(value: 'share', label: 'Share'),
+            ],
+          ),
+        ),
+      ),
+    ),
+  );
+}
+```
+
+A `MaterialApp`, `CupertinoApp`, `WidgetsApp`, or router with routing configured
+commonly provides a `Navigator` and its overlay already. Dialog helpers push
+routes, so their calling context must be below that caller-owned `Navigator`.
 
 ### Customizing Fortal Styles
 

--- a/packages/remix/example/main.dart
+++ b/packages/remix/example/main.dart
@@ -10,13 +10,14 @@ class RemixExampleApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      debugShowCheckedModeBanner: false,
-      home: FortalScope(
-        accent: .blue,
-        gray: .slate,
-        brightness: .light,
-        child: const RemixExampleScreen(),
+    return FortalScope(
+      accent: .blue,
+      gray: .slate,
+      brightness: .light,
+      child: WidgetsApp(
+        color: const Color(0xFFF8FAFC),
+        debugShowCheckedModeBanner: false,
+        builder: (_, _) => Overlay.wrap(child: const RemixExampleScreen()),
       ),
     );
   }
@@ -34,9 +35,9 @@ class _RemixExampleScreenState extends State<RemixExampleScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: const Color(0xFFF8FAFC),
-      body: SafeArea(
+    return ColoredBox(
+      color: const Color(0xFFF8FAFC),
+      child: SafeArea(
         child: Center(
           child: Padding(
             padding: const EdgeInsets.all(16),
@@ -76,6 +77,16 @@ class _RemixExampleScreenState extends State<RemixExampleScreen> {
                           trailingIcon: Icons.arrow_forward_rounded,
                           onPressed: () {
                             debugPrint('Continue pressed');
+                          },
+                        ),
+                        FortalMenu<String>.soft(
+                          trigger: const RemixMenuTrigger(label: 'Actions'),
+                          items: const [
+                            RemixMenuItem(value: 'preview', label: 'Preview'),
+                            RemixMenuItem(value: 'share', label: 'Share'),
+                          ],
+                          onSelected: (value) {
+                            debugPrint('Selected $value');
                           },
                         ),
                       ],

--- a/packages/remix/test/helpers/test_helpers.dart
+++ b/packages/remix/test/helpers/test_helpers.dart
@@ -5,7 +5,11 @@ import 'package:remix/remix.dart';
 
 /// Extension methods for WidgetTester to simplify test setup and interactions
 extension WidgetTesterHelpers on WidgetTester {
-  /// Pumps a Remix widget wrapped in a MaterialApp with Scaffold
+  /// Pumps a Remix widget in the Material interoperability test harness.
+  ///
+  /// `MaterialApp` and `Scaffold` are conveniences here, not Remix host
+  /// requirements. Host-contract tests should provide only the capability
+  /// under test, such as `Overlay.wrap` or a caller-owned `Navigator`.
   Future<void> pumpRemixApp(
     Widget widget, {
     TextDirection textDirection = TextDirection.ltr,
@@ -22,7 +26,7 @@ extension WidgetTesterHelpers on WidgetTester {
     );
   }
 
-  /// Pumps a widget with custom scaffold
+  /// Pumps a widget with a caller-provided Scaffold for Material interop tests.
   Future<void> pumpRemixAppWithScaffold(Widget scaffold) async {
     await pumpWidget(FortalScope(child: MaterialApp(home: scaffold)));
   }
@@ -495,7 +499,7 @@ extension WidgetTesterExtension on WidgetTester {
     );
   }
 
-  /// Pump widget wrapped in MaterialApp
+  /// Pumps a widget in the Material interoperability test harness.
   Future<void> pumpMaterialApp(Widget widget) async {
     await pumpWidget(MaterialApp(home: Scaffold(body: widget)));
   }

--- a/packages/remix/test/host_capabilities_test.dart
+++ b/packages/remix/test/host_capabilities_test.dart
@@ -1,0 +1,174 @@
+import 'dart:ui';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:remix/remix.dart';
+
+void main() {
+  group('Remix host capabilities', () {
+    testWidgets('ordinary Fortal widgets need no Overlay or Navigator', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _widgetsHost(FortalButton(label: 'Continue', onPressed: () {})),
+      );
+
+      expect(find.text('Continue'), findsOneWidget);
+      expect(find.byType(Overlay), findsNothing);
+      expect(find.byType(Navigator), findsNothing);
+    });
+
+    group('caller-owned Overlay', () {
+      testWidgets('opens a Fortal menu without a Navigator', (tester) async {
+        await tester.pumpWidget(
+          _overlayHost(
+            FortalMenu<String>(
+              trigger: const RemixMenuTrigger(label: 'Open menu'),
+              items: const [RemixMenuItem(value: 'item', label: 'Menu item')],
+            ),
+          ),
+        );
+
+        await tester.tap(find.text('Open menu'));
+        await tester.pumpAndSettle();
+
+        _expectThemedOverlayContent(tester, find.text('Menu item'));
+      });
+
+      testWidgets('opens a Fortal select without a Navigator', (tester) async {
+        await tester.pumpWidget(
+          _overlayHost(
+            FortalSelect<String>(
+              trigger: const RemixSelectTrigger(placeholder: 'Open select'),
+              items: const [
+                RemixSelectItem(value: 'item', label: 'Select item'),
+              ],
+            ),
+          ),
+        );
+
+        await tester.tap(find.byType(RemixSelect<String>));
+        await tester.pumpAndSettle();
+
+        _expectThemedOverlayContent(tester, find.text('Select item'));
+      });
+
+      testWidgets('opens a Fortal popover without a Navigator', (tester) async {
+        await tester.pumpWidget(
+          _overlayHost(
+            const FortalPopover(
+              popoverChild: Text('Popover content'),
+              child: Text('Open popover'),
+            ),
+          ),
+        );
+
+        await tester.tap(find.text('Open popover'));
+        await tester.pumpAndSettle();
+
+        _expectThemedOverlayContent(tester, find.text('Popover content'));
+      });
+
+      testWidgets('opens a Fortal tooltip without a Navigator', (tester) async {
+        await tester.pumpWidget(
+          _overlayHost(
+            const FortalTooltip(
+              tooltipChild: Text('Tooltip content'),
+              child: Text('Hover target'),
+            ),
+          ),
+        );
+
+        final gesture = await tester.createGesture(
+          kind: PointerDeviceKind.mouse,
+        );
+        await gesture.addPointer(location: Offset.zero);
+        await tester.pump();
+        await gesture.moveTo(tester.getCenter(find.text('Hover target')));
+        await tester.pump(const Duration(milliseconds: 200));
+        await tester.pumpAndSettle();
+
+        _expectThemedOverlayContent(tester, find.text('Tooltip content'));
+      });
+    });
+
+    testWidgets('opens a dialog with a caller-owned Navigator', (tester) async {
+      await tester.pumpWidget(
+        _navigatorHost(
+          Builder(
+            builder: (context) => FortalButton(
+              label: 'Open dialog',
+              onPressed: () => showRemixDialog<void>(
+                context: context,
+                transitionDuration: Duration.zero,
+                builder: (context) =>
+                    const Center(child: FortalDialog(title: 'Dialog title')),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(Navigator), findsOneWidget);
+
+      await tester.tap(find.text('Open dialog'));
+      await tester.pump();
+      await tester.pump();
+
+      final dialogTitle = find.text('Dialog title');
+      expect(dialogTitle, findsOneWidget);
+      _expectFortalInheritance(tester, dialogTitle);
+    });
+  });
+}
+
+Widget _widgetsHost(Widget child) {
+  return FortalScope(
+    brightness: .light,
+    child: WidgetsApp(
+      color: const Color(0xFFFFFFFF),
+      builder: (_, _) => Center(child: child),
+    ),
+  );
+}
+
+Widget _overlayHost(Widget child) {
+  return FortalScope(
+    brightness: .light,
+    child: WidgetsApp(
+      color: const Color(0xFFFFFFFF),
+      builder: (_, _) => Overlay.wrap(child: Center(child: child)),
+    ),
+  );
+}
+
+Widget _navigatorHost(Widget child) {
+  return FortalScope(
+    brightness: .light,
+    child: WidgetsApp(
+      color: const Color(0xFFFFFFFF),
+      builder: (_, _) => Navigator(
+        onGenerateRoute: (settings) => PageRouteBuilder<void>(
+          settings: settings,
+          transitionDuration: Duration.zero,
+          reverseTransitionDuration: Duration.zero,
+          pageBuilder: (_, _, _) => Center(child: child),
+        ),
+      ),
+    ),
+  );
+}
+
+void _expectThemedOverlayContent(WidgetTester tester, Finder content) {
+  expect(find.byType(Overlay), findsOneWidget);
+  expect(find.byType(Navigator), findsNothing);
+  expect(content, findsOneWidget);
+  _expectFortalInheritance(tester, content);
+}
+
+void _expectFortalInheritance(WidgetTester tester, Finder content) {
+  final context = tester.element(content);
+  expect(FortalTheme.maybeOf(context), isNotNull);
+  expect(MixScope.maybeOf(context), isNotNull);
+  expect(MixScope.tokenOf(FortalTokens.accent9, context), isA<Color>());
+}

--- a/packages/remix/tool/validate_docs.dart
+++ b/packages/remix/tool/validate_docs.dart
@@ -438,12 +438,12 @@ void _checkNavigation(
 void _checkFortalScopeTopology(Directory workspaceRoot, List<String> failures) {
   final index = File('${workspaceRoot.path}/docs/index.mdx').readAsStringSync();
   final topology = RegExp(
-    r'return\s+FortalScope\s*\(\s*child:\s*MaterialApp\s*\(',
+    r'return\s+FortalScope\s*\(\s*child:\s*WidgetsApp\s*\(',
     dotAll: true,
   );
   if (!topology.hasMatch(index)) {
     failures.add(
-      'docs/index.mdx must place the root FortalScope above MaterialApp.',
+      'docs/index.mdx must place the root FortalScope above WidgetsApp.',
     );
   }
 }

--- a/skills/using-remix/SKILL.md
+++ b/skills/using-remix/SKILL.md
@@ -17,6 +17,7 @@ standalone branded design-system package built on Remix, use the
 ## Quick Start
 
 ```dart
+import 'package:flutter/widgets.dart';
 import 'package:remix/remix.dart';
 ```
 
@@ -27,7 +28,10 @@ FortalScope(
   accent: FortalAccentColor.indigo,  // 31 options (default .indigo)
   gray: FortalGrayColor.slate,       // 6 neutral scales (default .slate)
   brightness: Brightness.light,      // or .dark
-  child: MaterialApp(home: MyScreen()),
+  child: WidgetsApp(
+    color: const Color(0xFFFFFFFF),
+    builder: (_, _) => const MyScreen(),
+  ),
 )
 ```
 
@@ -49,6 +53,48 @@ calls such as `FortalRadio.soft(value: 'option')` do not need `<String>`.
 Plain `Remix*` widgets work without `FortalScope`, but anything Fortal
 (`Fortal*` widgets, `fortal*Style()` functions, `FortalTokens`) requires it
 to resolve tokens.
+
+## Host Capabilities
+
+Remix composes inside the caller's Flutter host. Do not add a `RemixApp`,
+`RemixOverlayHost`, or `RemixScaffold`.
+
+| UI | Caller provides | Compatible hosts |
+|----|-----------------|------------------|
+| Ordinary `Remix*` widgets | The inherited Flutter services used by the widget subtree | Material, Cupertino, Widgets, and router-based hosts |
+| `Fortal*` widgets and recipes | `FortalScope`, in addition to the widget's normal Flutter services | Any Flutter host |
+| Menu, select, popover, and tooltip | An `Overlay` | Any host exposing an overlay; use `Overlay.wrap` when no `Navigator` is needed |
+| `showRemixDialog` and `showRemixAlertDialog` | A `Navigator` | Any host with a caller-owned navigator |
+
+Use the smallest host capability required by the screen. A portal-only screen
+can use a caller-owned overlay without routing:
+
+```dart
+import 'package:flutter/widgets.dart';
+import 'package:remix/remix.dart';
+
+Widget buildPortalHost() {
+  return FortalScope(
+    child: WidgetsApp(
+      color: const Color(0xFFFFFFFF),
+      builder: (_, _) => Overlay.wrap(
+        child: Center(
+          child: FortalMenu<String>.soft(
+            trigger: const RemixMenuTrigger(label: 'Actions'),
+            items: const [
+              RemixMenuItem(value: 'share', label: 'Share'),
+            ],
+          ),
+        ),
+      ),
+    ),
+  );
+}
+```
+
+Material, Cupertino, Widgets, and router hosts with routing configured commonly
+provide a `Navigator` and its overlay already. Dialog helpers push routes, so
+their calling context must be below that caller-owned `Navigator`.
 
 ## Three levels of styling
 
@@ -404,7 +450,10 @@ class AppStyles {
 RemixButton(label: 'Save', onPressed: save, style: AppStyles.primaryButton)
 ```
 
-### Dark Mode Toggle
+### Material Dark Mode Interoperability
+
+When the caller uses `MaterialApp`, keep its theme brightness aligned with
+`FortalScope`. `MaterialApp` and `Scaffold` are not Remix requirements.
 
 ```dart
 class _MyAppState extends State<MyApp> {

--- a/skills/using-remix/references/components.md
+++ b/skills/using-remix/references/components.md
@@ -348,6 +348,11 @@ thickness), no variant.
 
 ## Overlays
 
+Menu, select, popover, and tooltip content uses the nearest caller-provided
+`Overlay`; these components do not require a `Navigator`. If the existing host
+does not expose an overlay, wrap the relevant subtree with `Overlay.wrap`.
+Dialog helpers push routes and therefore require a caller-provided `Navigator`.
+
 ### showRemixDialog\<T\>
 
 The only `showRemix*` helper in the package. It wraps `showNakedDialog`. When


### PR DESCRIPTION
## Description

Defines Remix's host capability contract without introducing a Remix-owned app, overlay, navigator, or scaffold abstraction.

- Migrates the canonical package example to `FortalScope` + `WidgetsApp` + caller-owned `Overlay.wrap`, with no `MaterialApp`, `Scaffold`, or `Navigator`.
- Adds widget contracts for ordinary Fortal widgets, menu/select/popover/tooltip under an overlay without navigation, and dialogs under an explicit caller-owned navigator. Overlay content also verifies live Fortal and Mix inheritance.
- Aligns the README, documentation homepage, consumer skill, component guidance, shared test guidance, and docs validator with the verified host requirements.

## Validation

- `fvm flutter analyze` — passed with no issues.
- `fvm dart run melos run ci` — passed generation, documentation, Fortal parity, 20 dashboard tests, and 2,115 Remix tests.

## Related Issues

Closes #96.

---

## Checklist

**Note**: Updating the `pubspec.yaml` and `CHANGELOG.md` is not required. These are handled automatically during the release process.

- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors.
- [x] I have updated or added relevant documentation (doc comments with `///`).
- [x] I am prepared to follow up on review comments in a timely manner.

## Breaking Change

Does this PR require users of the package to manually update their code?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.
