### PR TITLE
feat(remix): add compound menu items with Radix-parity styling

### DIFF
--- a/docs/components/menu.mdx
+++ b/docs/components/menu.mdx
@@ -224,6 +224,12 @@ The root `items` list, each radio group's `items`, and every submenu's `items`
 are copied to immutable snapshots when their panel is built. Rebuild the menu
 after changing a source list; do not rely on mutating a visible panel in place.
 
+For dynamic menus, including lists that are filtered, have items inserted, or
+are reordered, supply a stable caller-owned `key:` on each ordinary item,
+checkbox item, radio group, radio item, submenu, and divider. Build keys from
+application-owned item identity and keep them stable across rebuilds. Item keys
+are not derived automatically from labels or values.
+
 ## Compound-item styling
 
 Compound rows use the same `MenuItemStyler` as ordinary rows, including
@@ -280,7 +286,7 @@ class FortalMenuExample extends StatelessWidget {
     final choiceItemStyle = MenuItemStyler().indicator(
       IconStyler().color(Colors.indigo),
     );
-    final menuStyle = MenuStyler()
+    final customStyle = MenuStyler()
         .checkboxItem(choiceItemStyle)
         .radioItem(choiceItemStyle);
     final items = <RemixMenuItemData<String>>[
@@ -306,14 +312,18 @@ class FortalMenuExample extends StatelessWidget {
     return Row(
       spacing: 16,
       children: [
-        FortalMenu<String>.solid(
-          style: menuStyle,
+        RemixMenu<String>(
+          style: fortalMenuStyle(
+            variant: FortalMenuVariant.solid,
+          ).merge(customStyle),
           trigger: const RemixMenuTrigger(label: 'Solid', icon: Icons.menu),
           items: items,
           onSelected: (value) => debugPrint(value),
         ),
-        FortalMenu<String>.soft(
-          style: menuStyle,
+        RemixMenu<String>(
+          style: fortalMenuStyle(
+            variant: FortalMenuVariant.soft,
+          ).merge(customStyle),
           trigger: const RemixMenuTrigger(label: 'Soft', icon: Icons.menu),
           items: items,
           onSelected: (value) => debugPrint(value),
@@ -325,9 +335,10 @@ class FortalMenuExample extends StatelessWidget {
 ```
 </CodeGroup>
 
-The generated default, `solid`, and `soft` constructors all accept `style:`.
-Pass a reusable `MenuStyler`; its fields merge after the Fortal recipe. A null
-override preserves the recipe unchanged.
+The generated `FortalMenu`, `FortalMenu.solid`, and `FortalMenu.soft`
+constructors apply only the selected recipe. For reusable menu-wide
+customization, pass `fortalMenuStyle(...).merge(customStyle)` to
+`RemixMenu.style`; the custom fields merge after the recipe.
 
 <Info>
   See the [fortalMenuStyle source code](https://github.com/btwld/remix/blob/main/packages/remix/lib/src/components/menu/fortal_menu_styles.dart) for all available options.

--- a/docs/components/menu.mdx
+++ b/docs/components/menu.mdx
@@ -39,20 +39,18 @@ class _MenuExampleState extends State<MenuExample> {
           value: 'History',
           leadingIcon: Icons.history,
           label: 'History',
-          style: menuItemStyle,
         ),
         RemixMenuItem(
           value: 'Settings',
           leadingIcon: Icons.settings,
           label: 'Settings',
-          style: menuItemStyle,
         ),
         const RemixMenuDivider(),
         RemixMenuItem(
           value: 'Logout',
           leadingIcon: Icons.logout,
           label: 'Logout',
-          style: menuItemStyle.onHovered(
+          style: MenuItemStyler().onHovered(
             MenuItemStyler()
                 .color(Colors.redAccent.withValues(alpha: 0.05))
                 .label(TextStyler().color(Colors.redAccent))
@@ -114,7 +112,8 @@ class _MenuExampleState extends State<MenuExample> {
               ],
             ),
           ),
-        );
+        )
+        .item(menuItemStyle);
   }
 
   MenuItemStyler get menuItemStyle {
@@ -130,6 +129,140 @@ class _MenuExampleState extends State<MenuExample> {
 ```
 </CodeGroup>
 
+## Checkboxes, radio groups, and submenus
+
+Checkboxes and radio groups are controlled. Keep their current value in your
+widget state and update that state from `onChanged`. Submenus can contain any
+menu item data, including another submenu.
+
+<CodeGroup title="Controlled compound items" defaultLanguage="dart">
+```dart
+import 'package:flutter/material.dart';
+import 'package:remix/remix.dart';
+
+class CompoundMenuExample extends StatefulWidget {
+  const CompoundMenuExample({super.key});
+
+  @override
+  State<CompoundMenuExample> createState() => _CompoundMenuExampleState();
+}
+
+class _CompoundMenuExampleState extends State<CompoundMenuExample> {
+  bool showStatus = true;
+  String density = 'comfortable';
+
+  @override
+  Widget build(BuildContext context) {
+    return FortalMenu<String>.soft(
+      trigger: const RemixMenuTrigger(label: 'View options'),
+      onSelected: (value) => debugPrint('Root selected: $value'),
+      items: [
+        RemixMenuCheckboxItem(
+          value: 'show-status',
+          label: 'Show status',
+          checked: showStatus,
+          closeOnActivate: false,
+          onChanged: (next) => setState(() => showStatus = next),
+        ),
+        RemixMenuRadioGroup(
+          value: density,
+          onChanged: (next) => setState(() => density = next),
+          items: const [
+            RemixMenuRadioItem(
+              value: 'compact',
+              label: 'Compact',
+              closeOnActivate: false,
+            ),
+            RemixMenuRadioItem(
+              value: 'comfortable',
+              label: 'Comfortable',
+              closeOnActivate: false,
+            ),
+          ],
+        ),
+        const RemixMenuDivider(),
+        const RemixMenuSubmenu(
+          label: 'Share',
+          items: [
+            RemixMenuItem(value: 'copy-link', label: 'Copy link'),
+            RemixMenuSubmenu(
+              label: 'More',
+              items: [
+                RemixMenuItem(value: 'email', label: 'Email'),
+              ],
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+```
+</CodeGroup>
+
+`RemixMenuCheckboxItem.checked` and `RemixMenuRadioGroup.value` are never
+changed internally. On activation, `RemixMenu.onSelected` runs first, followed
+by the checkbox or radio-group `onChanged`. Selecting the already-selected
+radio item re-emits its value. A checkbox or radio item is disabled when neither
+its local callback nor the root `onSelected` callback is supplied.
+
+`closeOnActivate` defaults to `true`. Set it to `false` for settings that should
+remain visible while they are changed. Submenus open after a 100 ms hover delay
+by default. The directional forward-arrow opens a focused submenu, the reverse
+arrow closes it, and Escape closes it and restores focus to its trigger. These
+directions are mirrored automatically in right-to-left layouts.
+
+| Key | Behavior |
+| --- | --- |
+| Down / Up arrow | Move focus between enabled items |
+| Enter / Space | Activate the focused item |
+| Right arrow in LTR / Left arrow in RTL | Open the focused submenu and focus its first item |
+| Left arrow in LTR / Right arrow in RTL | Close the current submenu and focus its trigger |
+| Escape | Close the current menu level and restore trigger focus |
+
+The root `items` list, each radio group's `items`, and every submenu's `items`
+are copied to immutable snapshots when their panel is built. Rebuild the menu
+after changing a source list; do not rely on mutating a visible panel in place.
+
+## Compound-item styling
+
+Compound rows use the same `MenuItemStyler` as ordinary rows, including
+hovered, focused, pressed, disabled, and selected-state variants. An open
+submenu trigger contributes `WidgetState.selected`.
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:remix/remix.dart';
+
+final sharedItemStyle = MenuItemStyler()
+    .paddingX(12)
+    .spacing(8)
+    .onSelected(.color(Colors.indigo.withValues(alpha: 0.08)));
+
+final choiceItemStyle = MenuItemStyler().indicator(
+  IconStyler().size(9).color(Colors.indigo),
+);
+
+final appMenuStyle = MenuStyler()
+    .item(sharedItemStyle)
+    .checkboxItem(choiceItemStyle)
+    .radioItem(choiceItemStyle)
+    .submenuItem(
+      MenuItemStyler().trailingIcon(IconStyler().color(Colors.indigo)),
+    );
+```
+
+`item` is the shared foundation for every actionable row. The semantic
+`checkboxItem`, `radioItem`, and `submenuItem` styles merge after it, and an
+individual item's `style` merges last. `RemixMenuRadioGroup` is behavioral and
+does not add another styling layer. Use the normal `MenuItemStyler` flex,
+padding, and spacing methods for layout.
+
+The renderer reserves one leading choice slot for every row in a panel when
+that panel directly contains a checkbox or radio group. Nested submenu panels
+decide this independently. A custom `trailingIcon` replaces the default
+directional submenu chevron.
+
 ## Fortal widgets
 
 Remix includes a Fortal-themed widget for this component:
@@ -144,27 +277,43 @@ class FortalMenuExample extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final choiceItemStyle = MenuItemStyler().indicator(
+      IconStyler().color(Colors.indigo),
+    );
+    final menuStyle = MenuStyler()
+        .checkboxItem(choiceItemStyle)
+        .radioItem(choiceItemStyle);
     final items = <RemixMenuItemData<String>>[
-      RemixMenuItem(
+      const RemixMenuItem(
         value: 'edit',
         label: 'Edit',
         leadingIcon: Icons.edit,
       ),
-      RemixMenuItem(
-        value: 'delete',
-        label: 'Delete',
-        leadingIcon: Icons.delete,
+      const RemixMenuCheckboxItem(
+        value: 'show-status',
+        label: 'Show status',
+        checked: true,
+      ),
+      const RemixMenuRadioGroup(
+        value: 'comfortable',
+        items: [
+          RemixMenuRadioItem(value: 'compact', label: 'Compact'),
+          RemixMenuRadioItem(value: 'comfortable', label: 'Comfortable'),
+        ],
       ),
     ];
+
     return Row(
       spacing: 16,
       children: [
-        FortalMenu.solid(
+        FortalMenu<String>.solid(
+          style: menuStyle,
           trigger: const RemixMenuTrigger(label: 'Solid', icon: Icons.menu),
           items: items,
           onSelected: (value) => debugPrint(value),
         ),
-        FortalMenu.soft(
+        FortalMenu<String>.soft(
+          style: menuStyle,
           trigger: const RemixMenuTrigger(label: 'Soft', icon: Icons.menu),
           items: items,
           onSelected: (value) => debugPrint(value),
@@ -175,6 +324,10 @@ class FortalMenuExample extends StatelessWidget {
 }
 ```
 </CodeGroup>
+
+The generated default, `solid`, and `soft` constructors all accept `style:`.
+Pass a reusable `MenuStyler`; its fields merge after the Fortal recipe. A null
+override preserves the recipe unchanged.
 
 <Info>
   See the [fortalMenuStyle source code](https://github.com/btwld/remix/blob/main/packages/remix/lib/src/components/menu/fortal_menu_styles.dart) for all available options.
@@ -222,7 +375,7 @@ Optional. Controls how one widget replaces another widget in the tree.
 
 #### `items` → `List<RemixMenuItemData<T>>`
 
-**Required**. The list of menu items and dividers. Use [RemixMenuItem] for selectable items and [RemixMenuDivider] for separators.
+**Required**. The list of ordinary items, checkbox items, radio groups, submenus, and dividers.
 
 #### `controller` → `MenuController?`
 
@@ -279,6 +432,8 @@ Optional. The style configuration for the menu.
 #### `styleSpec` → `MenuSpec?`
 
 Optional. A raw resolved style spec that bypasses fluent style resolution.
+For semantic item fields, `null` inherits the raw `item` spec and a supplied
+value completely replaces it; per-item fluent styles remain bypassed.
 
 
 ### Menu Style Methods
@@ -293,7 +448,19 @@ Configures the menu overlay container style.
 
 #### `item(MenuItemStyler value)`
 
-Configures the default menu item style.
+Configures the shared default for every actionable menu row.
+
+#### `checkboxItem(MenuItemStyler value)`
+
+Configures the menu-wide checkbox-row override after `item`.
+
+#### `radioItem(MenuItemStyler value)`
+
+Configures the menu-wide radio-row override after `item`.
+
+#### `submenuItem(MenuItemStyler value)`
+
+Configures the menu-wide submenu-trigger override after `item`.
 
 #### `divider(DividerStyler value)`
 
@@ -454,6 +621,10 @@ Configures the leading icon style.
 #### `trailingIcon(IconStyler value)`
 
 Configures the trailing icon style.
+
+#### `indicator(IconStyler value)`
+
+Configures the checkbox and radio indicator style.
 
 #### `alignment(Alignment value)`
 

--- a/packages/playground/lib/registry/component_registry.dart
+++ b/packages/playground/lib/registry/component_registry.dart
@@ -10,6 +10,7 @@ import 'entries/callout_entry.dart';
 import 'entries/card_entry.dart';
 import 'entries/checkbox_entry.dart';
 import 'entries/divider_entry.dart';
+import 'entries/menu_entry.dart';
 import 'entries/progress_entry.dart';
 import 'entries/radio_entry.dart';
 import 'entries/select_entry.dart';
@@ -48,6 +49,16 @@ final Map<String, WidgetBuilder> components = {
   'slider': (context) => FortalScope(
     brightness: Theme.of(context).brightness,
     child: PreviewShell(child: buildSliderExample()),
+  ),
+  // Resolve Fortal inside PreviewShell so its light/dark control owns tokens.
+  'menu': (context) => PreviewShell(
+    child: Builder(
+      builder: (context) => FortalScope(
+        brightness: Theme.of(context).brightness,
+        hasBackground: false,
+        child: buildMenuExample(),
+      ),
+    ),
   ),
   // A consolidated page to preview all components together
   'all': (context) => FortalScope(

--- a/packages/playground/lib/registry/entries/menu_entry.dart
+++ b/packages/playground/lib/registry/entries/menu_entry.dart
@@ -1,0 +1,103 @@
+import 'package:flutter/material.dart';
+import 'package:remix/remix.dart';
+
+Widget buildMenuExample() => const _MenuExample();
+
+class _MenuExample extends StatefulWidget {
+  const _MenuExample();
+
+  @override
+  State<_MenuExample> createState() => _MenuExampleState();
+}
+
+class _MenuExampleState extends State<_MenuExample> {
+  bool _showStatus = true;
+  String _density = 'comfortable';
+  String _lastSelection = 'None';
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 320,
+      child: Column(
+        mainAxisSize: .min,
+        crossAxisAlignment: .start,
+        children: [
+          Text('Compound menu', style: Theme.of(context).textTheme.titleMedium),
+          const SizedBox(height: 8),
+          Text(
+            'Open the menu and use the arrow keys to see focus and nested navigation.',
+            style: Theme.of(context).textTheme.bodySmall,
+          ),
+          const SizedBox(height: 16),
+          FortalMenu<String>.soft(
+            trigger: const RemixMenuTrigger(
+              label: 'View options',
+              icon: Icons.tune,
+            ),
+            onSelected: (value) {
+              setState(() => _lastSelection = value);
+            },
+            items: [
+              const RemixMenuItem(
+                value: 'rename',
+                label: 'Rename',
+                leadingIcon: Icons.edit_outlined,
+                trailingIcon: Icons.keyboard_command_key,
+              ),
+              const RemixMenuItem(
+                value: 'locked',
+                label: 'Locked action',
+                leadingIcon: Icons.lock_outline,
+                enabled: false,
+              ),
+              const RemixMenuDivider(),
+              RemixMenuCheckboxItem(
+                value: 'show-status',
+                label: 'Show status',
+                checked: _showStatus,
+                closeOnActivate: false,
+                onChanged: (next) => setState(() => _showStatus = next),
+              ),
+              RemixMenuRadioGroup(
+                value: _density,
+                onChanged: (next) => setState(() => _density = next),
+                items: const [
+                  RemixMenuRadioItem(
+                    value: 'compact',
+                    label: 'Compact',
+                    closeOnActivate: false,
+                  ),
+                  RemixMenuRadioItem(
+                    value: 'comfortable',
+                    label: 'Comfortable',
+                    closeOnActivate: false,
+                  ),
+                ],
+              ),
+              const RemixMenuDivider(),
+              const RemixMenuSubmenu(
+                label: 'Share',
+                leadingIcon: Icons.ios_share_outlined,
+                items: [
+                  RemixMenuItem(value: 'copy-link', label: 'Copy link'),
+                  RemixMenuSubmenu(
+                    label: 'Send with',
+                    items: [
+                      RemixMenuItem(value: 'email', label: 'Email'),
+                      RemixMenuItem(value: 'messages', label: 'Messages'),
+                    ],
+                  ),
+                ],
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          Text('Last selection: $_lastSelection'),
+          Text('Status: ${_showStatus ? 'shown' : 'hidden'}'),
+          Text('Density: $_density'),
+        ],
+      ),
+    );
+  }
+}

--- a/packages/remix/CHANGELOG.md
+++ b/packages/remix/CHANGELOG.md
@@ -3,9 +3,9 @@
 - **BREAKING** **FEAT**: Add checkbox items, radio groups, and submenus to the
   sealed `RemixMenuItemData` hierarchy. Downstream exhaustive switches must
   handle the new cases or add a wildcard; no runtime migration is required.
-- **FEAT**: Let the generated `FortalMenu`, `FortalMenu.solid`, and
-  `FortalMenu.soft` constructors accept a reusable menu-wide `style:` override
-  that merges after the Fortal recipe.
+- **FEAT**: Support reusable menu-wide customization by passing
+  `fortalMenuStyle(...).merge(customStyle)` to `RemixMenu.style`; generated
+  `FortalMenu` constructors remain recipe-only.
 - **FEAT**: Add the Remix rendering subsystem for layered inset and outer
   shadows, gradients, outlines, backdrop blur, blend modes, and ordered color
   filters used by the Radix-accurate Fortal recipes.

--- a/packages/remix/CHANGELOG.md
+++ b/packages/remix/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+- **BREAKING** **FEAT**: Add checkbox items, radio groups, and submenus to the
+  sealed `RemixMenuItemData` hierarchy. Downstream exhaustive switches must
+  handle the new cases or add a wildcard; no runtime migration is required.
+- **FEAT**: Let the generated `FortalMenu`, `FortalMenu.solid`, and
+  `FortalMenu.soft` constructors accept a reusable menu-wide `style:` override
+  that merges after the Fortal recipe.
 - **FEAT**: Add the Remix rendering subsystem for layered inset and outer
   shadows, gradients, outlines, backdrop blur, blend modes, and ordered color
   filters used by the Radix-accurate Fortal recipes.

--- a/packages/remix/lib/src/components/menu/fortal_menu_styles.dart
+++ b/packages/remix/lib/src/components/menu/fortal_menu_styles.dart
@@ -12,10 +12,6 @@ MenuStyler fortalMenuStyle({
   FortalMenuVariant variant = .solid,
   FortalMenuSize size = .size2,
   bool highContrast = false,
-  // Typed as the Mix supertype because the generated MenuStyler cannot be
-  // named in this signature: the widget generator resolves same-build
-  // generated classes as InvalidType.
-  Style<MenuSpec>? style,
 }) {
   final metrics = _fortalMenuMetrics(size);
   final base = MenuStyler()
@@ -42,7 +38,7 @@ MenuStyler fortalMenuStyle({
       )
       .divider(_fortalMenuDividerStyler(metrics));
 
-  return base.merge(style as MenuStyler?);
+  return base;
 }
 
 /// Fortal item recipe for per-item style overrides.

--- a/packages/remix/lib/src/components/menu/fortal_menu_styles.dart
+++ b/packages/remix/lib/src/components/menu/fortal_menu_styles.dart
@@ -12,24 +12,34 @@ MenuStyler fortalMenuStyle({
   FortalMenuVariant variant = .solid,
   FortalMenuSize size = .size2,
   bool highContrast = false,
+  FortalMenuStyleOverride? style,
 }) {
   final metrics = _fortalMenuMetrics(size);
-  return MenuStyler()
+  final base = MenuStyler()
+      .trigger(_fortalMenuTriggerStyler(metrics))
       .overlay(
         FlexBoxStyler()
             .paddingAll(metrics.contentPadding)
             .borderRadiusAll(metrics.contentRadius)
-            .color(FortalTokens.colorPanel())
+            // Radix pins menus to the solid panel with no backdrop blur,
+            // even when the theme panel background is translucent.
+            .color(FortalTokens.colorPanelSolid())
             .decoration(
               BoxDecorationMix.create(boxShadow: FortalTokens.shadow5.mix()),
             )
             .clipBehavior(Clip.antiAlias),
       )
-      .containerEffects(
-        RemixBoxEffectsMix(backdropBlur: FortalTokens.panelBlur()),
-      )
       .item(_fortalMenuItemStyler(variant, metrics, highContrast: highContrast))
+      .submenuItem(
+        _fortalMenuSubmenuItemStyler(
+          variant,
+          metrics,
+          highContrast: highContrast,
+        ),
+      )
       .divider(_fortalMenuDividerStyler(metrics));
+
+  return base.merge(style as MenuStyler?);
 }
 
 /// Fortal item recipe for per-item style overrides.
@@ -42,6 +52,15 @@ MenuItemStyler fortalMenuItemStyle({
   _fortalMenuMetrics(size),
   highContrast: highContrast,
 );
+
+/// Radix has no menu-owned trigger; this mirrors the base Radix button
+/// content treatment (gap, text token, icon) without button chrome.
+MenuTriggerStyler _fortalMenuTriggerStyler(_FortalMenuMetrics metrics) =>
+    MenuTriggerStyler()
+        .crossAxisAlignment(.center)
+        .spacing(metrics.triggerGap)
+        .label(.style(metrics.text.mix()).color(FortalTokens.gray12()))
+        .icon(.color(FortalTokens.gray12()).size(metrics.contentIconSize));
 
 MenuItemStyler _fortalMenuItemStyler(
   FortalMenuVariant variant,
@@ -57,53 +76,78 @@ MenuItemStyler _fortalMenuItemStyler(
       .paddingX(metrics.leadingInset)
       .borderRadiusAll(metrics.itemRadius)
       .label(.style(metrics.text.mix()).color(FortalTokens.gray12()))
-      .leadingIcon(.color(FortalTokens.gray12()).size(metrics.indicatorSize))
-      .trailingIcon(.color(FortalTokens.gray12()).size(metrics.indicatorSize));
-
-  final highlighted = switch (variant) {
-    .solid =>
-      MenuItemStyler()
-          .color(
-            highContrast ? FortalTokens.accent12() : FortalTokens.accent9(),
-          )
-          .label(
-            .color(
-              highContrast
-                  ? FortalTokens.accent1()
-                  : FortalTokens.accentContrast(),
-            ),
-          )
-          .leadingIcon(
-            .color(
-              highContrast
-                  ? FortalTokens.accent1()
-                  : FortalTokens.accentContrast(),
-            ),
-          )
-          .trailingIcon(
-            .color(
-              highContrast
-                  ? FortalTokens.accent1()
-                  : FortalTokens.accentContrast(),
-            ),
-          ),
-    .soft => MenuItemStyler().color(FortalTokens.accentA4()),
-  };
-  final submenuOpen = MenuItemStyler().color(
-    variant == .solid ? FortalTokens.grayA3() : FortalTokens.accentA3(),
+      // Radix pins only indicator/subtrigger icons (8/10px); content icons
+      // follow the repo-wide text-matched sizes used by tabs and toggles.
+      .leadingIcon(.color(FortalTokens.gray12()).size(metrics.contentIconSize))
+      .trailingIcon(
+        .color(FortalTokens.grayA11()).size(metrics.contentIconSize),
+      )
+      .indicator(.color(FortalTokens.gray12()).size(metrics.indicatorSize));
+  final highlighted = _fortalMenuHighlightedItemStyler(
+    variant,
+    highContrast: highContrast,
   );
   final disabled = MenuItemStyler()
       .color(Colors.transparent)
       .label(.color(FortalTokens.grayA8()))
       .leadingIcon(.color(FortalTokens.grayA8()))
-      .trailingIcon(.color(FortalTokens.grayA8()));
+      .trailingIcon(.color(FortalTokens.grayA8()))
+      .indicator(.color(FortalTokens.grayA8()));
 
   return base
-      .onSelected(submenuOpen)
       .onHovered(highlighted)
       .onFocused(highlighted)
       .onPressed(highlighted)
       .onDisabled(disabled);
+}
+
+MenuItemStyler _fortalMenuHighlightedItemStyler(
+  FortalMenuVariant variant, {
+  required bool highContrast,
+}) {
+  final solidForeground = highContrast
+      ? FortalTokens.accent1()
+      : FortalTokens.accentContrast();
+
+  return switch (variant) {
+    .solid =>
+      MenuItemStyler()
+          .color(
+            highContrast ? FortalTokens.accent12() : FortalTokens.accent9(),
+          )
+          .label(.color(solidForeground))
+          .leadingIcon(.color(solidForeground))
+          .trailingIcon(.color(solidForeground))
+          .indicator(.color(solidForeground)),
+    .soft =>
+      MenuItemStyler()
+          .color(FortalTokens.accentA4())
+          .trailingIcon(.color(FortalTokens.gray12())),
+  };
+}
+
+MenuItemStyler _fortalMenuSubmenuItemStyler(
+  FortalMenuVariant variant,
+  _FortalMenuMetrics metrics, {
+  required bool highContrast,
+}) {
+  final highlighted = _fortalMenuHighlightedItemStyler(
+    variant,
+    highContrast: highContrast,
+  );
+  final submenuOpen = MenuItemStyler()
+      .color(
+        variant == .solid ? FortalTokens.grayA3() : FortalTokens.accentA3(),
+      )
+      .onHovered(highlighted)
+      .onFocused(highlighted)
+      .onPressed(highlighted);
+
+  // The chevron keeps the exact Radix subtrigger icon size even though
+  // content trailing icons are text-matched.
+  return MenuItemStyler()
+      .trailingIcon(.color(FortalTokens.gray12()).size(metrics.indicatorSize))
+      .onSelected(submenuOpen);
 }
 
 DividerStyler _fortalMenuDividerStyler(_FortalMenuMetrics metrics) =>
@@ -126,6 +170,8 @@ class _FortalMenuMetrics {
     required this.leadingInset,
     required this.trailingInset,
     required this.indicatorSize,
+    required this.contentIconSize,
+    required this.triggerGap,
     required this.text,
   });
 
@@ -136,6 +182,8 @@ class _FortalMenuMetrics {
   final double leadingInset;
   final double trailingInset;
   final double indicatorSize;
+  final double contentIconSize;
+  final double triggerGap;
   final TextStyleToken text;
 }
 
@@ -148,6 +196,8 @@ _FortalMenuMetrics _fortalMenuMetrics(FortalMenuSize size) => switch (size) {
     leadingInset: FortalTokens.space2(),
     trailingInset: FortalTokens.space2(),
     indicatorSize: FortalTokens.selectIndicatorSize1(),
+    contentIconSize: FortalTokens.space3(),
+    triggerGap: FortalTokens.space1(),
     text: FortalTokens.text1,
   ),
   .size2 => _FortalMenuMetrics(
@@ -158,6 +208,8 @@ _FortalMenuMetrics _fortalMenuMetrics(FortalMenuSize size) => switch (size) {
     leadingInset: FortalTokens.space3(),
     trailingInset: FortalTokens.space3(),
     indicatorSize: FortalTokens.selectIndicatorSize2(),
+    contentIconSize: FortalTokens.space4(),
+    triggerGap: FortalTokens.space2(),
     text: FortalTokens.text2,
   ),
 };

--- a/packages/remix/lib/src/components/menu/fortal_menu_styles.dart
+++ b/packages/remix/lib/src/components/menu/fortal_menu_styles.dart
@@ -12,7 +12,10 @@ MenuStyler fortalMenuStyle({
   FortalMenuVariant variant = .solid,
   FortalMenuSize size = .size2,
   bool highContrast = false,
-  FortalMenuStyleOverride? style,
+  // Typed as the Mix supertype because the generated MenuStyler cannot be
+  // named in this signature: the widget generator resolves same-build
+  // generated classes as InvalidType.
+  Style<MenuSpec>? style,
 }) {
   final metrics = _fortalMenuMetrics(size);
   final base = MenuStyler()

--- a/packages/remix/lib/src/components/menu/menu.dart
+++ b/packages/remix/lib/src/components/menu/menu.dart
@@ -9,6 +9,7 @@ import 'package:naked_ui/naked_ui.dart';
 import '../../fortal/fortal.dart';
 import '../../rendering/remix_box_effects.dart';
 import '../../style/style.dart';
+import '../../utilities/remix_path_icon.dart';
 import '../../utilities/remix_style.dart';
 import '../../utilities/selected_mixin.dart';
 import '../divider/divider.dart';

--- a/packages/remix/lib/src/components/menu/menu.g.dart
+++ b/packages/remix/lib/src/components/menu/menu.g.dart
@@ -323,7 +323,6 @@ class FortalMenu<T> extends StatelessWidget {
     this.variant = .solid,
     this.size = .size2,
     this.highContrast = false,
-    this.style,
     required this.trigger,
     required this.items,
     this.controller,
@@ -344,7 +343,6 @@ class FortalMenu<T> extends StatelessWidget {
     super.key,
     this.size = .size2,
     this.highContrast = false,
-    this.style,
     required this.trigger,
     required this.items,
     this.controller,
@@ -365,7 +363,6 @@ class FortalMenu<T> extends StatelessWidget {
     super.key,
     this.size = .size2,
     this.highContrast = false,
-    this.style,
     required this.trigger,
     required this.items,
     this.controller,
@@ -387,8 +384,6 @@ class FortalMenu<T> extends StatelessWidget {
   final FortalMenuSize size;
 
   final bool highContrast;
-
-  final Style<MenuSpec>? style;
 
   final RemixMenuTrigger trigger;
 
@@ -426,7 +421,6 @@ class FortalMenu<T> extends StatelessWidget {
         variant: this.variant,
         size: this.size,
         highContrast: this.highContrast,
-        style: this.style,
       ),
       trigger: this.trigger,
       items: this.items,

--- a/packages/remix/lib/src/components/menu/menu.g.dart
+++ b/packages/remix/lib/src/components/menu/menu.g.dart
@@ -388,7 +388,7 @@ class FortalMenu<T> extends StatelessWidget {
 
   final bool highContrast;
 
-  final FortalMenuStyleOverride? style;
+  final Style<MenuSpec>? style;
 
   final RemixMenuTrigger trigger;
 
@@ -1111,8 +1111,7 @@ class MenuTriggerStyler extends MixStyler<MenuTriggerStyler, MenuTriggerSpec>
   ];
 }
 
-class MenuStyler extends MixStyler<MenuStyler, MenuSpec>
-    with _FortalMenuStyleOverrideMixin<MenuStyler> {
+class MenuStyler extends MixStyler<MenuStyler, MenuSpec> {
   final Prop<StyleSpec<MenuTriggerSpec>>? $trigger;
   final Prop<StyleSpec<FlexBoxSpec>>? $overlay;
   final Prop<RemixBoxEffectsSpec>? $containerEffects;

--- a/packages/remix/lib/src/components/menu/menu.g.dart
+++ b/packages/remix/lib/src/components/menu/menu.g.dart
@@ -95,6 +95,9 @@ mixin _$MenuSpec implements Spec<MenuSpec>, Diagnosticable {
   StyleSpec<FlexBoxSpec> get overlay;
   RemixBoxEffectsSpec? get containerEffects;
   StyleSpec<MenuItemSpec> get item;
+  StyleSpec<MenuItemSpec>? get checkboxItem;
+  StyleSpec<MenuItemSpec>? get radioItem;
+  StyleSpec<MenuItemSpec>? get submenuItem;
   StyleSpec<DividerSpec> get divider;
 
   @override
@@ -106,6 +109,9 @@ mixin _$MenuSpec implements Spec<MenuSpec>, Diagnosticable {
     StyleSpec<FlexBoxSpec>? overlay,
     RemixBoxEffectsSpec? containerEffects,
     StyleSpec<MenuItemSpec>? item,
+    StyleSpec<MenuItemSpec>? checkboxItem,
+    StyleSpec<MenuItemSpec>? radioItem,
+    StyleSpec<MenuItemSpec>? submenuItem,
     StyleSpec<DividerSpec>? divider,
   }) {
     return MenuSpec(
@@ -113,6 +119,9 @@ mixin _$MenuSpec implements Spec<MenuSpec>, Diagnosticable {
       overlay: overlay ?? this.overlay,
       containerEffects: containerEffects ?? this.containerEffects,
       item: item ?? this.item,
+      checkboxItem: checkboxItem ?? this.checkboxItem,
+      radioItem: radioItem ?? this.radioItem,
+      submenuItem: submenuItem ?? this.submenuItem,
       divider: divider ?? this.divider,
     );
   }
@@ -128,6 +137,9 @@ mixin _$MenuSpec implements Spec<MenuSpec>, Diagnosticable {
         t,
       ),
       item: item.lerp(other?.item, t),
+      checkboxItem: checkboxItem?.lerp(other?.checkboxItem, t),
+      radioItem: radioItem?.lerp(other?.radioItem, t),
+      submenuItem: submenuItem?.lerp(other?.submenuItem, t),
       divider: divider.lerp(other?.divider, t),
     );
   }
@@ -138,6 +150,9 @@ mixin _$MenuSpec implements Spec<MenuSpec>, Diagnosticable {
     overlay,
     containerEffects,
     item,
+    checkboxItem,
+    radioItem,
+    submenuItem,
     divider,
   ];
 
@@ -185,6 +200,9 @@ mixin _$MenuSpec implements Spec<MenuSpec>, Diagnosticable {
       ..add(DiagnosticsProperty('overlay', overlay))
       ..add(DiagnosticsProperty('containerEffects', containerEffects))
       ..add(DiagnosticsProperty('item', item))
+      ..add(DiagnosticsProperty('checkboxItem', checkboxItem))
+      ..add(DiagnosticsProperty('radioItem', radioItem))
+      ..add(DiagnosticsProperty('submenuItem', submenuItem))
       ..add(DiagnosticsProperty('divider', divider));
   }
 }
@@ -199,6 +217,7 @@ mixin _$MenuItemSpec implements Spec<MenuItemSpec>, Diagnosticable {
   StyleSpec<TextSpec> get label;
   StyleSpec<IconSpec> get leadingIcon;
   StyleSpec<IconSpec> get trailingIcon;
+  StyleSpec<IconSpec> get indicator;
 
   @override
   Type get type => MenuItemSpec;
@@ -209,12 +228,14 @@ mixin _$MenuItemSpec implements Spec<MenuItemSpec>, Diagnosticable {
     StyleSpec<TextSpec>? label,
     StyleSpec<IconSpec>? leadingIcon,
     StyleSpec<IconSpec>? trailingIcon,
+    StyleSpec<IconSpec>? indicator,
   }) {
     return MenuItemSpec(
       container: container ?? this.container,
       label: label ?? this.label,
       leadingIcon: leadingIcon ?? this.leadingIcon,
       trailingIcon: trailingIcon ?? this.trailingIcon,
+      indicator: indicator ?? this.indicator,
     );
   }
 
@@ -225,11 +246,18 @@ mixin _$MenuItemSpec implements Spec<MenuItemSpec>, Diagnosticable {
       label: label.lerp(other?.label, t),
       leadingIcon: leadingIcon.lerp(other?.leadingIcon, t),
       trailingIcon: trailingIcon.lerp(other?.trailingIcon, t),
+      indicator: indicator.lerp(other?.indicator, t),
     );
   }
 
   @override
-  List<Object?> get props => [container, label, leadingIcon, trailingIcon];
+  List<Object?> get props => [
+    container,
+    label,
+    leadingIcon,
+    trailingIcon,
+    indicator,
+  ];
 
   @override
   bool operator ==(Object other) {
@@ -274,7 +302,8 @@ mixin _$MenuItemSpec implements Spec<MenuItemSpec>, Diagnosticable {
       ..add(DiagnosticsProperty('container', container))
       ..add(DiagnosticsProperty('label', label))
       ..add(DiagnosticsProperty('leadingIcon', leadingIcon))
-      ..add(DiagnosticsProperty('trailingIcon', trailingIcon));
+      ..add(DiagnosticsProperty('trailingIcon', trailingIcon))
+      ..add(DiagnosticsProperty('indicator', indicator));
   }
 }
 
@@ -294,6 +323,7 @@ class FortalMenu<T> extends StatelessWidget {
     this.variant = .solid,
     this.size = .size2,
     this.highContrast = false,
+    this.style,
     required this.trigger,
     required this.items,
     this.controller,
@@ -314,6 +344,7 @@ class FortalMenu<T> extends StatelessWidget {
     super.key,
     this.size = .size2,
     this.highContrast = false,
+    this.style,
     required this.trigger,
     required this.items,
     this.controller,
@@ -334,6 +365,7 @@ class FortalMenu<T> extends StatelessWidget {
     super.key,
     this.size = .size2,
     this.highContrast = false,
+    this.style,
     required this.trigger,
     required this.items,
     this.controller,
@@ -355,6 +387,8 @@ class FortalMenu<T> extends StatelessWidget {
   final FortalMenuSize size;
 
   final bool highContrast;
+
+  final FortalMenuStyleOverride? style;
 
   final RemixMenuTrigger trigger;
 
@@ -392,6 +426,7 @@ class FortalMenu<T> extends StatelessWidget {
         variant: this.variant,
         size: this.size,
         highContrast: this.highContrast,
+        style: this.style,
       ),
       trigger: this.trigger,
       items: this.items,
@@ -1076,11 +1111,15 @@ class MenuTriggerStyler extends MixStyler<MenuTriggerStyler, MenuTriggerSpec>
   ];
 }
 
-class MenuStyler extends MixStyler<MenuStyler, MenuSpec> {
+class MenuStyler extends MixStyler<MenuStyler, MenuSpec>
+    with _FortalMenuStyleOverrideMixin<MenuStyler> {
   final Prop<StyleSpec<MenuTriggerSpec>>? $trigger;
   final Prop<StyleSpec<FlexBoxSpec>>? $overlay;
   final Prop<RemixBoxEffectsSpec>? $containerEffects;
   final Prop<StyleSpec<MenuItemSpec>>? $item;
+  final Prop<StyleSpec<MenuItemSpec>>? $checkboxItem;
+  final Prop<StyleSpec<MenuItemSpec>>? $radioItem;
+  final Prop<StyleSpec<MenuItemSpec>>? $submenuItem;
   final Prop<StyleSpec<DividerSpec>>? $divider;
 
   const MenuStyler.create({
@@ -1088,6 +1127,9 @@ class MenuStyler extends MixStyler<MenuStyler, MenuSpec> {
     Prop<StyleSpec<FlexBoxSpec>>? overlay,
     Prop<RemixBoxEffectsSpec>? containerEffects,
     Prop<StyleSpec<MenuItemSpec>>? item,
+    Prop<StyleSpec<MenuItemSpec>>? checkboxItem,
+    Prop<StyleSpec<MenuItemSpec>>? radioItem,
+    Prop<StyleSpec<MenuItemSpec>>? submenuItem,
     Prop<StyleSpec<DividerSpec>>? divider,
     super.variants,
     super.modifier,
@@ -1096,6 +1138,9 @@ class MenuStyler extends MixStyler<MenuStyler, MenuSpec> {
        $overlay = overlay,
        $containerEffects = containerEffects,
        $item = item,
+       $checkboxItem = checkboxItem,
+       $radioItem = radioItem,
+       $submenuItem = submenuItem,
        $divider = divider;
 
   MenuStyler({
@@ -1103,6 +1148,9 @@ class MenuStyler extends MixStyler<MenuStyler, MenuSpec> {
     FlexBoxStyler? overlay,
     RemixBoxEffectsMix? containerEffects,
     MenuItemStyler? item,
+    MenuItemStyler? checkboxItem,
+    MenuItemStyler? radioItem,
+    MenuItemStyler? submenuItem,
     DividerStyler? divider,
     AnimationConfig? animation,
     WidgetModifierConfig? modifier,
@@ -1112,6 +1160,9 @@ class MenuStyler extends MixStyler<MenuStyler, MenuSpec> {
          overlay: Prop.maybeMix(overlay),
          containerEffects: Prop.maybeMix(containerEffects),
          item: Prop.maybeMix(item),
+         checkboxItem: Prop.maybeMix(checkboxItem),
+         radioItem: Prop.maybeMix(radioItem),
+         submenuItem: Prop.maybeMix(submenuItem),
          divider: Prop.maybeMix(divider),
          variants: variants,
          modifier: modifier,
@@ -1125,6 +1176,12 @@ class MenuStyler extends MixStyler<MenuStyler, MenuSpec> {
   factory MenuStyler.containerEffects(RemixBoxEffectsMix value) =>
       MenuStyler().containerEffects(value);
   factory MenuStyler.item(MenuItemStyler value) => MenuStyler().item(value);
+  factory MenuStyler.checkboxItem(MenuItemStyler value) =>
+      MenuStyler().checkboxItem(value);
+  factory MenuStyler.radioItem(MenuItemStyler value) =>
+      MenuStyler().radioItem(value);
+  factory MenuStyler.submenuItem(MenuItemStyler value) =>
+      MenuStyler().submenuItem(value);
   factory MenuStyler.divider(DividerStyler value) =>
       MenuStyler().divider(value);
 
@@ -1146,6 +1203,21 @@ class MenuStyler extends MixStyler<MenuStyler, MenuSpec> {
   /// Sets the item.
   MenuStyler item(MenuItemStyler value) {
     return merge(MenuStyler(item: value));
+  }
+
+  /// Sets the checkboxItem.
+  MenuStyler checkboxItem(MenuItemStyler value) {
+    return merge(MenuStyler(checkboxItem: value));
+  }
+
+  /// Sets the radioItem.
+  MenuStyler radioItem(MenuItemStyler value) {
+    return merge(MenuStyler(radioItem: value));
+  }
+
+  /// Sets the submenuItem.
+  MenuStyler submenuItem(MenuItemStyler value) {
+    return merge(MenuStyler(submenuItem: value));
   }
 
   /// Sets the divider.
@@ -1187,6 +1259,9 @@ class MenuStyler extends MixStyler<MenuStyler, MenuSpec> {
         other?.$containerEffects,
       ),
       item: MixOps.merge($item, other?.$item),
+      checkboxItem: MixOps.merge($checkboxItem, other?.$checkboxItem),
+      radioItem: MixOps.merge($radioItem, other?.$radioItem),
+      submenuItem: MixOps.merge($submenuItem, other?.$submenuItem),
       divider: MixOps.merge($divider, other?.$divider),
       variants: MixOps.mergeVariants($variants, other?.$variants),
       modifier: MixOps.mergeModifier($modifier, other?.$modifier),
@@ -1202,6 +1277,9 @@ class MenuStyler extends MixStyler<MenuStyler, MenuSpec> {
       overlay: MixOps.resolve(context, $overlay),
       containerEffects: MixOps.resolve(context, $containerEffects),
       item: MixOps.resolve(context, $item),
+      checkboxItem: MixOps.resolve(context, $checkboxItem),
+      radioItem: MixOps.resolve(context, $radioItem),
+      submenuItem: MixOps.resolve(context, $submenuItem),
       divider: MixOps.resolve(context, $divider),
     );
 
@@ -1220,6 +1298,9 @@ class MenuStyler extends MixStyler<MenuStyler, MenuSpec> {
       ..add(DiagnosticsProperty('overlay', $overlay))
       ..add(DiagnosticsProperty('containerEffects', $containerEffects))
       ..add(DiagnosticsProperty('item', $item))
+      ..add(DiagnosticsProperty('checkboxItem', $checkboxItem))
+      ..add(DiagnosticsProperty('radioItem', $radioItem))
+      ..add(DiagnosticsProperty('submenuItem', $submenuItem))
       ..add(DiagnosticsProperty('divider', $divider));
   }
 
@@ -1229,6 +1310,9 @@ class MenuStyler extends MixStyler<MenuStyler, MenuSpec> {
     $overlay,
     $containerEffects,
     $item,
+    $checkboxItem,
+    $radioItem,
+    $submenuItem,
     $divider,
     $animation,
     $modifier,
@@ -1242,25 +1326,29 @@ class MenuItemStyler extends MixStyler<MenuItemStyler, MenuItemSpec>
   final Prop<StyleSpec<TextSpec>>? $label;
   final Prop<StyleSpec<IconSpec>>? $leadingIcon;
   final Prop<StyleSpec<IconSpec>>? $trailingIcon;
+  final Prop<StyleSpec<IconSpec>>? $indicator;
 
   const MenuItemStyler.create({
     Prop<StyleSpec<FlexBoxSpec>>? container,
     Prop<StyleSpec<TextSpec>>? label,
     Prop<StyleSpec<IconSpec>>? leadingIcon,
     Prop<StyleSpec<IconSpec>>? trailingIcon,
+    Prop<StyleSpec<IconSpec>>? indicator,
     super.variants,
     super.modifier,
     super.animation,
   }) : $container = container,
        $label = label,
        $leadingIcon = leadingIcon,
-       $trailingIcon = trailingIcon;
+       $trailingIcon = trailingIcon,
+       $indicator = indicator;
 
   MenuItemStyler({
     FlexBoxStyler? container,
     TextStyler? label,
     IconStyler? leadingIcon,
     IconStyler? trailingIcon,
+    IconStyler? indicator,
     AnimationConfig? animation,
     WidgetModifierConfig? modifier,
     List<VariantStyle<MenuItemSpec>>? variants,
@@ -1269,6 +1357,7 @@ class MenuItemStyler extends MixStyler<MenuItemStyler, MenuItemSpec>
          label: Prop.maybeMix(label),
          leadingIcon: Prop.maybeMix(leadingIcon),
          trailingIcon: Prop.maybeMix(trailingIcon),
+         indicator: Prop.maybeMix(indicator),
          variants: variants,
          modifier: modifier,
          animation: animation,
@@ -1282,6 +1371,8 @@ class MenuItemStyler extends MixStyler<MenuItemStyler, MenuItemSpec>
       MenuItemStyler().leadingIcon(value);
   factory MenuItemStyler.trailingIcon(IconStyler value) =>
       MenuItemStyler().trailingIcon(value);
+  factory MenuItemStyler.indicator(IconStyler value) =>
+      MenuItemStyler().indicator(value);
   factory MenuItemStyler.color(Color value) => MenuItemStyler().color(value);
   factory MenuItemStyler.gradient(GradientMix value) =>
       MenuItemStyler().gradient(value);
@@ -1827,6 +1918,11 @@ class MenuItemStyler extends MixStyler<MenuItemStyler, MenuItemSpec>
     return merge(MenuItemStyler(trailingIcon: value));
   }
 
+  /// Sets the indicator.
+  MenuItemStyler indicator(IconStyler value) {
+    return merge(MenuItemStyler(indicator: value));
+  }
+
   /// Sets the animation configuration.
   @override
   MenuItemStyler animate(AnimationConfig value) {
@@ -1858,6 +1954,7 @@ class MenuItemStyler extends MixStyler<MenuItemStyler, MenuItemSpec>
       label: MixOps.merge($label, other?.$label),
       leadingIcon: MixOps.merge($leadingIcon, other?.$leadingIcon),
       trailingIcon: MixOps.merge($trailingIcon, other?.$trailingIcon),
+      indicator: MixOps.merge($indicator, other?.$indicator),
       variants: MixOps.mergeVariants($variants, other?.$variants),
       modifier: MixOps.mergeModifier($modifier, other?.$modifier),
       animation: MixOps.mergeAnimation($animation, other?.$animation),
@@ -1872,6 +1969,7 @@ class MenuItemStyler extends MixStyler<MenuItemStyler, MenuItemSpec>
       label: MixOps.resolve(context, $label),
       leadingIcon: MixOps.resolve(context, $leadingIcon),
       trailingIcon: MixOps.resolve(context, $trailingIcon),
+      indicator: MixOps.resolve(context, $indicator),
     );
 
     return StyleSpec(
@@ -1888,7 +1986,8 @@ class MenuItemStyler extends MixStyler<MenuItemStyler, MenuItemSpec>
       ..add(DiagnosticsProperty('container', $container))
       ..add(DiagnosticsProperty('label', $label))
       ..add(DiagnosticsProperty('leadingIcon', $leadingIcon))
-      ..add(DiagnosticsProperty('trailingIcon', $trailingIcon));
+      ..add(DiagnosticsProperty('trailingIcon', $trailingIcon))
+      ..add(DiagnosticsProperty('indicator', $indicator));
   }
 
   @override
@@ -1897,6 +1996,7 @@ class MenuItemStyler extends MixStyler<MenuItemStyler, MenuItemSpec>
     $label,
     $leadingIcon,
     $trailingIcon,
+    $indicator,
     $animation,
     $modifier,
     $variants,

--- a/packages/remix/lib/src/components/menu/menu_spec.dart
+++ b/packages/remix/lib/src/components/menu/menu_spec.dart
@@ -37,11 +37,23 @@ class MenuTriggerSpec with _$MenuTriggerSpec {
 /// values use `MenuTriggerSpec` as their runtime type.
 typedef RemixMenuTriggerSpec = MenuTriggerSpec;
 
+/// Style override accepted by generated Fortal menu recipes.
+///
+/// [MenuStyler] is the only implementation. This source-declared type
+/// keeps the generated recipe field type-safe while the concrete styler is
+/// emitted into this library's generated part.
+sealed class FortalMenuStyleOverride {
+  const FortalMenuStyleOverride();
+}
+
+mixin _FortalMenuStyleOverrideMixin<T extends Mix<Object?>>
+    implements FortalMenuStyleOverride {}
+
 /// Resolved visual properties for a [RemixMenu].
 ///
-/// The menu spec owns the trigger, overlay, default item, and divider styles
-/// used when rendering the menu and its popup content.
-@MixableSpec()
+/// The menu spec owns the trigger, overlay, shared and semantic item styles,
+/// and divider style used when rendering the menu and its popup content.
+@MixableSpec(extraStylerMixins: [_FortalMenuStyleOverrideMixin])
 class MenuSpec with _$MenuSpec {
   /// Style spec for the trigger content.
   @override
@@ -60,6 +72,27 @@ class MenuSpec with _$MenuSpec {
   @override
   final StyleSpec<MenuItemSpec> item;
 
+  /// Optional menu-wide override for checkbox item rows.
+  ///
+  /// Fluent styles merge this after [item]. In a raw spec, `null` inherits
+  /// [item] and a non-null value is the complete checkbox-row style.
+  @override
+  final StyleSpec<MenuItemSpec>? checkboxItem;
+
+  /// Optional menu-wide override for radio item rows.
+  ///
+  /// Fluent styles merge this after [item]. In a raw spec, `null` inherits
+  /// [item] and a non-null value is the complete radio-row style.
+  @override
+  final StyleSpec<MenuItemSpec>? radioItem;
+
+  /// Optional menu-wide override for submenu trigger rows.
+  ///
+  /// Fluent styles merge this after [item]. In a raw spec, `null` inherits
+  /// [item] and a non-null value is the complete submenu-trigger style.
+  @override
+  final StyleSpec<MenuItemSpec>? submenuItem;
+
   /// Default style spec applied to menu dividers.
   @override
   final StyleSpec<DividerSpec> divider;
@@ -70,6 +103,9 @@ class MenuSpec with _$MenuSpec {
     StyleSpec<FlexBoxSpec>? overlay,
     this.containerEffects,
     StyleSpec<MenuItemSpec>? item,
+    this.checkboxItem,
+    this.radioItem,
+    this.submenuItem,
     StyleSpec<DividerSpec>? divider,
   }) : trigger = trigger ?? const StyleSpec(spec: MenuTriggerSpec()),
        overlay = overlay ?? const StyleSpec(spec: FlexBoxSpec()),
@@ -82,12 +118,42 @@ class MenuSpec with _$MenuSpec {
   MenuSpec lerp(MenuSpec? other, double t) {
     final generated = super.lerp(other, t);
     if (other == null) return generated;
-    return generated.copyWith(
+
+    StyleSpec<MenuItemSpec>? lerpOptionalItem(
+      StyleSpec<MenuItemSpec>? current,
+      StyleSpec<MenuItemSpec>? next,
+      StyleSpec<MenuItemSpec> currentFallback,
+      StyleSpec<MenuItemSpec> nextFallback,
+    ) {
+      if (current == null && next == null) return null;
+      if (t <= 0) return current;
+      if (t >= 1) return next;
+      return (current ?? currentFallback).lerp(next ?? nextFallback, t);
+    }
+
+    return MenuSpec(
+      trigger: generated.trigger,
+      overlay: generated.overlay,
       containerEffects: RemixBoxEffectsSpec.lerpNullable(
         containerEffects,
         other.containerEffects,
         t,
       ),
+      item: generated.item,
+      checkboxItem: lerpOptionalItem(
+        checkboxItem,
+        other.checkboxItem,
+        item,
+        other.item,
+      ),
+      radioItem: lerpOptionalItem(radioItem, other.radioItem, item, other.item),
+      submenuItem: lerpOptionalItem(
+        submenuItem,
+        other.submenuItem,
+        item,
+        other.item,
+      ),
+      divider: generated.divider,
     );
   }
 }
@@ -118,16 +184,22 @@ class MenuItemSpec with _$MenuItemSpec {
   @override
   final StyleSpec<IconSpec> trailingIcon;
 
+  /// Icon style shared by checked checkbox and selected radio indicators.
+  @override
+  final StyleSpec<IconSpec> indicator;
+
   /// Creates an item spec with default empty child specs.
   const MenuItemSpec({
     StyleSpec<FlexBoxSpec>? container,
     StyleSpec<TextSpec>? label,
     StyleSpec<IconSpec>? leadingIcon,
     StyleSpec<IconSpec>? trailingIcon,
+    StyleSpec<IconSpec>? indicator,
   }) : container = container ?? const StyleSpec(spec: FlexBoxSpec()),
        label = label ?? const StyleSpec(spec: TextSpec()),
        leadingIcon = leadingIcon ?? const StyleSpec(spec: IconSpec()),
-       trailingIcon = trailingIcon ?? const StyleSpec(spec: IconSpec());
+       trailingIcon = trailingIcon ?? const StyleSpec(spec: IconSpec()),
+       indicator = indicator ?? const StyleSpec(spec: IconSpec());
 }
 
 /// Backward-compatible name for [MenuItemSpec].

--- a/packages/remix/lib/src/components/menu/menu_spec.dart
+++ b/packages/remix/lib/src/components/menu/menu_spec.dart
@@ -114,8 +114,8 @@ class MenuSpec with _$MenuSpec {
       StyleSpec<MenuItemSpec> nextFallback,
     ) {
       if (current == null && next == null) return null;
-      if (t <= 0) return current;
-      if (t >= 1) return next;
+      if (t == 0) return current;
+      if (t == 1) return next;
       return (current ?? currentFallback).lerp(next ?? nextFallback, t);
     }
 

--- a/packages/remix/lib/src/components/menu/menu_spec.dart
+++ b/packages/remix/lib/src/components/menu/menu_spec.dart
@@ -37,23 +37,11 @@ class MenuTriggerSpec with _$MenuTriggerSpec {
 /// values use `MenuTriggerSpec` as their runtime type.
 typedef RemixMenuTriggerSpec = MenuTriggerSpec;
 
-/// Style override accepted by generated Fortal menu recipes.
-///
-/// [MenuStyler] is the only implementation. This source-declared type
-/// keeps the generated recipe field type-safe while the concrete styler is
-/// emitted into this library's generated part.
-sealed class FortalMenuStyleOverride {
-  const FortalMenuStyleOverride();
-}
-
-mixin _FortalMenuStyleOverrideMixin<T extends Mix<Object?>>
-    implements FortalMenuStyleOverride {}
-
 /// Resolved visual properties for a [RemixMenu].
 ///
 /// The menu spec owns the trigger, overlay, shared and semantic item styles,
 /// and divider style used when rendering the menu and its popup content.
-@MixableSpec(extraStylerMixins: [_FortalMenuStyleOverrideMixin])
+@MixableSpec()
 class MenuSpec with _$MenuSpec {
   /// Style spec for the trigger content.
   @override

--- a/packages/remix/lib/src/components/menu/menu_style.dart
+++ b/packages/remix/lib/src/components/menu/menu_style.dart
@@ -10,19 +10,23 @@ extension RemixMenuTriggerStylerRemixHelpers on MenuTriggerStyler {
   }
 }
 
-/// Style configuration for [RemixMenu] trigger, overlay, items, and dividers.
+/// Style configuration for [RemixMenu] trigger, overlay, shared and semantic
+/// item defaults, and dividers.
 extension RemixMenuStylerRemixHelpers on MenuStyler {
   /// Creates a [RemixMenu] widget with this style applied.
   ///
   /// Example:
   /// ```dart
-  /// MenuStyler()
-  ///   .trigger(...)
-  ///   .overlay(...)
-  ///   .call<String>(
+  /// final appMenuStyle = MenuStyler()
+  ///     .trigger(...)
+  ///     .overlay(...)
+  ///     .item(sharedItemStyle)
+  ///     .radioItem(radioItemStyle);
+  ///
+  /// return appMenuStyle.call<String>(
   ///     trigger: RemixMenuTrigger(label: 'Options'),
   ///     items: [...],
-  ///   )
+  ///   );
   /// ```
   RemixMenu<T> call<T>({
     Key? key,

--- a/packages/remix/lib/src/components/menu/menu_widget.dart
+++ b/packages/remix/lib/src/components/menu/menu_widget.dart
@@ -802,15 +802,13 @@ class _RemixMenuItemContent extends StatelessWidget {
       styleSpec: spec.container,
       children: [
         if (reserveChoiceSlot)
-          SizedBox.square(
-            dimension: indicatorSize,
-            child: showIndicator
-                ? RemixPathIcon(
-                    key: ValueKey('remix-menu-indicator-$label'),
-                    glyph: RemixPathGlyph.thickCheck,
-                    styleSpec: indicatorSpec,
-                  )
-                : null,
+          Visibility.maintain(
+            visible: showIndicator,
+            child: RemixPathIcon(
+              key: ValueKey('remix-menu-indicator-$label'),
+              glyph: RemixPathGlyph.thickCheck,
+              styleSpec: indicatorSpec,
+            ),
           ),
         if (leadingIcon != null)
           StyledIcon(icon: leadingIcon!, styleSpec: spec.leadingIcon),

--- a/packages/remix/lib/src/components/menu/menu_widget.dart
+++ b/packages/remix/lib/src/components/menu/menu_widget.dart
@@ -65,7 +65,8 @@ final class RemixMenuItem<T> extends RemixMenuItemData<T> {
     this.closeOnActivate = true,
     this.semanticLabel,
     this.style = const MenuItemStyler.create(),
-  });
+  }) : assert(label != '', 'Item labels must not be empty'),
+       assert(semanticLabel != '', 'Item semantic labels must not be empty');
 }
 
 /// A controlled checkbox item in a [RemixMenu].
@@ -591,6 +592,10 @@ class _RemixMenuItemsPanel<T> extends StatelessWidget {
       value: item.value,
       checked: item.checked,
       onChanged: item.onChanged,
+      // Deliberate duplication of Naked's enabled formula: Naked's root menu
+      // scope installs an internal selection handler even when the public
+      // onSelected is null, so its own callback guard can never disable an
+      // item. Remix must gate on the public callbacks itself.
       enabled:
           item.enabled && (item.onChanged != null || hasRootSelectionCallback),
       semanticLabel: item.semanticLabel ?? item.label,
@@ -642,6 +647,8 @@ class _RemixMenuItemsPanel<T> extends StatelessWidget {
             .map(
               (item) => NakedMenuRadioItem<T>(
                 value: item.value,
+                // Same public-callback gate as checkbox items; see
+                // _buildCheckboxItem for why Naked cannot own this.
                 enabled:
                     item.enabled &&
                     (group.onChanged != null || hasRootSelectionCallback),

--- a/packages/remix/lib/src/components/menu/menu_widget.dart
+++ b/packages/remix/lib/src/components/menu/menu_widget.dart
@@ -22,8 +22,7 @@ class RemixMenuTrigger {
 /// Base sealed class for all menu item types.
 ///
 /// This ensures type safety and exhaustive pattern matching when
-/// handling menu items. Use [RemixMenuItem] for selectable items
-/// and [RemixMenuDivider] for visual separators.
+/// handling ordinary, checkbox, radio, submenu, and divider data.
 sealed class RemixMenuItemData<T> {
   const RemixMenuItemData();
 }
@@ -54,7 +53,7 @@ final class RemixMenuItem<T> extends RemixMenuItemData<T> {
   /// Semantic label for accessibility.
   final String? semanticLabel;
 
-  /// The style for the menu item.
+  /// Per-item visual style applied after [MenuStyler.item].
   final MenuItemStyler style;
 
   const RemixMenuItem({
@@ -67,6 +66,191 @@ final class RemixMenuItem<T> extends RemixMenuItemData<T> {
     this.semanticLabel,
     this.style = const MenuItemStyler.create(),
   });
+}
+
+/// A controlled checkbox item in a [RemixMenu].
+///
+/// Activation can invoke both the root [RemixMenu.onSelected] callback with
+/// [value] and [onChanged] with the toggled checked value, in that order.
+final class RemixMenuCheckboxItem<T> extends RemixMenuItemData<T> {
+  const RemixMenuCheckboxItem({
+    required this.value,
+    required this.label,
+    required this.checked,
+    this.onChanged,
+    this.leadingIcon,
+    this.trailingIcon,
+    this.enabled = true,
+    this.closeOnActivate = true,
+    this.semanticLabel,
+    this.style = const MenuItemStyler.create(),
+  }) : assert(label != '', 'Item labels must not be empty'),
+       assert(semanticLabel != '', 'Item semantic labels must not be empty');
+
+  /// The value reported to [RemixMenu.onSelected].
+  final T value;
+
+  /// The visible item label.
+  final String label;
+
+  /// The controlled checked state.
+  final bool checked;
+
+  /// Called with the toggled checked state after root selection is reported.
+  final ValueChanged<bool>? onChanged;
+
+  /// Optional icon before the label.
+  final IconData? leadingIcon;
+
+  /// Optional content icon in the trailing slot.
+  final IconData? trailingIcon;
+
+  /// Whether the item participates in interaction.
+  final bool enabled;
+
+  /// Whether activation closes the complete menu hierarchy.
+  final bool closeOnActivate;
+
+  /// Optional accessible name. Defaults to [label].
+  final String? semanticLabel;
+
+  /// Per-item visual style applied after the menu-wide shared and checkbox
+  /// item styles.
+  final MenuItemStyler style;
+}
+
+/// A controlled mutually exclusive section in a [RemixMenu].
+///
+/// The list must not be mutated while a panel is being built. A panel takes an
+/// immutable snapshot and requires [value] to match exactly one unique item.
+/// The group is behavioral; configure menu-wide row visuals with
+/// [MenuStyler.radioItem] or override an individual radio item's style.
+final class RemixMenuRadioGroup<T> extends RemixMenuItemData<T> {
+  const RemixMenuRadioGroup({
+    required this.value,
+    required this.items,
+    this.onChanged,
+    this.enabled = true,
+  }) : assert(value != null, 'Radio group values must not be null');
+
+  /// The non-null controlled selected value required by Naked.
+  final T value;
+
+  /// The radio items in this section.
+  final List<RemixMenuRadioItem<T>> items;
+
+  /// Called after root selection is reported, including for [value] itself.
+  final ValueChanged<T>? onChanged;
+
+  /// Whether every item in the group participates in interaction.
+  final bool enabled;
+}
+
+/// A selectable item in a [RemixMenuRadioGroup].
+final class RemixMenuRadioItem<T> {
+  const RemixMenuRadioItem({
+    required this.value,
+    required this.label,
+    this.leadingIcon,
+    this.trailingIcon,
+    this.enabled = true,
+    this.closeOnActivate = true,
+    this.semanticLabel,
+    this.style = const MenuItemStyler.create(),
+  }) : assert(label != '', 'Item labels must not be empty'),
+       assert(semanticLabel != '', 'Item semantic labels must not be empty');
+
+  /// The value reported to both root and group callbacks.
+  final T value;
+
+  /// The visible item label.
+  final String label;
+
+  /// Optional icon before the label.
+  final IconData? leadingIcon;
+
+  /// Optional content icon in the trailing slot.
+  final IconData? trailingIcon;
+
+  /// Whether this item participates in interaction.
+  final bool enabled;
+
+  /// Whether activation closes the complete menu hierarchy.
+  final bool closeOnActivate;
+
+  /// Optional accessible name. Defaults to [label].
+  final String? semanticLabel;
+
+  /// Per-item visual style applied after the menu-wide shared and radio item
+  /// styles.
+  final MenuItemStyler style;
+}
+
+/// A recursively nestable submenu in a [RemixMenu].
+///
+/// The list must not be mutated while a panel is being built. Each nested
+/// panel consumes an immutable snapshot independently from its parent.
+final class RemixMenuSubmenu<T> extends RemixMenuItemData<T> {
+  const RemixMenuSubmenu({
+    required this.label,
+    required this.items,
+    this.leadingIcon,
+    this.trailingIcon,
+    this.controller,
+    this.enabled = true,
+    this.hoverDelay = const Duration(milliseconds: 100),
+    this.positioning = const OverlayPositionConfig(
+      side: OverlaySide.right,
+      alignment: OverlayAlignment.start,
+      sideOffset: 4,
+    ),
+    this.focusNode,
+    this.semanticLabel,
+    this.onOpen,
+    this.onClose,
+    this.style = const MenuItemStyler.create(),
+  }) : assert(label != '', 'Item labels must not be empty'),
+       assert(semanticLabel != '', 'Item semantic labels must not be empty');
+
+  /// The visible submenu trigger label.
+  final String label;
+
+  /// The nested menu items.
+  final List<RemixMenuItemData<T>> items;
+
+  /// Optional icon before the label.
+  final IconData? leadingIcon;
+
+  /// Optional trailing icon replacing the default directional chevron.
+  final IconData? trailingIcon;
+
+  /// Optional controller for programmatic submenu control.
+  final MenuController? controller;
+
+  /// Whether the submenu trigger participates in interaction.
+  final bool enabled;
+
+  /// Delay before pointer hover opens or closes the submenu.
+  final Duration hoverDelay;
+
+  /// Child-panel placement relative to the submenu trigger.
+  final OverlayPositionConfig positioning;
+
+  /// Optional caller-owned focus node for the submenu trigger.
+  final FocusNode? focusNode;
+
+  /// Optional accessible name. Defaults to [label].
+  final String? semanticLabel;
+
+  /// Called after the submenu opens.
+  final VoidCallback? onOpen;
+
+  /// Called after the submenu closes.
+  final VoidCallback? onClose;
+
+  /// Per-trigger visual style applied after the menu-wide shared and submenu
+  /// item styles.
+  final MenuItemStyler style;
 }
 
 /// Data class representing a menu divider.
@@ -134,8 +318,7 @@ class RemixMenu<T> extends StatefulWidget {
   /// The trigger data that defines the menu's button.
   final RemixMenuTrigger trigger;
 
-  /// The list of menu items and dividers.
-  /// Use [RemixMenuItem] for selectable items and [RemixMenuDivider] for separators.
+  /// The declarative ordinary, compound, submenu, and divider data.
   final List<RemixMenuItemData<T>> items;
 
   /// Optional controller for programmatic control of the menu state.
@@ -218,27 +401,15 @@ class _RemixMenuState<T> extends State<RemixMenu<T>> {
           style: style,
           styleSpec: widget.styleSpec,
           builder: (context, spec) {
-            return RemixFlexBoxWithEffects(
-              styleSpec: spec.overlay,
-              direction: Axis.vertical,
+            return _RemixMenuItemsPanel<T>(
+              items: widget.items,
+              overlayStyleSpec: spec.overlay,
               containerEffects: spec.containerEffects,
-              children: widget.items.map((item) {
-                // Pattern matching ensures exhaustiveness
-                return switch (item) {
-                  RemixMenuItem<T>() => _RemixMenuItemWidget(
-                    data: item,
-                    defaultStyle: widget.styleSpec == null ? style.$item : null,
-                    defaultStyleSpec: widget.styleSpec == null
-                        ? null
-                        : spec.item,
-                  ),
-                  RemixMenuDivider<T>() => StyleSpecBuilder(
-                    styleSpec: spec.divider,
-                    builder: (context, dividerSpec) =>
-                        RemixDivider(styleSpec: dividerSpec),
-                  ),
-                };
-              }).toList(),
+              dividerStyleSpec: spec.divider,
+              hasRootSelectionCallback: widget.onSelected != null,
+              itemStyles: widget.styleSpec == null
+                  ? _RemixMenuItemStyles.fromStyler(style)
+                  : _RemixMenuItemStyles.fromSpec(spec),
             );
           },
         );
@@ -290,79 +461,341 @@ class _RemixMenuState<T> extends State<RemixMenu<T>> {
 // INTERNAL WIDGETS - Render data classes to actual widgets
 // ============================================================================
 
-/// Internal widget that renders [RemixMenuItem] data with provided styling.
+enum _RemixMenuItemKind { ordinary, checkbox, radio, submenu }
+
+/// Carries either unresolved fluent styles or one fully resolved raw spec.
 ///
-/// Receives styling directly from parent [RemixMenu] via styleSpec parameter.
-class _RemixMenuItemWidget<T> extends StatelessWidget {
-  const _RemixMenuItemWidget({
-    required this.data,
-    this.defaultStyle,
-    this.defaultStyleSpec,
-  });
+/// Keeping the complete menu style together makes the base-to-semantic merge
+/// order explicit without threading a parallel set of fields through every
+/// recursive submenu panel.
+final class _RemixMenuItemStyles {
+  const _RemixMenuItemStyles.fromStyler(MenuStyler this.styler) : spec = null;
 
-  final RemixMenuItem<T> data;
-  final Prop<StyleSpec<MenuItemSpec>>? defaultStyle;
-  final StyleSpec<MenuItemSpec>? defaultStyleSpec;
+  const _RemixMenuItemStyles.fromSpec(MenuSpec this.spec) : styler = null;
 
-  StyleSpec<MenuItemSpec> _resolveStyle(BuildContext context) {
-    final rawDefault = defaultStyleSpec;
-    if (rawDefault != null) return rawDefault;
+  final MenuStyler? styler;
+  final MenuSpec? spec;
 
-    final itemStyle = MixOps.merge(
-      defaultStyle,
-      Prop.maybeMix<StyleSpec<MenuItemSpec>>(data.style),
+  StyleSpec<MenuItemSpec> resolve(
+    BuildContext context,
+    _RemixMenuItemKind kind,
+    MenuItemStyler itemStyle,
+  ) {
+    final resolvedSpec = spec;
+    if (resolvedSpec != null) {
+      return switch (kind) {
+        .ordinary => resolvedSpec.item,
+        .checkbox => resolvedSpec.checkboxItem ?? resolvedSpec.item,
+        .radio => resolvedSpec.radioItem ?? resolvedSpec.item,
+        .submenu => resolvedSpec.submenuItem ?? resolvedSpec.item,
+      };
+    }
+
+    final fluentStyle = styler!;
+    final semanticStyle = switch (kind) {
+      .ordinary => null,
+      .checkbox => fluentStyle.$checkboxItem,
+      .radio => fluentStyle.$radioItem,
+      .submenu => fluentStyle.$submenuItem,
+    };
+    final menuStyle = MixOps.merge(fluentStyle.$item, semanticStyle);
+    final mergedStyle = MixOps.merge(
+      menuStyle,
+      Prop.maybeMix<StyleSpec<MenuItemSpec>>(itemStyle),
     );
 
-    return MixOps.resolve(context, itemStyle) ??
+    return MixOps.resolve(context, mergedStyle) ??
         const StyleSpec(spec: MenuItemSpec());
   }
+}
+
+/// One renderer intentionally serves root and recursive submenu overlays so
+/// item, divider, decoration, and choice-row layout cannot drift.
+class _RemixMenuItemsPanel<T> extends StatelessWidget {
+  const _RemixMenuItemsPanel({
+    required this.items,
+    required this.overlayStyleSpec,
+    required this.containerEffects,
+    required this.dividerStyleSpec,
+    required this.hasRootSelectionCallback,
+    required this.itemStyles,
+  });
+
+  final List<RemixMenuItemData<T>> items;
+  final StyleSpec<FlexBoxSpec> overlayStyleSpec;
+  final RemixBoxEffectsSpec? containerEffects;
+  final StyleSpec<DividerSpec> dividerStyleSpec;
+  final bool hasRootSelectionCallback;
+  final _RemixMenuItemStyles itemStyles;
 
   @override
   Widget build(BuildContext context) {
-    return NakedMenuItem<T>(
-      value: data.value,
-      enabled: data.enabled,
-      semanticLabel: data.semanticLabel ?? data.label,
-      closeOnActivate: data.closeOnActivate,
-      builder: (context, state, _) {
-        final controller = NakedMenuItemState.controllerOf<T>(context);
+    final snapshot = List<RemixMenuItemData<T>>.unmodifiable(items);
+    final hasChoiceItems = snapshot.any(
+      (item) =>
+          item is RemixMenuCheckboxItem<T> || item is RemixMenuRadioGroup<T>,
+    );
 
-        return ExcludeSemantics(
-          child: ListenableBuilder(
-            listenable: controller,
-            builder: (context, child) {
-              return WidgetStateProvider(
-                states: controller.value,
-                child: Builder(
-                  builder: (context) {
-                    return StyleSpecBuilder<MenuItemSpec>(
-                      styleSpec: _resolveStyle(context),
-                      builder: (context, spec) {
-                        return FlexBox(
-                          styleSpec: spec.container,
-                          children: [
-                            if (data.leadingIcon != null)
-                              StyledIcon(
-                                icon: data.leadingIcon!,
-                                styleSpec: spec.leadingIcon,
-                              ),
-                            StyledText(data.label, styleSpec: spec.label),
-                            if (data.trailingIcon != null)
-                              StyledIcon(
-                                icon: data.trailingIcon!,
-                                styleSpec: spec.trailingIcon,
-                              ),
-                          ],
-                        );
-                      },
-                    );
-                  },
-                ),
-              );
+    return RemixFlexBoxWithEffects(
+      styleSpec: overlayStyleSpec,
+      direction: Axis.vertical,
+      containerEffects: containerEffects,
+      children: snapshot
+          .map(
+            (item) => switch (item) {
+              RemixMenuItem<T>() => _buildOrdinaryItem(item, hasChoiceItems),
+              RemixMenuCheckboxItem<T>() => _buildCheckboxItem(
+                item,
+                hasChoiceItems,
+              ),
+              RemixMenuRadioGroup<T>() => _buildRadioGroup(
+                item,
+                hasChoiceItems,
+              ),
+              RemixMenuSubmenu<T>() => _buildSubmenu(item, hasChoiceItems),
+              RemixMenuDivider<T>() => StyleSpecBuilder(
+                styleSpec: dividerStyleSpec,
+                builder: (context, dividerSpec) =>
+                    RemixDivider(styleSpec: dividerSpec),
+              ),
             },
+          )
+          .toList(growable: false),
+    );
+  }
+
+  Widget _buildOrdinaryItem(RemixMenuItem<T> item, bool reserveChoiceSlot) {
+    return NakedMenuItem<T>(
+      value: item.value,
+      enabled: item.enabled,
+      semanticLabel: item.semanticLabel ?? item.label,
+      closeOnActivate: item.closeOnActivate,
+      builder: (context, state, _) => _RemixMenuItemContent(
+        label: item.label,
+        leadingIcon: item.leadingIcon,
+        trailingIcon: item.trailingIcon,
+        style: item.style,
+        kind: .ordinary,
+        controller: NakedMenuItemState.controllerOf<T>(context),
+        reserveChoiceSlot: reserveChoiceSlot,
+        itemStyles: itemStyles,
+      ),
+    );
+  }
+
+  Widget _buildCheckboxItem(
+    RemixMenuCheckboxItem<T> item,
+    bool reserveChoiceSlot,
+  ) {
+    return NakedMenuCheckboxItem<T>(
+      value: item.value,
+      checked: item.checked,
+      onChanged: item.onChanged,
+      enabled:
+          item.enabled && (item.onChanged != null || hasRootSelectionCallback),
+      semanticLabel: item.semanticLabel ?? item.label,
+      closeOnActivate: item.closeOnActivate,
+      builder: (context, state, _) => _RemixMenuItemContent(
+        label: item.label,
+        leadingIcon: item.leadingIcon,
+        trailingIcon: item.trailingIcon,
+        showIndicator: item.checked,
+        style: item.style,
+        kind: .checkbox,
+        controller: NakedMenuItemState.controllerOf<T>(context),
+        reserveChoiceSlot: reserveChoiceSlot,
+        itemStyles: itemStyles,
+      ),
+    );
+  }
+
+  Widget _buildRadioGroup(
+    RemixMenuRadioGroup<T> group,
+    bool reserveChoiceSlot,
+  ) {
+    final radioItems = List<RemixMenuRadioItem<T>>.unmodifiable(group.items);
+    assert(
+      radioItems.isNotEmpty,
+      'Radio groups must contain at least one item',
+    );
+    assert(
+      radioItems.map((item) => item.value).toSet().length == radioItems.length,
+      'Radio group item values must be unique',
+    );
+    assert(
+      radioItems.where((item) => item.value == group.value).length == 1,
+      'A radio group value must match exactly one item',
+    );
+
+    return NakedMenuRadioGroup<T>(
+      value: group.value,
+      onChanged: group.onChanged,
+      enabled: group.enabled,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        spacing: overlayStyleSpec.spec.flex?.spec.spacing ?? 0,
+        verticalDirection:
+            overlayStyleSpec.spec.flex?.spec.verticalDirection ??
+            VerticalDirection.down,
+        children: radioItems
+            .map(
+              (item) => NakedMenuRadioItem<T>(
+                value: item.value,
+                enabled:
+                    item.enabled &&
+                    (group.onChanged != null || hasRootSelectionCallback),
+                semanticLabel: item.semanticLabel ?? item.label,
+                closeOnActivate: item.closeOnActivate,
+                builder: (context, state, _) => _RemixMenuItemContent(
+                  label: item.label,
+                  leadingIcon: item.leadingIcon,
+                  trailingIcon: item.trailingIcon,
+                  showIndicator: item.value == group.value,
+                  style: item.style,
+                  kind: .radio,
+                  controller: NakedMenuItemState.controllerOf<T>(context),
+                  reserveChoiceSlot: reserveChoiceSlot,
+                  itemStyles: itemStyles,
+                ),
+              ),
+            )
+            .toList(growable: false),
+      ),
+    );
+  }
+
+  Widget _buildSubmenu(RemixMenuSubmenu<T> submenu, bool reserveChoiceSlot) {
+    return NakedMenuSubmenu<T>(
+      controller: submenu.controller,
+      enabled: submenu.enabled,
+      hoverDelay: submenu.hoverDelay,
+      positioning: submenu.positioning,
+      focusNode: submenu.focusNode,
+      semanticLabel: submenu.semanticLabel ?? submenu.label,
+      onOpen: submenu.onOpen,
+      onClose: submenu.onClose,
+      overlayBuilder: (context, info) => _RemixMenuItemsPanel<T>(
+        items: submenu.items,
+        overlayStyleSpec: overlayStyleSpec,
+        containerEffects: containerEffects,
+        dividerStyleSpec: dividerStyleSpec,
+        hasRootSelectionCallback: hasRootSelectionCallback,
+        itemStyles: itemStyles,
+      ),
+      builder: (context, state, _) => _RemixMenuItemContent(
+        label: submenu.label,
+        leadingIcon: submenu.leadingIcon,
+        trailingIcon: submenu.trailingIcon,
+        submenuOpen: state.isOpen,
+        style: submenu.style,
+        kind: .submenu,
+        controller: NakedMenuState.controllerOf(context),
+        reserveChoiceSlot: reserveChoiceSlot,
+        itemStyles: itemStyles,
+      ),
+    );
+  }
+}
+
+class _RemixMenuItemContent extends StatelessWidget {
+  const _RemixMenuItemContent({
+    required this.label,
+    required this.style,
+    required this.kind,
+    required this.controller,
+    required this.reserveChoiceSlot,
+    required this.itemStyles,
+    this.leadingIcon,
+    this.trailingIcon,
+    this.showIndicator = false,
+    this.submenuOpen = false,
+  });
+
+  static const _defaultIndicatorSize = 9.0;
+
+  final String label;
+  final IconData? leadingIcon;
+  final IconData? trailingIcon;
+  final bool showIndicator;
+  final bool submenuOpen;
+  final MenuItemStyler style;
+  final _RemixMenuItemKind kind;
+  final WidgetStatesController controller;
+  final bool reserveChoiceSlot;
+  final _RemixMenuItemStyles itemStyles;
+
+  StyleSpec<MenuItemSpec> _resolveStyle(BuildContext context) =>
+      itemStyles.resolve(context, kind, style);
+
+  @override
+  Widget build(BuildContext context) {
+    return ExcludeSemantics(
+      child: ListenableBuilder(
+        listenable: controller,
+        builder: (context, child) {
+          final states = <WidgetState>{
+            ...controller.value,
+            if (submenuOpen) WidgetState.selected,
+          };
+          return WidgetStateProvider(
+            states: states,
+            child: Builder(
+              builder: (context) => StyleSpecBuilder<MenuItemSpec>(
+                styleSpec: _resolveStyle(context),
+                builder: (context, spec) => _buildRow(context, spec),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildRow(BuildContext context, MenuItemSpec spec) {
+    final flexSpec = spec.container.spec.flex?.spec;
+    final itemAxis = flexSpec?.direction ?? Axis.horizontal;
+    final indicatorSize = spec.indicator.spec.size ?? _defaultIndicatorSize;
+    final indicatorSpec = spec.indicator.spec.size == null
+        ? spec.indicator.copyWith(
+            spec: spec.indicator.spec.copyWith(size: indicatorSize),
+          )
+        : spec.indicator;
+
+    Widget? trailing;
+    if (trailingIcon != null) {
+      trailing = StyledIcon(icon: trailingIcon!, styleSpec: spec.trailingIcon);
+    } else if (kind == .submenu) {
+      trailing = RemixPathIcon(
+        key: ValueKey('remix-menu-submenu-chevron-$label'),
+        glyph: RemixPathGlyph.thickChevronRight,
+        styleSpec: spec.trailingIcon,
+        matchTextDirection: true,
+      );
+    }
+
+    return FlexBox(
+      styleSpec: spec.container,
+      children: [
+        if (reserveChoiceSlot)
+          SizedBox.square(
+            dimension: indicatorSize,
+            child: showIndicator
+                ? RemixPathIcon(
+                    key: ValueKey('remix-menu-indicator-$label'),
+                    glyph: RemixPathGlyph.thickCheck,
+                    styleSpec: indicatorSpec,
+                  )
+                : null,
           ),
-        );
-      },
+        if (leadingIcon != null)
+          StyledIcon(icon: leadingIcon!, styleSpec: spec.leadingIcon),
+        if (itemAxis == Axis.horizontal)
+          Expanded(child: StyledText(label, styleSpec: spec.label))
+        else
+          StyledText(label, styleSpec: spec.label),
+        if (trailing != null) trailing,
+      ],
     );
   }
 }

--- a/packages/remix/lib/src/components/menu/menu_widget.dart
+++ b/packages/remix/lib/src/components/menu/menu_widget.dart
@@ -69,8 +69,7 @@ final class RemixMenuItem<T> extends RemixMenuItemData<T> {
     this.closeOnActivate = true,
     this.semanticLabel,
     this.style = const MenuItemStyler.create(),
-  }) : assert(label != '', 'Item labels must not be empty'),
-       assert(semanticLabel != '', 'Item semantic labels must not be empty');
+  });
 }
 
 /// A controlled checkbox item in a [RemixMenu].
@@ -202,6 +201,17 @@ final class RemixMenuRadioItem<T> {
 /// The list must not be mutated while a panel is being built. Each nested
 /// panel consumes an immutable snapshot independently from its parent.
 final class RemixMenuSubmenu<T> extends RemixMenuItemData<T> {
+  static const _defaultLtrPositioning = OverlayPositionConfig(
+    side: OverlaySide.right,
+    alignment: OverlayAlignment.start,
+    sideOffset: 4,
+  );
+  static const _defaultRtlPositioning = OverlayPositionConfig(
+    side: OverlaySide.left,
+    alignment: OverlayAlignment.start,
+    sideOffset: 4,
+  );
+
   const RemixMenuSubmenu({
     super.key,
     required this.label,
@@ -211,17 +221,15 @@ final class RemixMenuSubmenu<T> extends RemixMenuItemData<T> {
     this.controller,
     this.enabled = true,
     this.hoverDelay = const Duration(milliseconds: 100),
-    this.positioning = const OverlayPositionConfig(
-      side: OverlaySide.right,
-      alignment: OverlayAlignment.start,
-      sideOffset: 4,
-    ),
+    OverlayPositionConfig? positioning,
     this.focusNode,
     this.semanticLabel,
     this.onOpen,
     this.onClose,
     this.style = const MenuItemStyler.create(),
-  }) : assert(label != '', 'Item labels must not be empty'),
+  }) : positioning = positioning ?? _defaultLtrPositioning,
+       _usesDefaultPositioning = positioning == null,
+       assert(label != '', 'Item labels must not be empty'),
        assert(semanticLabel != '', 'Item semantic labels must not be empty');
 
   /// The visible submenu trigger label.
@@ -246,7 +254,13 @@ final class RemixMenuSubmenu<T> extends RemixMenuItemData<T> {
   final Duration hoverDelay;
 
   /// Child-panel placement relative to the submenu trigger.
+  ///
+  /// When omitted, the panel opens toward logical end: right in left-to-right
+  /// layouts and left in right-to-left layouts. An explicit configuration
+  /// keeps its physical [OverlayPositionConfig.side] in either direction.
   final OverlayPositionConfig positioning;
+
+  final bool _usesDefaultPositioning;
 
   /// Optional caller-owned focus node for the submenu trigger.
   final FocusNode? focusNode;
@@ -263,6 +277,11 @@ final class RemixMenuSubmenu<T> extends RemixMenuItemData<T> {
   /// Per-trigger visual style applied after the menu-wide shared and submenu
   /// item styles.
   final MenuItemStyler style;
+
+  OverlayPositionConfig _resolvePositioning(TextDirection direction) =>
+      _usesDefaultPositioning && direction == TextDirection.rtl
+      ? _defaultRtlPositioning
+      : positioning;
 }
 
 /// Data class representing a menu divider.
@@ -564,7 +583,11 @@ class _RemixMenuItemsPanel<T> extends StatelessWidget {
                 item,
                 hasChoiceItems,
               ),
-              RemixMenuSubmenu<T>() => _buildSubmenu(item, hasChoiceItems),
+              RemixMenuSubmenu<T>() => _buildSubmenu(
+                context,
+                item,
+                hasChoiceItems,
+              ),
               RemixMenuDivider<T>() => StyleSpecBuilder(
                 key: item.key,
                 styleSpec: dividerStyleSpec,
@@ -688,13 +711,17 @@ class _RemixMenuItemsPanel<T> extends StatelessWidget {
     );
   }
 
-  Widget _buildSubmenu(RemixMenuSubmenu<T> submenu, bool reserveChoiceSlot) {
+  Widget _buildSubmenu(
+    BuildContext context,
+    RemixMenuSubmenu<T> submenu,
+    bool reserveChoiceSlot,
+  ) {
     return NakedMenuSubmenu<T>(
       key: submenu.key,
       controller: submenu.controller,
       enabled: submenu.enabled,
       hoverDelay: submenu.hoverDelay,
-      positioning: submenu.positioning,
+      positioning: submenu._resolvePositioning(Directionality.of(context)),
       focusNode: submenu.focusNode,
       semanticLabel: submenu.semanticLabel ?? submenu.label,
       onOpen: submenu.onOpen,

--- a/packages/remix/lib/src/components/menu/menu_widget.dart
+++ b/packages/remix/lib/src/components/menu/menu_widget.dart
@@ -24,7 +24,10 @@ class RemixMenuTrigger {
 /// This ensures type safety and exhaustive pattern matching when
 /// handling ordinary, checkbox, radio, submenu, and divider data.
 sealed class RemixMenuItemData<T> {
-  const RemixMenuItemData();
+  const RemixMenuItemData({this.key});
+
+  /// Optional caller-owned identity for the rendered item root.
+  final Key? key;
 }
 
 /// Data class representing a selectable menu item.
@@ -57,6 +60,7 @@ final class RemixMenuItem<T> extends RemixMenuItemData<T> {
   final MenuItemStyler style;
 
   const RemixMenuItem({
+    super.key,
     required this.value,
     required this.label,
     this.leadingIcon,
@@ -75,6 +79,7 @@ final class RemixMenuItem<T> extends RemixMenuItemData<T> {
 /// [value] and [onChanged] with the toggled checked value, in that order.
 final class RemixMenuCheckboxItem<T> extends RemixMenuItemData<T> {
   const RemixMenuCheckboxItem({
+    super.key,
     required this.value,
     required this.label,
     required this.checked,
@@ -128,6 +133,7 @@ final class RemixMenuCheckboxItem<T> extends RemixMenuItemData<T> {
 /// [MenuStyler.radioItem] or override an individual radio item's style.
 final class RemixMenuRadioGroup<T> extends RemixMenuItemData<T> {
   const RemixMenuRadioGroup({
+    super.key,
     required this.value,
     required this.items,
     this.onChanged,
@@ -150,6 +156,7 @@ final class RemixMenuRadioGroup<T> extends RemixMenuItemData<T> {
 /// A selectable item in a [RemixMenuRadioGroup].
 final class RemixMenuRadioItem<T> {
   const RemixMenuRadioItem({
+    this.key,
     required this.value,
     required this.label,
     this.leadingIcon,
@@ -160,6 +167,9 @@ final class RemixMenuRadioItem<T> {
     this.style = const MenuItemStyler.create(),
   }) : assert(label != '', 'Item labels must not be empty'),
        assert(semanticLabel != '', 'Item semantic labels must not be empty');
+
+  /// Optional caller-owned identity for the rendered radio item root.
+  final Key? key;
 
   /// The value reported to both root and group callbacks.
   final T value;
@@ -193,6 +203,7 @@ final class RemixMenuRadioItem<T> {
 /// panel consumes an immutable snapshot independently from its parent.
 final class RemixMenuSubmenu<T> extends RemixMenuItemData<T> {
   const RemixMenuSubmenu({
+    super.key,
     required this.label,
     required this.items,
     this.leadingIcon,
@@ -258,7 +269,7 @@ final class RemixMenuSubmenu<T> extends RemixMenuItemData<T> {
 ///
 /// Used with [RemixMenu]'s items list to visually separate groups of items.
 final class RemixMenuDivider<T> extends RemixMenuItemData<T> {
-  const RemixMenuDivider();
+  const RemixMenuDivider({super.key});
 }
 
 // ============================================================================
@@ -555,6 +566,7 @@ class _RemixMenuItemsPanel<T> extends StatelessWidget {
               ),
               RemixMenuSubmenu<T>() => _buildSubmenu(item, hasChoiceItems),
               RemixMenuDivider<T>() => StyleSpecBuilder(
+                key: item.key,
                 styleSpec: dividerStyleSpec,
                 builder: (context, dividerSpec) =>
                     RemixDivider(styleSpec: dividerSpec),
@@ -567,6 +579,7 @@ class _RemixMenuItemsPanel<T> extends StatelessWidget {
 
   Widget _buildOrdinaryItem(RemixMenuItem<T> item, bool reserveChoiceSlot) {
     return NakedMenuItem<T>(
+      key: item.key,
       value: item.value,
       enabled: item.enabled,
       semanticLabel: item.semanticLabel ?? item.label,
@@ -589,6 +602,7 @@ class _RemixMenuItemsPanel<T> extends StatelessWidget {
     bool reserveChoiceSlot,
   ) {
     return NakedMenuCheckboxItem<T>(
+      key: item.key,
       value: item.value,
       checked: item.checked,
       onChanged: item.onChanged,
@@ -633,6 +647,7 @@ class _RemixMenuItemsPanel<T> extends StatelessWidget {
     );
 
     return NakedMenuRadioGroup<T>(
+      key: group.key,
       value: group.value,
       onChanged: group.onChanged,
       enabled: group.enabled,
@@ -646,6 +661,7 @@ class _RemixMenuItemsPanel<T> extends StatelessWidget {
         children: radioItems
             .map(
               (item) => NakedMenuRadioItem<T>(
+                key: item.key,
                 value: item.value,
                 // Same public-callback gate as checkbox items; see
                 // _buildCheckboxItem for why Naked cannot own this.
@@ -674,6 +690,7 @@ class _RemixMenuItemsPanel<T> extends StatelessWidget {
 
   Widget _buildSubmenu(RemixMenuSubmenu<T> submenu, bool reserveChoiceSlot) {
     return NakedMenuSubmenu<T>(
+      key: submenu.key,
       controller: submenu.controller,
       enabled: submenu.enabled,
       hoverDelay: submenu.hoverDelay,

--- a/packages/remix/lib/src/utilities/remix_path_icon.dart
+++ b/packages/remix/lib/src/utilities/remix_path_icon.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:mix/mix.dart';
 
 /// Exact nine-unit paths shared by Radix-shaped component recipes.
-enum RemixPathGlyph { chevronDown, thickCheck }
+enum RemixPathGlyph { chevronDown, thickCheck, thickChevronRight }
 
 /// Paints a resolved icon spec with one of the pinned Radix vector paths.
 class RemixPathIcon extends StatelessWidget {
@@ -71,6 +71,7 @@ class _RemixPathIconPainter extends CustomPainter {
     final path = switch (glyph) {
       .chevronDown => _chevronDownPath(),
       .thickCheck => _thickCheckPath(),
+      .thickChevronRight => _thickChevronRightPath(),
     };
     for (final shadow in shadows) {
       canvas.drawPath(path.shift(shadow.offset / scale), shadow.toPaint());
@@ -112,4 +113,17 @@ Path _thickCheckPath() => Path()
   ..lineTo(3.73256, 6.60459)
   ..lineTo(7.49741, 0.840706)
   ..cubicTo(7.72393, 0.493916, 8.18868, 0.396414, 8.53547, 0.62293)
+  ..close();
+
+Path _thickChevronRightPath() => Path()
+  ..moveTo(3.23826, 0.201711)
+  ..cubicTo(3.54108, -0.0809141, 4.01567, -0.0645489, 4.29829, 0.238264)
+  ..lineTo(7.79829, 3.98826)
+  ..cubicTo(8.06724, 4.27642, 8.06724, 4.72359, 7.79829, 5.01174)
+  ..lineTo(4.29829, 8.76174)
+  ..cubicTo(4.01567, 9.06455, 3.54108, 9.08092, 3.23826, 8.79829)
+  ..cubicTo(2.93545, 8.51567, 2.91909, 8.04108, 3.20171, 7.73826)
+  ..lineTo(6.22409, 4.5)
+  ..lineTo(3.20171, 1.26174)
+  ..cubicTo(2.91909, 0.958928, 2.93545, 0.484337, 3.23826, 0.201711)
   ..close();

--- a/packages/remix/reference/radix_themes_3_3_0/README.md
+++ b/packages/remix/reference/radix_themes_3_3_0/README.md
@@ -8,15 +8,17 @@ boundaries, and reference-fixture paths live in `manifest.json`.
 `coverage_evidence.json` maps every manifest enum value and state to an exact
 executable test case in the corresponding `coverage.tests` allowlist. The
 parity checker rejects unknown keys, missing keys, stale test descriptions,
-uncited test files, source drift, an inexact Naked beta.7 dependency, or an
+uncited test files, source drift, an inexact Naked beta.8 dependency, or an
 undocumented approximation. Parameterized cases use their literal Dart test
 description, such as
 `${size.name} matches the pinned dimension and radius`.
 
-The only tracked parity approximation is the Dialog `modal: false` interaction
-boundary recorded in `manifest.json`: it changes accessibility route scoping,
-while the Navigator route remains pointer-modal. Resolved visual output has no
-tolerance for that boundary.
+The tracked parity approximations are the Dialog `modal: false` interaction
+boundary and the Menu's flex-based row geometry. The dialog boundary changes
+accessibility route scoping while the Navigator route remains pointer-modal.
+Menu behavior, semantics, paths, colors, sizes, and interaction states are
+covered; Remix uses a normal leading flex slot and item spacing instead of
+Radix's CSS-specific absolute indicator and trailing-slot positioning.
 
 Run the contract gate from this package directory:
 

--- a/packages/remix/reference/radix_themes_3_3_0/coverage_evidence.json
+++ b/packages/remix/reference/radix_themes_3_3_0/coverage_evidence.json
@@ -284,6 +284,26 @@
       "test": "test/components/menu/menu_widget_test.dart",
       "case": "onSelected callback fires when item is selected",
       "covers": ["state:selected"]
+    },
+    {
+      "test": "test/components/menu/menu_widget_test.dart",
+      "case": "exposes role, checked state, callback order, and rebuild",
+      "covers": ["state:checked", "state:unchecked"]
+    },
+    {
+      "test": "test/components/menu/menu_widget_test.dart",
+      "case": "open submenus resolve existing selected-state recipes",
+      "covers": ["state:submenuOpen"]
+    },
+    {
+      "test": "test/components/menu/menu_widget_test.dart",
+      "case": "${variant.name} distinguishes checked, highlighted, and submenu-open surfaces",
+      "covers": ["state:highlighted"]
+    },
+    {
+      "test": "test/components/menu/menu_widget_test.dart",
+      "case": "directional arrows and Escape restore submenu focus",
+      "covers": ["state:rtl", "state:escape", "state:focusRestored"]
     }
   ],
   "icon_button": [

--- a/packages/remix/reference/radix_themes_3_3_0/manifest.json
+++ b/packages/remix/reference/radix_themes_3_3_0/manifest.json
@@ -1325,6 +1325,10 @@
         "open",
         "highlighted",
         "disabled",
+        "checked",
+        "unchecked",
+        "submenuOpen",
+        "rtl",
         "escape",
         "focusRestored",
         "highContrast"
@@ -1343,7 +1347,7 @@
         ".rt-BaseMenuSubTrigger"
       ],
       "flutterExceptions": [
-        "The visual recipe maps supported Radix states onto the established data-driven RemixMenuItem list; compound menu items are deferred."
+        "Checkbox, radio, and submenu behavior delegates to the pinned Naked beta.8 primitives; Remix uses one standard leading flex slot and normal item spacing instead of Radix's CSS-specific absolute row geometry."
       ],
       "coverage": {
         "enums": [
@@ -1357,6 +1361,10 @@
           "open",
           "highlighted",
           "disabled",
+          "checked",
+          "unchecked",
+          "submenuOpen",
+          "rtl",
           "escape",
           "focusRestored",
           "highContrast"
@@ -1406,15 +1414,16 @@
         "open",
         "highlighted",
         "disabled",
+        "checked",
+        "unchecked",
+        "submenuOpen",
+        "rtl",
         "escape",
         "focusRestored",
         "highContrast"
       ],
       "deferredCapabilities": [
-        "compositional items",
-        "checkbox items",
-        "radio items",
-        "submenus"
+        "compositional items"
       ],
       "visualMapping": {
         "color": "FortalScope.accent",
@@ -3209,6 +3218,13 @@
       "flutter": "RemixDialog with modal=false disables modal accessibility route scoping, but showRemixDialog remains a RawDialogRoute whose barrier blocks background pointer input.",
       "reason": "Flutter Navigator dialog routes are modal routes; non-modal pointer interaction requires a separate OverlayEntry lifecycle rather than the approved dialog route API.",
       "tolerance": "Interaction-model boundary only; no visual tolerance. The route barrier and both accessibility modes are covered by dialog_widget_test.dart."
+    },
+    {
+      "family": "menu",
+      "upstream": "Radix Themes uses CSS absolute positioning and size-specific conditional offsets for checkbox, radio, submenu, and trailing content geometry.",
+      "flutter": "Remix uses the exact pinned check and chevron paths, colors, sizes, and states with one private leading flex slot and normal MenuItemStyler spacing.",
+      "reason": "Standard MenuItemStyler flex, padding, and spacing keep the layout reusable and avoid menu-only public gutter and offset APIs.",
+      "tolerance": "Pixel placement of the leading choice slot and trailing-content spacing may differ; behavior, semantics, paths, colors, sizes, state precedence, directionality, and panel-end alignment have no tolerance."
     }
   ],
   "upstreamInventory": {
@@ -4211,10 +4227,7 @@
       "interactive card behavior"
     ],
     "menu": [
-      "compositional items",
-      "checkbox items",
-      "radio items",
-      "submenus"
+      "compositional items"
     ],
     "select": [
       "structured content",

--- a/packages/remix/test/components/fortal_widget_test.dart
+++ b/packages/remix/test/components/fortal_widget_test.dart
@@ -4,6 +4,13 @@ import 'package:remix/remix.dart';
 
 import '../helpers/test_helpers.dart';
 
+typedef _StyleAwareFortalMenuConstructor =
+    FortalMenu<String> Function({
+      required RemixMenuTrigger trigger,
+      required List<RemixMenuItemData<String>> items,
+      MenuStyler? style,
+    });
+
 void main() {
   group('Fortal widgets', () {
     test('named constructors pin variants and infer generic types', () {
@@ -30,21 +37,15 @@ void main() {
       expect(select.variant, FortalSelectVariant.ghost);
     });
 
-    test('all FortalMenu constructors retain typed style overrides', () {
-      final style = MenuStyler().radioItem(
-        MenuItemStyler().indicator(IconStyler().size(13)),
-      );
-      const trigger = RemixMenuTrigger(label: 'Menu');
-      const items = [RemixMenuItem(value: 'a', label: 'A')];
-
-      final menus = <FortalMenu<String>>[
-        FortalMenu(style: style, trigger: trigger, items: items),
-        FortalMenu.solid(style: style, trigger: trigger, items: items),
-        FortalMenu.soft(style: style, trigger: trigger, items: items),
+    test('FortalMenu constructors do not expose style overrides', () {
+      final constructors = [
+        FortalMenu<String>.new,
+        FortalMenu<String>.solid,
+        FortalMenu<String>.soft,
       ];
 
-      for (final menu in menus) {
-        expect(menu.style, same(style));
+      for (final constructor in constructors) {
+        expect(constructor, isNot(isA<_StyleAwareFortalMenuConstructor>()));
       }
     });
 
@@ -276,21 +277,13 @@ void main() {
       expect(find.byType(RemixTooltip), findsOneWidget);
     });
 
-    testWidgets('forwards FortalMenu recipe parameters and style', (
-      tester,
-    ) async {
-      final choiceItemStyle = MenuItemStyler().indicator(IconStyler().size(13));
-      final style = MenuStyler()
-          .checkboxItem(choiceItemStyle)
-          .radioItem(choiceItemStyle);
-
+    testWidgets('forwards FortalMenu recipe parameters', (tester) async {
       await tester.pumpRemixApp(
-        FortalMenu<String>.soft(
+        const FortalMenu<String>.soft(
           size: .size1,
           highContrast: true,
-          style: style,
-          trigger: const RemixMenuTrigger(label: 'Menu'),
-          items: const [
+          trigger: RemixMenuTrigger(label: 'Menu'),
+          items: [
             RemixMenuCheckboxItem(
               value: 'checked',
               label: 'Checked',
@@ -309,19 +302,13 @@ void main() {
       expect(generated.variant, FortalMenuVariant.soft);
       expect(generated.size, FortalMenuSize.size1);
       expect(generated.highContrast, isTrue);
-      expect(generated.style, same(style));
 
       final menu = tester.widget<RemixMenu<String>>(
         find.byType(RemixMenu<String>),
       );
       expect(
         menu.style,
-        fortalMenuStyle(
-          variant: .soft,
-          size: .size1,
-          highContrast: true,
-          style: style,
-        ),
+        fortalMenuStyle(variant: .soft, size: .size1, highContrast: true),
       );
     });
 

--- a/packages/remix/test/components/fortal_widget_test.dart
+++ b/packages/remix/test/components/fortal_widget_test.dart
@@ -30,6 +30,24 @@ void main() {
       expect(select.variant, FortalSelectVariant.ghost);
     });
 
+    test('all FortalMenu constructors retain typed style overrides', () {
+      final style = MenuStyler().radioItem(
+        MenuItemStyler().indicator(IconStyler().size(13)),
+      );
+      const trigger = RemixMenuTrigger(label: 'Menu');
+      const items = [RemixMenuItem(value: 'a', label: 'A')];
+
+      final menus = <FortalMenu<String>>[
+        FortalMenu(style: style, trigger: trigger, items: items),
+        FortalMenu.solid(style: style, trigger: trigger, items: items),
+        FortalMenu.soft(style: style, trigger: trigger, items: items),
+      ];
+
+      for (final menu in menus) {
+        expect(menu.style, same(style));
+      }
+    });
+
     testWidgets('renders FortalAccordion', (tester) async {
       await tester.pumpRemixApp(
         RemixAccordionGroup<String>(
@@ -258,15 +276,53 @@ void main() {
       expect(find.byType(RemixTooltip), findsOneWidget);
     });
 
-    testWidgets('renders FortalMenu', (tester) async {
+    testWidgets('forwards FortalMenu recipe parameters and style', (
+      tester,
+    ) async {
+      final choiceItemStyle = MenuItemStyler().indicator(IconStyler().size(13));
+      final style = MenuStyler()
+          .checkboxItem(choiceItemStyle)
+          .radioItem(choiceItemStyle);
+
       await tester.pumpRemixApp(
-        FortalMenu<String>(
+        FortalMenu<String>.soft(
+          size: .size1,
+          highContrast: true,
+          style: style,
           trigger: const RemixMenuTrigger(label: 'Menu'),
-          items: const [RemixMenuItem(value: 'a', label: 'A')],
+          items: const [
+            RemixMenuCheckboxItem(
+              value: 'checked',
+              label: 'Checked',
+              checked: true,
+            ),
+          ],
         ),
       );
+
       expect(find.byType(FortalMenu<String>), findsOneWidget);
       expect(find.byType(RemixMenu<String>), findsOneWidget);
+
+      final generated = tester.widget<FortalMenu<String>>(
+        find.byType(FortalMenu<String>),
+      );
+      expect(generated.variant, FortalMenuVariant.soft);
+      expect(generated.size, FortalMenuSize.size1);
+      expect(generated.highContrast, isTrue);
+      expect(generated.style, same(style));
+
+      final menu = tester.widget<RemixMenu<String>>(
+        find.byType(RemixMenu<String>),
+      );
+      expect(
+        menu.style,
+        fortalMenuStyle(
+          variant: .soft,
+          size: .size1,
+          highContrast: true,
+          style: style,
+        ),
+      );
     });
 
     testWidgets('renders FortalSelect', (tester) async {

--- a/packages/remix/test/components/menu/menu_spec_test.dart
+++ b/packages/remix/test/components/menu/menu_spec_test.dart
@@ -170,6 +170,9 @@ void main() {
         expect(spec.trigger, isA<StyleSpec<MenuTriggerSpec>>());
         expect(spec.overlay, isA<StyleSpec<FlexBoxSpec>>());
         expect(spec.item, isA<StyleSpec<MenuItemSpec>>());
+        expect(spec.checkboxItem, isNull);
+        expect(spec.radioItem, isNull);
+        expect(spec.submenuItem, isNull);
         expect(spec.divider, isA<StyleSpec<DividerSpec>>());
       });
 
@@ -177,18 +180,33 @@ void main() {
         final trigger = StyleSpec(spec: MenuTriggerSpec());
         final overlay = StyleSpec(spec: FlexBoxSpec());
         final item = StyleSpec(spec: MenuItemSpec());
+        final checkboxItem = StyleSpec(
+          spec: MenuItemSpec(indicator: StyleSpec(spec: IconSpec(size: 10))),
+        );
+        final radioItem = StyleSpec(
+          spec: MenuItemSpec(indicator: StyleSpec(spec: IconSpec(size: 11))),
+        );
+        final submenuItem = StyleSpec(
+          spec: MenuItemSpec(trailingIcon: StyleSpec(spec: IconSpec(size: 12))),
+        );
         final divider = StyleSpec(spec: DividerSpec());
 
         final spec = MenuSpec(
           trigger: trigger,
           overlay: overlay,
           item: item,
+          checkboxItem: checkboxItem,
+          radioItem: radioItem,
+          submenuItem: submenuItem,
           divider: divider,
         );
 
         expect(spec.trigger, equals(trigger));
         expect(spec.overlay, equals(overlay));
         expect(spec.item, equals(item));
+        expect(spec.checkboxItem, equals(checkboxItem));
+        expect(spec.radioItem, equals(radioItem));
+        expect(spec.submenuItem, equals(submenuItem));
         expect(spec.divider, equals(divider));
       });
     });
@@ -221,18 +239,33 @@ void main() {
         final newTrigger = StyleSpec(spec: MenuTriggerSpec());
         final newOverlay = StyleSpec(spec: FlexBoxSpec());
         final newItem = StyleSpec(spec: MenuItemSpec());
+        final newCheckboxItem = StyleSpec(
+          spec: MenuItemSpec(indicator: StyleSpec(spec: IconSpec(size: 10))),
+        );
+        final newRadioItem = StyleSpec(
+          spec: MenuItemSpec(indicator: StyleSpec(spec: IconSpec(size: 11))),
+        );
+        final newSubmenuItem = StyleSpec(
+          spec: MenuItemSpec(trailingIcon: StyleSpec(spec: IconSpec(size: 12))),
+        );
         final newDivider = StyleSpec(spec: DividerSpec());
 
         final updatedSpec = originalSpec.copyWith(
           trigger: newTrigger,
           overlay: newOverlay,
           item: newItem,
+          checkboxItem: newCheckboxItem,
+          radioItem: newRadioItem,
+          submenuItem: newSubmenuItem,
           divider: newDivider,
         );
 
         expect(updatedSpec.trigger, equals(newTrigger));
         expect(updatedSpec.overlay, equals(newOverlay));
         expect(updatedSpec.item, equals(newItem));
+        expect(updatedSpec.checkboxItem, equals(newCheckboxItem));
+        expect(updatedSpec.radioItem, equals(newRadioItem));
+        expect(updatedSpec.submenuItem, equals(newSubmenuItem));
         expect(updatedSpec.divider, equals(newDivider));
       });
     });
@@ -266,6 +299,96 @@ void main() {
         expect(result, isNot(same(spec2)));
         expect(result.trigger, equals(spec2.trigger));
       });
+
+      test('preserves nullable semantic styles at exact endpoints', () {
+        const checkboxItem = StyleSpec(
+          spec: MenuItemSpec(indicator: StyleSpec(spec: IconSpec(size: 10))),
+        );
+        const radioItem = StyleSpec(
+          spec: MenuItemSpec(indicator: StyleSpec(spec: IconSpec(size: 11))),
+        );
+        const submenuItem = StyleSpec(
+          spec: MenuItemSpec(trailingIcon: StyleSpec(spec: IconSpec(size: 12))),
+        );
+        const absent = MenuSpec();
+        const present = MenuSpec(
+          checkboxItem: checkboxItem,
+          radioItem: radioItem,
+          submenuItem: submenuItem,
+        );
+
+        List<StyleSpec<MenuItemSpec>?> semanticStyles(MenuSpec spec) => [
+          spec.checkboxItem,
+          spec.radioItem,
+          spec.submenuItem,
+        ];
+
+        expect(semanticStyles(absent.lerp(present, 0)), [null, null, null]);
+        expect(semanticStyles(absent.lerp(present, 1)), [
+          checkboxItem,
+          radioItem,
+          submenuItem,
+        ]);
+        expect(semanticStyles(present.lerp(absent, 0)), [
+          checkboxItem,
+          radioItem,
+          submenuItem,
+        ]);
+        expect(semanticStyles(present.lerp(absent, 1)), [null, null, null]);
+      });
+
+      test('interpolates an absent semantic style from the item fallback', () {
+        const start = MenuSpec(
+          item: StyleSpec(
+            spec: MenuItemSpec(
+              indicator: StyleSpec(spec: IconSpec(size: 4)),
+            ),
+          ),
+        );
+        const end = MenuSpec(
+          checkboxItem: StyleSpec(
+            spec: MenuItemSpec(
+              indicator: StyleSpec(spec: IconSpec(size: 20)),
+            ),
+          ),
+        );
+
+        final middle = start.lerp(end, 0.5);
+
+        expect(middle.checkboxItem?.spec.indicator.spec.size, 12);
+      });
+
+      test('keeps both-null semantic styles absent while lerping', () {
+        const start = MenuSpec();
+        const end = MenuSpec();
+
+        final middle = start.lerp(end, 0.5);
+
+        expect(middle.checkboxItem, isNull);
+        expect(middle.radioItem, isNull);
+        expect(middle.submenuItem, isNull);
+      });
+
+      test('interpolates semantic styles when both endpoints define them', () {
+        const start = MenuSpec(
+          radioItem: StyleSpec(
+            spec: MenuItemSpec(
+              indicator: StyleSpec(spec: IconSpec(size: 4)),
+            ),
+          ),
+        );
+        const end = MenuSpec(
+          radioItem: StyleSpec(
+            spec: MenuItemSpec(
+              indicator: StyleSpec(spec: IconSpec(size: 20)),
+            ),
+          ),
+        );
+
+        final middle = start.lerp(end, 0.5);
+
+        expect(middle.radioItem?.spec.indicator.spec.size, 12);
+      });
     });
 
     group('Equality and Props', () {
@@ -294,10 +417,13 @@ void main() {
       test('props list contains all properties', () {
         const spec = MenuSpec();
 
-        expect(spec.props, hasLength(5));
+        expect(spec.props, hasLength(8));
         expect(spec.props, contains(spec.trigger));
         expect(spec.props, contains(spec.overlay));
         expect(spec.props, contains(spec.item));
+        expect(spec.props, contains(spec.checkboxItem));
+        expect(spec.props, contains(spec.radioItem));
+        expect(spec.props, contains(spec.submenuItem));
         expect(spec.props, contains(spec.divider));
       });
     });
@@ -330,6 +456,7 @@ void main() {
         expect(spec.label, isA<StyleSpec<TextSpec>>());
         expect(spec.leadingIcon, isA<StyleSpec<IconSpec>>());
         expect(spec.trailingIcon, isA<StyleSpec<IconSpec>>());
+        expect(spec.indicator, isA<StyleSpec<IconSpec>>());
       });
 
       test('creates spec with provided parameters', () {
@@ -337,18 +464,21 @@ void main() {
         final label = StyleSpec(spec: TextSpec());
         final leadingIcon = StyleSpec(spec: IconSpec());
         final trailingIcon = StyleSpec(spec: IconSpec());
+        final indicator = StyleSpec(spec: IconSpec());
 
         final spec = MenuItemSpec(
           container: container,
           label: label,
           leadingIcon: leadingIcon,
           trailingIcon: trailingIcon,
+          indicator: indicator,
         );
 
         expect(spec.container, equals(container));
         expect(spec.label, equals(label));
         expect(spec.leadingIcon, equals(leadingIcon));
         expect(spec.trailingIcon, equals(trailingIcon));
+        expect(spec.indicator, equals(indicator));
       });
     });
 
@@ -381,18 +511,21 @@ void main() {
         final newLabel = StyleSpec(spec: TextSpec());
         final newLeadingIcon = StyleSpec(spec: IconSpec());
         final newTrailingIcon = StyleSpec(spec: IconSpec());
+        final newIndicator = StyleSpec(spec: IconSpec());
 
         final updatedSpec = originalSpec.copyWith(
           container: newContainer,
           label: newLabel,
           leadingIcon: newLeadingIcon,
           trailingIcon: newTrailingIcon,
+          indicator: newIndicator,
         );
 
         expect(updatedSpec.container, equals(newContainer));
         expect(updatedSpec.label, equals(newLabel));
         expect(updatedSpec.leadingIcon, equals(newLeadingIcon));
         expect(updatedSpec.trailingIcon, equals(newTrailingIcon));
+        expect(updatedSpec.indicator, equals(newIndicator));
       });
     });
 
@@ -453,11 +586,12 @@ void main() {
       test('props list contains all properties', () {
         const spec = MenuItemSpec();
 
-        expect(spec.props, hasLength(4));
+        expect(spec.props, hasLength(5));
         expect(spec.props, contains(spec.container));
         expect(spec.props, contains(spec.label));
         expect(spec.props, contains(spec.leadingIcon));
         expect(spec.props, contains(spec.trailingIcon));
+        expect(spec.props, contains(spec.indicator));
       });
     });
 
@@ -487,6 +621,19 @@ void main() {
         final updatedSpec = spec.copyWith(container: null);
 
         expect(updatedSpec.container, equals(originalContainer));
+      });
+
+      test('lerps indicator style', () {
+        const start = MenuItemSpec(
+          indicator: StyleSpec(spec: IconSpec(size: 8)),
+        );
+        const end = MenuItemSpec(
+          indicator: StyleSpec(spec: IconSpec(size: 12)),
+        );
+
+        final middle = start.lerp(end, 0.5);
+
+        expect(middle.indicator.spec.size, 10);
       });
     });
   });

--- a/packages/remix/test/components/menu/menu_spec_test.dart
+++ b/packages/remix/test/components/menu/menu_spec_test.dart
@@ -337,19 +337,49 @@ void main() {
         expect(semanticStyles(present.lerp(absent, 1)), [null, null, null]);
       });
 
-      test('interpolates an absent semantic style from the item fallback', () {
+      test('extrapolates before zero using the item fallback', () {
         const start = MenuSpec(
           item: StyleSpec(
-            spec: MenuItemSpec(
-              indicator: StyleSpec(spec: IconSpec(size: 4)),
-            ),
+            spec: MenuItemSpec(indicator: StyleSpec(spec: IconSpec(size: 8))),
           ),
         );
         const end = MenuSpec(
           checkboxItem: StyleSpec(
-            spec: MenuItemSpec(
-              indicator: StyleSpec(spec: IconSpec(size: 20)),
-            ),
+            spec: MenuItemSpec(indicator: StyleSpec(spec: IconSpec(size: 16))),
+          ),
+        );
+
+        final result = start.lerp(end, -0.5);
+
+        expect(result.checkboxItem?.spec.indicator.spec.size, 4);
+      });
+
+      test('extrapolates beyond one using the item fallback', () {
+        const start = MenuSpec(
+          item: StyleSpec(
+            spec: MenuItemSpec(indicator: StyleSpec(spec: IconSpec(size: 8))),
+          ),
+        );
+        const end = MenuSpec(
+          checkboxItem: StyleSpec(
+            spec: MenuItemSpec(indicator: StyleSpec(spec: IconSpec(size: 16))),
+          ),
+        );
+
+        final result = start.lerp(end, 1.5);
+
+        expect(result.checkboxItem?.spec.indicator.spec.size, 20);
+      });
+
+      test('interpolates an absent semantic style from the item fallback', () {
+        const start = MenuSpec(
+          item: StyleSpec(
+            spec: MenuItemSpec(indicator: StyleSpec(spec: IconSpec(size: 4))),
+          ),
+        );
+        const end = MenuSpec(
+          checkboxItem: StyleSpec(
+            spec: MenuItemSpec(indicator: StyleSpec(spec: IconSpec(size: 20))),
           ),
         );
 
@@ -372,16 +402,12 @@ void main() {
       test('interpolates semantic styles when both endpoints define them', () {
         const start = MenuSpec(
           radioItem: StyleSpec(
-            spec: MenuItemSpec(
-              indicator: StyleSpec(spec: IconSpec(size: 4)),
-            ),
+            spec: MenuItemSpec(indicator: StyleSpec(spec: IconSpec(size: 4))),
           ),
         );
         const end = MenuSpec(
           radioItem: StyleSpec(
-            spec: MenuItemSpec(
-              indicator: StyleSpec(spec: IconSpec(size: 20)),
-            ),
+            spec: MenuItemSpec(indicator: StyleSpec(spec: IconSpec(size: 20))),
           ),
         );
 

--- a/packages/remix/test/components/menu/menu_style_test.dart
+++ b/packages/remix/test/components/menu/menu_style_test.dart
@@ -328,6 +328,9 @@ void main() {
         final trigger = Prop.maybeMix(MenuTriggerStyler());
         final overlay = Prop.maybeMix(FlexBoxStyler());
         final item = Prop.maybeMix(MenuItemStyler());
+        final checkboxItem = Prop.maybeMix(MenuItemStyler());
+        final radioItem = Prop.maybeMix(MenuItemStyler());
+        final submenuItem = Prop.maybeMix(MenuItemStyler());
         final divider = Prop.maybeMix(DividerStyler());
         final variants = <VariantStyle<MenuSpec>>[];
 
@@ -335,6 +338,9 @@ void main() {
           trigger: trigger,
           overlay: overlay,
           item: item,
+          checkboxItem: checkboxItem,
+          radioItem: radioItem,
+          submenuItem: submenuItem,
           divider: divider,
           variants: variants,
         );
@@ -343,6 +349,9 @@ void main() {
         expect(style.$trigger, equals(trigger));
         expect(style.$overlay, equals(overlay));
         expect(style.$item, equals(item));
+        expect(style.$checkboxItem, equals(checkboxItem));
+        expect(style.$radioItem, equals(radioItem));
+        expect(style.$submenuItem, equals(submenuItem));
         expect(style.$divider, equals(divider));
         expect(style.$variants, equals(variants));
       });
@@ -351,12 +360,18 @@ void main() {
         final triggerStyle = MenuTriggerStyler();
         final overlayStyler = FlexBoxStyler();
         final itemStyle = MenuItemStyler();
+        final checkboxItemStyle = MenuItemStyler();
+        final radioItemStyle = MenuItemStyler();
+        final submenuItemStyle = MenuItemStyler();
         final dividerStyle = DividerStyler();
 
         final style = MenuStyler(
           trigger: triggerStyle,
           overlay: overlayStyler,
           item: itemStyle,
+          checkboxItem: checkboxItemStyle,
+          radioItem: radioItemStyle,
+          submenuItem: submenuItemStyle,
           divider: dividerStyle,
         );
 
@@ -364,6 +379,9 @@ void main() {
         expect(style.$trigger, isNotNull);
         expect(style.$overlay, isNotNull);
         expect(style.$item, isNotNull);
+        expect(style.$checkboxItem, isNotNull);
+        expect(style.$radioItem, isNotNull);
+        expect(style.$submenuItem, isNotNull);
         expect(style.$divider, isNotNull);
       });
     });
@@ -393,6 +411,33 @@ void main() {
         modify: (style) => style.item(MenuItemStyler()),
         expect: (style) {
           expect(style.$item, equals(Prop.maybeMix(MenuItemStyler())));
+        },
+      );
+
+      styleMethodTest(
+        'checkboxItem',
+        initial: MenuStyler(),
+        modify: (style) => style.checkboxItem(MenuItemStyler()),
+        expect: (style) {
+          expect(style.$checkboxItem, equals(Prop.maybeMix(MenuItemStyler())));
+        },
+      );
+
+      styleMethodTest(
+        'radioItem',
+        initial: MenuStyler(),
+        modify: (style) => style.radioItem(MenuItemStyler()),
+        expect: (style) {
+          expect(style.$radioItem, equals(Prop.maybeMix(MenuItemStyler())));
+        },
+      );
+
+      styleMethodTest(
+        'submenuItem',
+        initial: MenuStyler(),
+        modify: (style) => style.submenuItem(MenuItemStyler()),
+        expect: (style) {
+          expect(style.$submenuItem, equals(Prop.maybeMix(MenuItemStyler())));
         },
       );
 
@@ -496,6 +541,63 @@ void main() {
         expect(menu.triggerFocusNode, equals(focusNode));
         expect(menu.positioning, same(positioning));
       });
+
+      test('assigned Fortal recipe composes semantic styles before call', () {
+        final radioItemStyle = MenuItemStyler().indicator(
+          IconStyler().size(13),
+        );
+        final menuStyle = fortalMenuStyle(
+          variant: .soft,
+        ).radioItem(radioItemStyle);
+
+        final menu = menuStyle.call<String>(
+          trigger: const RemixMenuTrigger(label: 'Options'),
+          items: const [
+            RemixMenuRadioGroup(
+              value: 'compact',
+              items: [RemixMenuRadioItem(value: 'compact', label: 'Compact')],
+            ),
+          ],
+          onSelected: (_) {},
+        );
+
+        expect(menu, isA<RemixMenu<String>>());
+        expect(menu.style.$radioItem, Prop.maybeMix(radioItemStyle));
+      });
+
+      test('Fortal recipe merges an optional menu-wide style last', () {
+        final choiceItemStyle = MenuItemStyler().indicator(
+          IconStyler().size(13),
+        );
+        final override = MenuStyler()
+            .checkboxItem(choiceItemStyle)
+            .radioItem(choiceItemStyle);
+        final base = fortalMenuStyle(
+          variant: .soft,
+          size: .size1,
+          highContrast: true,
+        );
+
+        final customized = fortalMenuStyle(
+          variant: .soft,
+          size: .size1,
+          highContrast: true,
+          style: override,
+        );
+
+        expect(customized, base.merge(override));
+        expect(customized.$checkboxItem, Prop.maybeMix(choiceItemStyle));
+        expect(customized.$radioItem, Prop.maybeMix(choiceItemStyle));
+        expect(
+          fortalMenuStyle(
+            variant: .soft,
+            size: .size1,
+            highContrast: true,
+            style: null,
+          ),
+          base,
+        );
+      });
     });
 
     group('Core Methods', () {
@@ -515,6 +617,9 @@ void main() {
                 expect(spec.spec.trigger, isA<StyleSpec<MenuTriggerSpec>>());
                 expect(spec.spec.overlay, isA<StyleSpec<FlexBoxSpec>>());
                 expect(spec.spec.item, isA<StyleSpec<MenuItemSpec>>());
+                expect(spec.spec.checkboxItem, isNull);
+                expect(spec.spec.radioItem, isNull);
+                expect(spec.spec.submenuItem, isNull);
                 expect(spec.spec.divider, isA<StyleSpec<DividerSpec>>());
 
                 return Container();
@@ -569,6 +674,7 @@ void main() {
         final label = Prop.maybeMix(TextStyler());
         final leadingIcon = Prop.maybeMix(IconStyler());
         final trailingIcon = Prop.maybeMix(IconStyler());
+        final indicator = Prop.maybeMix(IconStyler());
         final variants = <VariantStyle<MenuItemSpec>>[];
 
         final style = MenuItemStyler.create(
@@ -576,6 +682,7 @@ void main() {
           label: label,
           leadingIcon: leadingIcon,
           trailingIcon: trailingIcon,
+          indicator: indicator,
           variants: variants,
         );
 
@@ -584,6 +691,7 @@ void main() {
         expect(style.$label, equals(label));
         expect(style.$leadingIcon, equals(leadingIcon));
         expect(style.$trailingIcon, equals(trailingIcon));
+        expect(style.$indicator, equals(indicator));
         expect(style.$variants, equals(variants));
       });
 
@@ -592,12 +700,14 @@ void main() {
         final labelStyler = TextStyler();
         final leadingIconStyler = IconStyler();
         final trailingIconStyler = IconStyler();
+        final indicatorStyler = IconStyler();
 
         final style = MenuItemStyler(
           container: containerStyler,
           label: labelStyler,
           leadingIcon: leadingIconStyler,
           trailingIcon: trailingIconStyler,
+          indicator: indicatorStyler,
         );
 
         expect(style, isNotNull);
@@ -605,6 +715,7 @@ void main() {
         expect(style.$label, isNotNull);
         expect(style.$leadingIcon, isNotNull);
         expect(style.$trailingIcon, isNotNull);
+        expect(style.$indicator, isNotNull);
       });
     });
 
@@ -633,6 +744,18 @@ void main() {
         modify: (style) => style.trailingIcon(IconStyler()),
         expect: (style) {
           expect(style.$trailingIcon, equals(Prop.maybeMix(IconStyler())));
+        },
+      );
+
+      styleMethodTest(
+        'indicator',
+        initial: MenuItemStyler(),
+        modify: (style) => style.indicator(IconStyler().size(10)),
+        expect: (style) {
+          expect(
+            style.$indicator,
+            equals(Prop.maybeMix(IconStyler().size(10))),
+          );
         },
       );
 
@@ -830,6 +953,7 @@ void main() {
                 expect(spec.spec.label, isA<StyleSpec<TextSpec>>());
                 expect(spec.spec.leadingIcon, isA<StyleSpec<IconSpec>>());
                 expect(spec.spec.trailingIcon, isA<StyleSpec<IconSpec>>());
+                expect(spec.spec.indicator, isA<StyleSpec<IconSpec>>());
 
                 return Container();
               },
@@ -844,6 +968,30 @@ void main() {
         final mergedStyle = originalStyle.merge(null);
 
         expect(mergedStyle, equals(originalStyle));
+      });
+
+      testWidgets('fluent indicator style resolves like a raw item spec', (
+        tester,
+      ) async {
+        const raw = MenuItemSpec(
+          indicator: StyleSpec(spec: IconSpec(size: 10)),
+        );
+        late MenuItemSpec resolved;
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Builder(
+              builder: (context) {
+                resolved = MenuItemStyler()
+                    .indicator(IconStyler().size(10))
+                    .resolve(context)
+                    .spec;
+                return const SizedBox.shrink();
+              },
+            ),
+          ),
+        );
+
+        expect(resolved, raw);
       });
     });
 

--- a/packages/remix/test/components/menu/menu_style_test.dart
+++ b/packages/remix/test/components/menu/menu_style_test.dart
@@ -565,38 +565,31 @@ void main() {
         expect(menu.style.$radioItem, Prop.maybeMix(radioItemStyle));
       });
 
-      test('Fortal recipe merges an optional menu-wide style last', () {
+      test('RemixMenu composes a Fortal recipe with custom styling', () {
         final choiceItemStyle = MenuItemStyler().indicator(
           IconStyler().size(13),
         );
-        final override = MenuStyler()
+        final customStyle = MenuStyler()
             .checkboxItem(choiceItemStyle)
             .radioItem(choiceItemStyle);
-        final base = fortalMenuStyle(
-          variant: .soft,
-          size: .size1,
-          highContrast: true,
-        );
-
-        final customized = fortalMenuStyle(
-          variant: .soft,
-          size: .size1,
-          highContrast: true,
-          style: override,
-        );
-
-        expect(customized, base.merge(override));
-        expect(customized.$checkboxItem, Prop.maybeMix(choiceItemStyle));
-        expect(customized.$radioItem, Prop.maybeMix(choiceItemStyle));
-        expect(
-          fortalMenuStyle(
+        final menu = RemixMenu<String>(
+          style: fortalMenuStyle(
             variant: .soft,
             size: .size1,
             highContrast: true,
-            style: null,
-          ),
-          base,
+          ).merge(customStyle),
+          trigger: const RemixMenuTrigger(label: 'Options'),
+          items: const [
+            RemixMenuCheckboxItem(
+              value: 'checked',
+              label: 'Checked',
+              checked: true,
+            ),
+          ],
         );
+
+        expect(menu.style.$checkboxItem, Prop.maybeMix(choiceItemStyle));
+        expect(menu.style.$radioItem, Prop.maybeMix(choiceItemStyle));
       });
     });
 

--- a/packages/remix/test/components/menu/menu_widget_test.dart
+++ b/packages/remix/test/components/menu/menu_widget_test.dart
@@ -1116,10 +1116,6 @@ void main() {
 
     test('compound labels and semantic labels must not be empty', () {
       expect(
-        () => RemixMenuItem<String>(value: 'ordinary', label: ''),
-        throwsAssertionError,
-      );
-      expect(
         () => RemixMenuCheckboxItem<String>(
           value: 'checkbox',
           label: '',
@@ -1572,6 +1568,85 @@ void main() {
   });
 
   group('RemixMenu submenus', () {
+    testWidgets(
+      'omitted submenu side follows direction and explicit right stays physical',
+      (tester) async {
+        await tester.binding.setSurfaceSize(const Size(1200, 800));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+
+        Future<void> expectPlacement({
+          required TextDirection direction,
+          required OverlaySide expectedSide,
+          bool explicitRight = false,
+        }) async {
+          final menuController = MenuController();
+          final submenuController = MenuController();
+          final submenu = explicitRight
+              ? RemixMenuSubmenu<String>(
+                  controller: submenuController,
+                  label: 'More',
+                  positioning: const OverlayPositionConfig(
+                    side: OverlaySide.right,
+                    alignment: OverlayAlignment.start,
+                    sideOffset: 4,
+                  ),
+                  items: const [
+                    RemixMenuItem(value: 'archive', label: 'Archive'),
+                  ],
+                )
+              : RemixMenuSubmenu<String>(
+                  controller: submenuController,
+                  label: 'More',
+                  items: const [
+                    RemixMenuItem(value: 'archive', label: 'Archive'),
+                  ],
+                );
+
+          await tester.pumpRemixApp(
+            RemixMenu<String>(
+              controller: menuController,
+              trigger: const RemixMenuTrigger(label: 'Options'),
+              items: [submenu],
+            ),
+            textDirection: direction,
+          );
+          menuController.open();
+          await tester.pump();
+          submenuController.open();
+          await tester.pump();
+          await tester.pump();
+
+          final triggerRect = tester.getRect(find.text('More'));
+          final childRect = tester.getRect(find.text('Archive'));
+          final placement = OverlayPlacement.of(
+            tester.element(find.text('Archive')),
+          );
+
+          expect(placement.side, expectedSide);
+          expect(placement.wasFlipped, isFalse);
+          if (expectedSide == OverlaySide.right) {
+            expect(childRect.left, greaterThan(triggerRect.right));
+          } else {
+            expect(childRect.right, lessThan(triggerRect.left));
+          }
+        }
+
+        await expectPlacement(
+          direction: TextDirection.ltr,
+          expectedSide: OverlaySide.right,
+        );
+        await expectPlacement(
+          direction: TextDirection.rtl,
+          expectedSide: OverlaySide.left,
+        );
+        await expectPlacement(
+          direction: TextDirection.rtl,
+          expectedSide: OverlaySide.right,
+          explicitRight: true,
+        );
+      },
+    );
+
     testWidgets('hover opens only after the configured 100 ms delay', (
       tester,
     ) async {
@@ -2072,36 +2147,43 @@ void main() {
       },
     );
 
-    testWidgets('raw and fluent indicator styles control the shared path', (
+    testWidgets('raw and fluent indicators stay size 13 at 200%', (
       tester,
     ) async {
       Future<Size> indicatorSize({required bool raw}) async {
         final controller = MenuController();
         await tester.pumpRemixApp(
-          RemixMenu<String>(
-            controller: controller,
-            trigger: const RemixMenuTrigger(label: 'Options'),
-            items: const [
-              RemixMenuCheckboxItem(
-                value: 'notifications',
-                label: 'Notifications',
-                checked: true,
-              ),
-            ],
-            style: raw
-                ? const MenuStyler.create()
-                : MenuStyler().item(
-                    MenuItemStyler().indicator(IconStyler().size(13)),
-                  ),
-            styleSpec: raw
-                ? const MenuSpec(
-                    item: StyleSpec(
-                      spec: MenuItemSpec(
-                        indicator: StyleSpec(spec: IconSpec(size: 13)),
+          MediaQuery(
+            data: const MediaQueryData(textScaler: TextScaler.linear(2)),
+            child: RemixMenu<String>(
+              controller: controller,
+              trigger: const RemixMenuTrigger(label: 'Options'),
+              items: const [
+                RemixMenuCheckboxItem(
+                  value: 'notifications',
+                  label: 'Notifications',
+                  checked: true,
+                ),
+              ],
+              style: raw
+                  ? const MenuStyler.create()
+                  : MenuStyler().item(
+                      MenuItemStyler().indicator(
+                        IconStyler().size(13).applyTextScaling(false),
                       ),
                     ),
-                  )
-                : null,
+              styleSpec: raw
+                  ? const MenuSpec(
+                      item: StyleSpec(
+                        spec: MenuItemSpec(
+                          indicator: StyleSpec(
+                            spec: IconSpec(size: 13, applyTextScaling: false),
+                          ),
+                        ),
+                      ),
+                    )
+                  : null,
+            ),
           ),
         );
         await tester.pump();
@@ -2113,6 +2195,14 @@ void main() {
         expect(
           tester.widget<RemixPathIcon>(indicator).glyph,
           RemixPathGlyph.thickCheck,
+        );
+        expect(
+          tester
+              .widget<RemixPathIcon>(indicator)
+              .styleSpec
+              .spec
+              .applyTextScaling,
+          isFalse,
         );
         return tester.getSize(indicator);
       }

--- a/packages/remix/test/components/menu/menu_widget_test.dart
+++ b/packages/remix/test/components/menu/menu_widget_test.dart
@@ -1,7 +1,12 @@
+import 'dart:ui' show CheckedState, SemanticsRole;
+
+import 'package:flutter/gestures.dart' show PointerDeviceKind;
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show LogicalKeyboardKey;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:naked_ui/naked_ui.dart';
 import 'package:remix/remix.dart';
+import 'package:remix/src/utilities/remix_path_icon.dart';
 
 import '../../helpers/test_helpers.dart';
 
@@ -525,6 +530,156 @@ void main() {
 
       expect(tester.widget<Text>(find.text('Copy')).style?.color, Colors.red);
     });
+
+    testWidgets(
+      'menu-wide semantic item styles merge after the shared item style '
+      'and before per-item styles',
+      (tester) async {
+        final style = MenuStyler()
+            .item(
+              MenuItemStyler().label(
+                TextStyler().color(Colors.red).fontSize(13),
+              ),
+            )
+            .checkboxItem(
+              MenuItemStyler().label(TextStyler().color(Colors.green)),
+            )
+            .radioItem(MenuItemStyler().label(TextStyler().color(Colors.blue)))
+            .submenuItem(
+              MenuItemStyler().label(TextStyler().color(Colors.orange)),
+            );
+
+        final controller = MenuController();
+        await tester.pumpRemixApp(
+          RemixMenu<String>(
+            controller: controller,
+            trigger: const RemixMenuTrigger(label: 'Options'),
+            style: style,
+            items: [
+              const RemixMenuItem(value: 'ordinary', label: 'Ordinary'),
+              const RemixMenuCheckboxItem(
+                value: 'checkbox',
+                label: 'Checkbox',
+                checked: true,
+              ),
+              RemixMenuRadioGroup(
+                value: 'default-radio',
+                onChanged: (_) {},
+                items: [
+                  const RemixMenuRadioItem(
+                    value: 'default-radio',
+                    label: 'Default radio',
+                  ),
+                  RemixMenuRadioItem(
+                    value: 'local-radio',
+                    label: 'Local radio',
+                    style: MenuItemStyler().label(
+                      TextStyler().color(Colors.purple),
+                    ),
+                  ),
+                ],
+              ),
+              const RemixMenuSubmenu(
+                label: 'Submenu',
+                items: [
+                  RemixMenuCheckboxItem(
+                    value: 'nested-checkbox',
+                    label: 'Nested checkbox',
+                    checked: true,
+                  ),
+                ],
+              ),
+            ],
+          ),
+        );
+        controller.open();
+        await tester.pump();
+
+        TextStyle? textStyle(String label) =>
+            tester.widget<Text>(find.text(label)).style;
+
+        expect(textStyle('Ordinary')?.color, Colors.red);
+        expect(textStyle('Checkbox')?.color, Colors.green);
+        expect(textStyle('Default radio')?.color, Colors.blue);
+        expect(textStyle('Local radio')?.color, Colors.purple);
+        expect(textStyle('Submenu')?.color, Colors.orange);
+        for (final label in [
+          'Ordinary',
+          'Checkbox',
+          'Default radio',
+          'Local radio',
+          'Submenu',
+        ]) {
+          expect(textStyle(label)?.fontSize, 13);
+        }
+
+        await tester.tap(find.text('Submenu'));
+        await tester.pump();
+        expect(textStyle('Nested checkbox')?.color, Colors.green);
+        expect(textStyle('Nested checkbox')?.fontSize, 13);
+      },
+    );
+
+    testWidgets(
+      'raw semantic item specs replace the raw shared item spec while null '
+      'semantic specs inherit it',
+      (tester) async {
+        final controller = MenuController();
+        await tester.pumpRemixApp(
+          RemixMenu<String>(
+            controller: controller,
+            trigger: const RemixMenuTrigger(label: 'Options'),
+            styleSpec: const MenuSpec(
+              item: StyleSpec(
+                spec: MenuItemSpec(
+                  label: StyleSpec(
+                    spec: TextSpec(
+                      style: TextStyle(color: Colors.red, fontSize: 13),
+                    ),
+                  ),
+                ),
+              ),
+              radioItem: StyleSpec(
+                spec: MenuItemSpec(
+                  label: StyleSpec(
+                    spec: TextSpec(style: TextStyle(color: Colors.blue)),
+                  ),
+                ),
+              ),
+            ),
+            items: [
+              const RemixMenuCheckboxItem(
+                value: 'checkbox',
+                label: 'Checkbox',
+                checked: true,
+              ),
+              RemixMenuRadioGroup(
+                value: 'radio',
+                onChanged: (_) {},
+                items: [
+                  RemixMenuRadioItem(
+                    value: 'radio',
+                    label: 'Radio',
+                    style: MenuItemStyler().label(
+                      TextStyler().color(Colors.purple).fontSize(20),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        );
+        controller.open();
+        await tester.pump();
+
+        final checkbox = tester.widget<Text>(find.text('Checkbox')).style;
+        final radio = tester.widget<Text>(find.text('Radio')).style;
+        expect(checkbox?.color, Colors.red);
+        expect(checkbox?.fontSize, 13);
+        expect(radio?.color, Colors.blue);
+        expect(radio?.fontSize, isNull);
+      },
+    );
   });
 
   group('RemixMenu Semantics and Accessibility', () {
@@ -735,6 +890,1475 @@ void main() {
       expect(selectedValue, equals(MenuAction.copy));
     });
   });
+
+  group('RemixMenu compound data contract', () {
+    test('constructors retain the complete immutable public surface', () {
+      final checkboxChanged = <bool>[];
+      final radioChanged = <String>[];
+      final submenuController = MenuController();
+      final submenuFocusNode = FocusNode();
+      addTearDown(submenuFocusNode.dispose);
+
+      final checkbox = RemixMenuCheckboxItem<String>(
+        value: 'notifications',
+        label: 'Notifications',
+        checked: true,
+        onChanged: checkboxChanged.add,
+        leadingIcon: Icons.notifications,
+        trailingIcon: Icons.keyboard_command_key,
+        enabled: false,
+        closeOnActivate: false,
+        semanticLabel: 'Toggle notifications',
+        style: MenuItemStyler().label(TextStyler().color(Colors.purple)),
+      );
+      final radioItem = RemixMenuRadioItem<String>(
+        value: 'compact',
+        label: 'Compact',
+        leadingIcon: Icons.view_compact,
+        trailingIcon: Icons.keyboard_command_key,
+        enabled: false,
+        closeOnActivate: false,
+        semanticLabel: 'Compact density',
+        style: MenuItemStyler().label(TextStyler().color(Colors.blue)),
+      );
+      final radioGroup = RemixMenuRadioGroup<String>(
+        value: 'compact',
+        items: [radioItem],
+        onChanged: radioChanged.add,
+        enabled: false,
+      );
+      final submenu = RemixMenuSubmenu<String>(
+        label: 'More',
+        items: const [RemixMenuItem(value: 'archive', label: 'Archive')],
+        leadingIcon: Icons.more_horiz,
+        trailingIcon: Icons.chevron_right,
+        controller: submenuController,
+        enabled: false,
+        hoverDelay: const Duration(milliseconds: 250),
+        positioning: const OverlayPositionConfig(
+          side: OverlaySide.left,
+          alignment: OverlayAlignment.end,
+          sideOffset: 8,
+        ),
+        focusNode: submenuFocusNode,
+        semanticLabel: 'More actions',
+        onOpen: () {},
+        onClose: () {},
+        style: MenuItemStyler().label(TextStyler().color(Colors.green)),
+      );
+
+      expect(checkbox.value, 'notifications');
+      expect(checkbox.checked, isTrue);
+      expect(checkbox.onChanged, isNotNull);
+      expect(checkbox.leadingIcon, Icons.notifications);
+      expect(checkbox.trailingIcon, Icons.keyboard_command_key);
+      expect(checkbox.enabled, isFalse);
+      expect(checkbox.closeOnActivate, isFalse);
+      expect(checkbox.semanticLabel, 'Toggle notifications');
+      expect(checkbox, isA<RemixMenuItemData<String>>());
+      expect(radioItem.value, 'compact');
+      expect(radioItem.enabled, isFalse);
+      expect(radioItem.closeOnActivate, isFalse);
+      expect(radioGroup.value, 'compact');
+      expect(radioGroup.items, [same(radioItem)]);
+      expect(radioGroup.onChanged, isNotNull);
+      expect(radioGroup.enabled, isFalse);
+      expect(radioGroup, isA<RemixMenuItemData<String>>());
+      expect(submenu.label, 'More');
+      expect(submenu.items.single, isA<RemixMenuItem<String>>());
+      expect(submenu.controller, same(submenuController));
+      expect(submenu.hoverDelay, const Duration(milliseconds: 250));
+      expect(submenu.positioning.side, OverlaySide.left);
+      expect(submenu.focusNode, same(submenuFocusNode));
+      expect(submenu, isA<RemixMenuItemData<String>>());
+    });
+
+    test('compound labels and semantic labels must not be empty', () {
+      expect(
+        () => RemixMenuCheckboxItem<String>(
+          value: 'checkbox',
+          label: '',
+          checked: false,
+        ),
+        throwsAssertionError,
+      );
+      expect(
+        () => RemixMenuRadioItem<String>(value: 'radio', label: ''),
+        throwsAssertionError,
+      );
+      expect(
+        () => RemixMenuSubmenu<String>(label: '', items: const []),
+        throwsAssertionError,
+      );
+      expect(
+        () => RemixMenuCheckboxItem<String>(
+          value: 'checkbox',
+          label: 'Checkbox',
+          checked: false,
+          semanticLabel: '',
+        ),
+        throwsAssertionError,
+      );
+      expect(
+        () => RemixMenuRadioGroup<String?>(value: null, items: const []),
+        throwsAssertionError,
+      );
+    });
+
+    testWidgets('radio groups reject duplicate or missing controlled values', (
+      tester,
+    ) async {
+      Future<Object?> openAndTakeException(
+        RemixMenuRadioGroup<String> group,
+      ) async {
+        final controller = MenuController();
+        await tester.pumpRemixApp(
+          RemixMenu<String>(
+            controller: controller,
+            trigger: const RemixMenuTrigger(label: 'Options'),
+            items: [group],
+          ),
+        );
+        controller.open();
+        await tester.pump();
+        final exception = tester.takeException();
+        await tester.pumpWidget(const SizedBox.shrink());
+        await tester.pump();
+        return exception;
+      }
+
+      expect(
+        await openAndTakeException(
+          const RemixMenuRadioGroup(
+            value: 'missing',
+            items: [RemixMenuRadioItem(value: 'present', label: 'Present')],
+          ),
+        ),
+        isA<AssertionError>(),
+      );
+      expect(
+        await openAndTakeException(
+          const RemixMenuRadioGroup(
+            value: 'duplicate',
+            items: [
+              RemixMenuRadioItem(value: 'duplicate', label: 'First'),
+              RemixMenuRadioItem(value: 'duplicate', label: 'Second'),
+            ],
+          ),
+        ),
+        isA<AssertionError>(),
+      );
+    });
+  });
+
+  group('RemixMenu checkbox items', () {
+    testWidgets('exposes role, checked state, callback order, and rebuild', (
+      tester,
+    ) async {
+      final semantics = tester.ensureSemantics();
+      var checked = false;
+      final calls = <String>[];
+
+      await tester.pumpRemixApp(
+        StatefulBuilder(
+          builder: (context, setState) => RemixMenu<String>(
+            trigger: const RemixMenuTrigger(label: 'Options'),
+            onSelected: (value) => calls.add('root:$value'),
+            items: [
+              RemixMenuCheckboxItem(
+                value: 'notifications',
+                label: 'Notifications',
+                checked: checked,
+                closeOnActivate: false,
+                onChanged: (value) {
+                  calls.add('item:$value');
+                  setState(() => checked = value);
+                },
+              ),
+            ],
+          ),
+        ),
+      );
+      await tester.tap(find.text('Options'));
+      await tester.pump();
+
+      var data = tester
+          .getSemantics(find.text('Notifications'))
+          .getSemanticsData();
+      expect(data.role, SemanticsRole.menuItemCheckbox);
+      expect(data.flagsCollection.isChecked, CheckedState.isFalse);
+
+      await tester.tap(find.text('Notifications'));
+      await tester.pump();
+
+      expect(calls, ['root:notifications', 'item:true']);
+      expect(checked, isTrue);
+      data = tester.getSemantics(find.text('Notifications')).getSemanticsData();
+      expect(data.flagsCollection.isChecked, CheckedState.isTrue);
+      expect(find.text('Notifications'), findsOneWidget);
+      semantics.dispose();
+    });
+
+    testWidgets('supports root-only and item-only callbacks', (tester) async {
+      final calls = <String>[];
+      final rootOnlyController = MenuController();
+      await tester.pumpRemixApp(
+        RemixMenu<String>(
+          controller: rootOnlyController,
+          trigger: const RemixMenuTrigger(label: 'Options'),
+          onSelected: (value) => calls.add('root:$value'),
+          items: const [
+            RemixMenuCheckboxItem(
+              value: 'root',
+              label: 'Root only',
+              checked: false,
+              closeOnActivate: false,
+            ),
+          ],
+        ),
+      );
+      rootOnlyController.open();
+      await tester.pump();
+      await tester.tap(find.text('Root only'));
+      await tester.pump();
+      expect(calls, ['root:root']);
+
+      final itemOnlyController = MenuController();
+      await tester.pumpRemixApp(
+        RemixMenu<String>(
+          controller: itemOnlyController,
+          trigger: const RemixMenuTrigger(label: 'Options'),
+          items: [
+            RemixMenuCheckboxItem(
+              value: 'item',
+              label: 'Item only',
+              checked: false,
+              closeOnActivate: false,
+              onChanged: (value) => calls.add('item:$value'),
+            ),
+          ],
+        ),
+      );
+      await tester.pump();
+      itemOnlyController.open();
+      await tester.pump();
+      await tester.tap(find.text('Item only'));
+      await tester.pump();
+      expect(calls, ['root:root', 'item:true']);
+    });
+
+    testWidgets('both-null and explicitly disabled items suppress activation', (
+      tester,
+    ) async {
+      final calls = <String>[];
+      final neitherController = MenuController();
+      await tester.pumpRemixApp(
+        RemixMenu<String>(
+          controller: neitherController,
+          trigger: const RemixMenuTrigger(label: 'Options'),
+          items: const [
+            RemixMenuCheckboxItem(
+              value: 'neither',
+              label: 'Neither callback',
+              checked: false,
+            ),
+          ],
+        ),
+      );
+      await tester.pump();
+      neitherController.open();
+      await tester.pump();
+      final neitherControllerState = NakedMenuItemState.controllerOf<String>(
+        tester.element(find.text('Neither callback')),
+      );
+      expect(neitherControllerState.value, contains(WidgetState.disabled));
+      await tester.tap(find.text('Neither callback'));
+      await tester.pump();
+      expect(find.text('Neither callback'), findsOneWidget);
+
+      final disabledController = MenuController();
+      await tester.pumpRemixApp(
+        RemixMenu<String>(
+          controller: disabledController,
+          trigger: const RemixMenuTrigger(label: 'Options'),
+          onSelected: calls.add,
+          items: [
+            RemixMenuCheckboxItem(
+              value: 'disabled',
+              label: 'Explicitly disabled',
+              checked: false,
+              enabled: false,
+              onChanged: (value) => calls.add('changed:$value'),
+            ),
+          ],
+        ),
+      );
+      await tester.pump();
+      disabledController.open();
+      await tester.pump();
+      await tester.tap(find.text('Explicitly disabled'));
+      await tester.pump();
+      expect(calls, isEmpty);
+    });
+  });
+
+  group('RemixMenu radio groups', () {
+    testWidgets('exposes exclusive roles and updates controlled selection', (
+      tester,
+    ) async {
+      final semantics = tester.ensureSemantics();
+      var value = 'compact';
+      final calls = <String>[];
+
+      await tester.pumpRemixApp(
+        StatefulBuilder(
+          builder: (context, setState) => RemixMenu<String>(
+            trigger: const RemixMenuTrigger(label: 'Options'),
+            onSelected: (next) => calls.add('root:$next'),
+            items: [
+              RemixMenuRadioGroup(
+                value: value,
+                onChanged: (next) {
+                  calls.add('group:$next');
+                  setState(() => value = next);
+                },
+                items: const [
+                  RemixMenuRadioItem(
+                    value: 'compact',
+                    label: 'Compact',
+                    closeOnActivate: false,
+                  ),
+                  RemixMenuRadioItem(
+                    value: 'comfortable',
+                    label: 'Comfortable',
+                    closeOnActivate: false,
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      );
+      await tester.tap(find.text('Options'));
+      await tester.pump();
+
+      final selected = tester
+          .getSemantics(find.text('Compact'))
+          .getSemanticsData();
+      final unselected = tester
+          .getSemantics(find.text('Comfortable'))
+          .getSemanticsData();
+      expect(selected.role, SemanticsRole.menuItemRadio);
+      expect(selected.flagsCollection.isChecked, CheckedState.isTrue);
+      expect(selected.flagsCollection.isInMutuallyExclusiveGroup, isTrue);
+      expect(unselected.role, SemanticsRole.menuItemRadio);
+      expect(unselected.flagsCollection.isChecked, CheckedState.isFalse);
+      expect(unselected.flagsCollection.isInMutuallyExclusiveGroup, isTrue);
+
+      await tester.tap(find.text('Comfortable'));
+      await tester.pump();
+      expect(value, 'comfortable');
+      expect(calls, ['root:comfortable', 'group:comfortable']);
+      expect(
+        tester
+            .getSemantics(find.text('Comfortable'))
+            .getSemanticsData()
+            .flagsCollection
+            .isChecked,
+        CheckedState.isTrue,
+      );
+      semantics.dispose();
+    });
+
+    testWidgets('re-emits the selected value through root then group', (
+      tester,
+    ) async {
+      final calls = <String>[];
+      await tester.pumpRemixApp(
+        RemixMenu<String>(
+          trigger: const RemixMenuTrigger(label: 'Options'),
+          onSelected: (value) => calls.add('root:$value'),
+          items: [
+            RemixMenuRadioGroup(
+              value: 'compact',
+              onChanged: (value) => calls.add('group:$value'),
+              items: const [
+                RemixMenuRadioItem(
+                  value: 'compact',
+                  label: 'Compact',
+                  closeOnActivate: false,
+                ),
+              ],
+            ),
+          ],
+        ),
+      );
+      await tester.tap(find.text('Options'));
+      await tester.pump();
+      await tester.tap(find.text('Compact'));
+      await tester.pump();
+
+      expect(calls, ['root:compact', 'group:compact']);
+    });
+
+    testWidgets('supports root-only and group-only callbacks', (tester) async {
+      final calls = <String>[];
+      final rootOnlyController = MenuController();
+      await tester.pumpRemixApp(
+        RemixMenu<String>(
+          controller: rootOnlyController,
+          trigger: const RemixMenuTrigger(label: 'Options'),
+          onSelected: (value) => calls.add('root:$value'),
+          items: const [
+            RemixMenuRadioGroup(
+              value: 'root',
+              items: [
+                RemixMenuRadioItem(
+                  value: 'root',
+                  label: 'Root only',
+                  closeOnActivate: false,
+                ),
+              ],
+            ),
+          ],
+        ),
+      );
+      rootOnlyController.open();
+      await tester.pump();
+      await tester.tap(find.text('Root only'));
+      await tester.pump();
+      expect(calls, ['root:root']);
+
+      final groupOnlyController = MenuController();
+      await tester.pumpRemixApp(
+        RemixMenu<String>(
+          controller: groupOnlyController,
+          trigger: const RemixMenuTrigger(label: 'Options'),
+          items: [
+            RemixMenuRadioGroup(
+              value: 'group',
+              onChanged: (value) => calls.add('group:$value'),
+              items: const [
+                RemixMenuRadioItem(
+                  value: 'group',
+                  label: 'Group only',
+                  closeOnActivate: false,
+                ),
+              ],
+            ),
+          ],
+        ),
+      );
+      await tester.pump();
+      groupOnlyController.open();
+      await tester.pump();
+      await tester.tap(find.text('Group only'));
+      await tester.pump();
+      expect(calls, ['root:root', 'group:group']);
+    });
+
+    testWidgets('both-null radio callbacks disable activation', (tester) async {
+      final controller = MenuController();
+      await tester.pumpRemixApp(
+        RemixMenu<String>(
+          controller: controller,
+          trigger: const RemixMenuTrigger(label: 'Options'),
+          items: const [
+            RemixMenuRadioGroup(
+              value: 'neither',
+              items: [
+                RemixMenuRadioItem(value: 'neither', label: 'Neither callback'),
+              ],
+            ),
+          ],
+        ),
+      );
+      controller.open();
+      await tester.pump();
+
+      final itemController = NakedMenuItemState.controllerOf<String>(
+        tester.element(find.text('Neither callback')),
+      );
+      expect(itemController.value, contains(WidgetState.disabled));
+      await tester.tap(find.text('Neither callback'));
+      await tester.pump();
+      expect(find.text('Neither callback'), findsOneWidget);
+    });
+
+    testWidgets('group and item disabled states suppress radio callbacks', (
+      tester,
+    ) async {
+      final calls = <String>[];
+      await tester.pumpRemixApp(
+        RemixMenu<String>(
+          trigger: const RemixMenuTrigger(label: 'Options'),
+          onSelected: calls.add,
+          items: [
+            RemixMenuRadioGroup(
+              value: 'selected',
+              enabled: false,
+              onChanged: calls.add,
+              items: const [
+                RemixMenuRadioItem(value: 'selected', label: 'Group disabled'),
+              ],
+            ),
+            RemixMenuRadioGroup(
+              value: 'selected',
+              onChanged: calls.add,
+              items: const [
+                RemixMenuRadioItem(
+                  value: 'selected',
+                  label: 'Item disabled',
+                  enabled: false,
+                ),
+              ],
+            ),
+          ],
+        ),
+      );
+      await tester.tap(find.text('Options'));
+      await tester.pump();
+      await tester.tap(find.text('Group disabled'));
+      await tester.tap(find.text('Item disabled'));
+      await tester.pump();
+
+      expect(calls, isEmpty);
+    });
+  });
+
+  group('RemixMenu submenus', () {
+    testWidgets('hover opens only after the configured 100 ms delay', (
+      tester,
+    ) async {
+      await tester.pumpRemixApp(
+        const RemixMenu<String>(
+          trigger: RemixMenuTrigger(label: 'Options'),
+          items: [
+            RemixMenuSubmenu(
+              label: 'More',
+              items: [RemixMenuItem(value: 'archive', label: 'Archive')],
+            ),
+          ],
+        ),
+      );
+      await tester.tap(find.text('Options'));
+      await tester.pump();
+      final mouse = await tester.createGesture(kind: PointerDeviceKind.mouse);
+      await mouse.addPointer(location: Offset.zero);
+      addTearDown(mouse.removePointer);
+      await mouse.moveTo(tester.getCenter(find.text('More')));
+
+      await tester.pump(const Duration(milliseconds: 99));
+      expect(find.text('Archive'), findsNothing);
+      await tester.pump(const Duration(milliseconds: 1));
+      await tester.pump();
+      expect(find.text('Archive'), findsOneWidget);
+    });
+
+    testWidgets('directional arrows and Escape restore submenu focus', (
+      tester,
+    ) async {
+      for (final direction in TextDirection.values) {
+        final focusNode = FocusNode();
+        final controller = MenuController();
+        await tester.pumpRemixApp(
+          RemixMenu<String>(
+            controller: controller,
+            trigger: const RemixMenuTrigger(label: 'Options'),
+            items: [
+              RemixMenuSubmenu(
+                label: 'More',
+                focusNode: focusNode,
+                items: const [
+                  RemixMenuItem(value: 'archive', label: 'Archive'),
+                ],
+              ),
+            ],
+          ),
+          textDirection: direction,
+        );
+        await tester.pump();
+        controller.open();
+        await tester.pump();
+        focusNode.requestFocus();
+        await tester.pump();
+
+        await tester.sendKeyEvent(
+          direction == TextDirection.ltr
+              ? LogicalKeyboardKey.arrowRight
+              : LogicalKeyboardKey.arrowLeft,
+        );
+        await tester.pump();
+        await tester.pump();
+        expect(find.text('Archive'), findsOneWidget);
+        expect(Focus.of(tester.element(find.text('Archive'))).hasFocus, isTrue);
+
+        await tester.sendKeyEvent(
+          direction == TextDirection.ltr
+              ? LogicalKeyboardKey.arrowLeft
+              : LogicalKeyboardKey.arrowRight,
+        );
+        await tester.pump();
+        await tester.pump();
+        expect(find.text('Archive'), findsNothing);
+        expect(focusNode.hasFocus, isTrue);
+
+        await tester.sendKeyEvent(
+          direction == TextDirection.ltr
+              ? LogicalKeyboardKey.arrowRight
+              : LogicalKeyboardKey.arrowLeft,
+        );
+        await tester.pump();
+        await tester.pump();
+        expect(find.text('Archive'), findsOneWidget);
+
+        await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+        await tester.pump();
+        await tester.pump();
+        expect(find.text('Archive'), findsNothing);
+        expect(focusNode.hasFocus, isTrue);
+        focusNode.dispose();
+      }
+    });
+
+    testWidgets('controller callbacks, disabled trigger, and recursive close', (
+      tester,
+    ) async {
+      final submenuController = MenuController();
+      final calls = <String>[];
+      await tester.pumpRemixApp(
+        RemixMenu<String>(
+          trigger: const RemixMenuTrigger(label: 'Options'),
+          onSelected: (value) => calls.add('selected:$value'),
+          items: [
+            RemixMenuSubmenu(
+              label: 'Disabled',
+              enabled: false,
+              items: const [RemixMenuItem(value: 'hidden', label: 'Hidden')],
+            ),
+            RemixMenuSubmenu(
+              label: 'More',
+              controller: submenuController,
+              onOpen: () => calls.add('open'),
+              onClose: () => calls.add('close'),
+              items: const [
+                RemixMenuSubmenu(
+                  label: 'Even more',
+                  items: [RemixMenuItem(value: 'archive', label: 'Archive')],
+                ),
+              ],
+            ),
+          ],
+        ),
+      );
+      await tester.tap(find.text('Options'));
+      await tester.pump();
+      await tester.tap(find.text('Disabled'));
+      await tester.pump();
+      expect(find.text('Hidden'), findsNothing);
+
+      await tester.tap(find.text('More'));
+      await tester.pump();
+      expect(calls, contains('open'));
+      await tester.tap(find.text('Even more'));
+      await tester.pump();
+      await tester.tap(find.text('Archive'));
+      await tester.pump();
+      await tester.pump();
+      expect(calls, containsAllInOrder(['open', 'selected:archive', 'close']));
+      expect(find.text('More'), findsNothing);
+    });
+
+    testWidgets('caller-owned focus nodes remain usable after unmount', (
+      tester,
+    ) async {
+      final focusNode = FocusNode();
+      addTearDown(focusNode.dispose);
+      await tester.pumpRemixApp(
+        RemixMenu<String>(
+          trigger: const RemixMenuTrigger(label: 'Options'),
+          items: [
+            RemixMenuSubmenu(
+              label: 'More',
+              focusNode: focusNode,
+              items: const [RemixMenuItem(value: 'archive', label: 'Archive')],
+            ),
+          ],
+        ),
+      );
+      await tester.tap(find.text('Options'));
+      await tester.pump();
+      await tester.pumpWidget(const SizedBox.shrink());
+
+      expect(() => focusNode.requestFocus(), returnsNormally);
+    });
+  });
+
+  group('RemixMenu compound rendering', () {
+    testWidgets('vertical item styles remain shrink-wrapped and layout-safe', (
+      tester,
+    ) async {
+      final controller = MenuController();
+      await tester.pumpRemixApp(
+        RemixMenu<String>(
+          controller: controller,
+          trigger: const RemixMenuTrigger(label: 'Options'),
+          style: MenuStyler().item(
+            MenuItemStyler().direction(.vertical).mainAxisSize(.min),
+          ),
+          items: const [
+            RemixMenuItem(
+              value: 'vertical',
+              label: 'Vertical item',
+              trailingIcon: Icons.keyboard_command_key,
+            ),
+          ],
+        ),
+      );
+
+      controller.open();
+      await tester.pump();
+
+      expect(tester.takeException(), isNull);
+      expect(find.text('Vertical item'), findsOneWidget);
+    });
+
+    testWidgets('overlay spacing applies between adjacent radio rows', (
+      tester,
+    ) async {
+      final controller = MenuController();
+      await tester.pumpRemixApp(
+        RemixMenu<String>(
+          controller: controller,
+          trigger: const RemixMenuTrigger(label: 'Options'),
+          style: MenuStyler().overlay(FlexBoxStyler().spacing(12)),
+          onSelected: (_) {},
+          items: const [
+            RemixMenuRadioGroup(
+              value: 'first',
+              items: [
+                RemixMenuRadioItem(value: 'first', label: 'First radio'),
+                RemixMenuRadioItem(value: 'second', label: 'Second radio'),
+              ],
+            ),
+          ],
+        ),
+      );
+
+      controller.open();
+      await tester.pump();
+
+      Finder rowFor(String label) => find
+          .ancestor(of: find.text(label), matching: find.byType(FlexBox))
+          .first;
+      final first = tester.getRect(rowFor('First radio'));
+      final second = tester.getRect(rowFor('Second radio'));
+
+      expect(second.top - first.bottom, 12);
+    });
+
+    testWidgets('overlay vertical direction applies within radio groups', (
+      tester,
+    ) async {
+      final controller = MenuController();
+      await tester.pumpRemixApp(
+        RemixMenu<String>(
+          controller: controller,
+          trigger: const RemixMenuTrigger(label: 'Options'),
+          style: MenuStyler().overlay(FlexBoxStyler().verticalDirection(.up)),
+          onSelected: (_) {},
+          items: const [
+            RemixMenuRadioGroup(
+              value: 'first',
+              items: [
+                RemixMenuRadioItem(value: 'first', label: 'First radio'),
+                RemixMenuRadioItem(value: 'second', label: 'Second radio'),
+              ],
+            ),
+          ],
+        ),
+      );
+
+      controller.open();
+      await tester.pump();
+
+      final first = tester.getTopLeft(find.text('First radio'));
+      final second = tester.getTopLeft(find.text('Second radio'));
+
+      expect(second.dy, lessThan(first.dy));
+    });
+
+    testWidgets(
+      'radio wrapper preserves neighboring item and divider geometry',
+      (tester) async {
+        await tester.pumpRemixApp(
+          const RemixMenu<String>(
+            trigger: RemixMenuTrigger(label: 'Options'),
+            items: [
+              RemixMenuItem(value: 'before', label: 'Before'),
+              RemixMenuDivider(),
+              RemixMenuRadioGroup(
+                value: 'radio',
+                items: [RemixMenuRadioItem(value: 'radio', label: 'Radio')],
+              ),
+              RemixMenuDivider(),
+              RemixMenuItem(value: 'after', label: 'After'),
+            ],
+          ),
+        );
+        await tester.tap(find.text('Options'));
+        await tester.pump();
+
+        final beforeRow = find
+            .ancestor(of: find.text('Before'), matching: find.byType(FlexBox))
+            .first;
+        final radioRow = find
+            .ancestor(of: find.text('Radio'), matching: find.byType(FlexBox))
+            .first;
+        final afterRow = find
+            .ancestor(of: find.text('After'), matching: find.byType(FlexBox))
+            .first;
+        expect(
+          tester.getSize(beforeRow).height,
+          tester.getSize(radioRow).height,
+        );
+        expect(
+          tester.getSize(afterRow).height,
+          tester.getSize(radioRow).height,
+        );
+        expect(find.byType(RemixDivider), findsNWidgets(2));
+      },
+    );
+
+    testWidgets('a mixed panel reserves one common choice slot', (
+      tester,
+    ) async {
+      Future<double> ordinaryLabelX(
+        List<RemixMenuItemData<String>> items,
+      ) async {
+        final controller = MenuController();
+        await tester.pumpRemixApp(
+          RemixMenu<String>(
+            controller: controller,
+            trigger: const RemixMenuTrigger(label: 'Options'),
+            items: items,
+          ),
+        );
+        await tester.pump();
+        controller.open();
+        await tester.pump();
+        return tester.getTopLeft(find.text('Ordinary')).dx;
+      }
+
+      final ordinaryOnlyX = await ordinaryLabelX(const [
+        RemixMenuItem(value: 'ordinary', label: 'Ordinary'),
+      ]);
+      final mixedOrdinaryX = await ordinaryLabelX(const [
+        RemixMenuItem(value: 'ordinary', label: 'Ordinary'),
+        RemixMenuCheckboxItem(
+          value: 'checkbox',
+          label: 'Checkbox',
+          checked: true,
+        ),
+      ]);
+      final checkboxX = tester.getTopLeft(find.text('Checkbox')).dx;
+
+      expect(mixedOrdinaryX, greaterThan(ordinaryOnlyX));
+      expect(checkboxX, mixedOrdinaryX);
+    });
+
+    testWidgets('nested panels decide choice slots independently', (
+      tester,
+    ) async {
+      await tester.pumpRemixApp(
+        const RemixMenu<String>(
+          trigger: RemixMenuTrigger(label: 'Options'),
+          items: [
+            RemixMenuCheckboxItem(
+              value: 'checkbox',
+              label: 'Checkbox',
+              checked: true,
+            ),
+            RemixMenuSubmenu(
+              label: 'More',
+              items: [RemixMenuItem(value: 'ordinary', label: 'Nested')],
+            ),
+          ],
+        ),
+      );
+      await tester.tap(find.text('Options'));
+      await tester.pump();
+      await tester.tap(find.text('More'));
+      await tester.pump();
+
+      final rootRow = tester.widget<FlexBox>(
+        find
+            .ancestor(of: find.text('More'), matching: find.byType(FlexBox))
+            .first,
+      );
+      final nestedRow = tester.widget<FlexBox>(
+        find
+            .ancestor(of: find.text('Nested'), matching: find.byType(FlexBox))
+            .first,
+      );
+      expect(rootRow.children.first, isA<SizedBox>());
+      expect(nestedRow.children.first, isA<Expanded>());
+    });
+
+    testWidgets('raw and fluent indicator styles control the shared path', (
+      tester,
+    ) async {
+      Future<Size> indicatorSize({required bool raw}) async {
+        final controller = MenuController();
+        await tester.pumpRemixApp(
+          RemixMenu<String>(
+            controller: controller,
+            trigger: const RemixMenuTrigger(label: 'Options'),
+            items: const [
+              RemixMenuCheckboxItem(
+                value: 'notifications',
+                label: 'Notifications',
+                checked: true,
+              ),
+            ],
+            style: raw
+                ? const MenuStyler.create()
+                : MenuStyler().item(
+                    MenuItemStyler().indicator(IconStyler().size(13)),
+                  ),
+            styleSpec: raw
+                ? const MenuSpec(
+                    item: StyleSpec(
+                      spec: MenuItemSpec(
+                        indicator: StyleSpec(spec: IconSpec(size: 13)),
+                      ),
+                    ),
+                  )
+                : null,
+          ),
+        );
+        await tester.pump();
+        controller.open();
+        await tester.pump();
+        final indicator = find.byKey(
+          const ValueKey('remix-menu-indicator-Notifications'),
+        );
+        expect(
+          tester.widget<RemixPathIcon>(indicator).glyph,
+          RemixPathGlyph.thickCheck,
+        );
+        return tester.getSize(indicator);
+      }
+
+      expect(await indicatorSize(raw: false), const Size.square(13));
+      expect(await indicatorSize(raw: true), const Size.square(13));
+    });
+
+    testWidgets('checked and radio indicators inherit item widget states', (
+      tester,
+    ) async {
+      final hovered = MenuItemStyler().indicator(IconStyler().size(17));
+      final itemStyle = MenuItemStyler()
+          .indicator(IconStyler().size(9))
+          .onHovered(hovered);
+      await tester.pumpRemixApp(
+        RemixMenu<String>(
+          trigger: const RemixMenuTrigger(label: 'Options'),
+          onSelected: (_) {},
+          style: MenuStyler().checkboxItem(itemStyle).radioItem(itemStyle),
+          items: const [
+            RemixMenuCheckboxItem(
+              value: 'notifications',
+              label: 'Notifications',
+              checked: true,
+              closeOnActivate: false,
+            ),
+            RemixMenuRadioGroup(
+              value: 'compact',
+              items: [
+                RemixMenuRadioItem(
+                  value: 'compact',
+                  label: 'Compact',
+                  closeOnActivate: false,
+                ),
+              ],
+            ),
+          ],
+        ),
+      );
+      await tester.tap(find.text('Options'));
+      await tester.pump();
+      final checkboxIndicator = find.byKey(
+        const ValueKey('remix-menu-indicator-Notifications'),
+      );
+      final radioIndicator = find.byKey(
+        const ValueKey('remix-menu-indicator-Compact'),
+      );
+      expect(tester.getSize(checkboxIndicator), const Size.square(9));
+      expect(tester.getSize(radioIndicator), const Size.square(9));
+
+      final mouse = await tester.createGesture(kind: PointerDeviceKind.mouse);
+      await mouse.addPointer(location: Offset.zero);
+      addTearDown(mouse.removePointer);
+      await mouse.moveTo(tester.getCenter(find.text('Notifications')));
+      await tester.pump();
+      await tester.pump();
+      expect(
+        WidgetStateProvider.of(tester.element(checkboxIndicator))?.hovered,
+        isTrue,
+      );
+      expect(tester.getSize(checkboxIndicator), const Size.square(17));
+      await mouse.moveTo(tester.getCenter(find.text('Compact')));
+      await tester.pump();
+      await tester.pump();
+      expect(tester.getSize(radioIndicator), const Size.square(17));
+    });
+
+    testWidgets('trailing slots align to the directional panel end', (
+      tester,
+    ) async {
+      for (final direction in TextDirection.values) {
+        final controller = MenuController();
+        await tester.pumpRemixApp(
+          RemixMenu<String>(
+            controller: controller,
+            trigger: const RemixMenuTrigger(label: 'Options'),
+            style: MenuStyler().item(
+              MenuItemStyler()
+                  .direction(.horizontal)
+                  .mainAxisSize(.max)
+                  .width(220)
+                  .spacing(12),
+            ),
+            items: const [
+              RemixMenuItem(
+                value: 'short',
+                label: 'Short',
+                trailingIcon: Icons.keyboard_command_key,
+              ),
+              RemixMenuItem(
+                value: 'long',
+                label: 'A much longer label',
+                trailingIcon: Icons.keyboard_command_key,
+              ),
+            ],
+          ),
+          textDirection: direction,
+        );
+        await tester.pump();
+        controller.open();
+        await tester.pump();
+        final icons = find.byIcon(Icons.keyboard_command_key);
+        final first = tester.getRect(icons.at(0));
+        final second = tester.getRect(icons.at(1));
+        if (direction == TextDirection.ltr) {
+          expect(first.right, second.right);
+          expect(
+            first.left - tester.getRect(find.text('Short')).right,
+            greaterThanOrEqualTo(12),
+          );
+        } else {
+          expect(first.left, second.left);
+          expect(
+            tester.getRect(find.text('Short')).left - first.right,
+            greaterThanOrEqualTo(12),
+          );
+        }
+      }
+    });
+
+    testWidgets(
+      'default submenu path is directional and custom trailing replaces it',
+      (tester) async {
+        for (final direction in TextDirection.values) {
+          final controller = MenuController();
+          await tester.pumpRemixApp(
+            RemixMenu<String>(
+              controller: controller,
+              trigger: const RemixMenuTrigger(label: 'Options'),
+              items: const [
+                RemixMenuSubmenu(
+                  label: 'Default',
+                  items: [RemixMenuItem(value: 'child', label: 'Child')],
+                ),
+                RemixMenuSubmenu(
+                  label: 'Custom',
+                  trailingIcon: Icons.star,
+                  items: [RemixMenuItem(value: 'other', label: 'Other')],
+                ),
+              ],
+            ),
+            textDirection: direction,
+          );
+          await tester.pump();
+          controller.open();
+          await tester.pump();
+
+          expect(
+            find.byKey(const ValueKey('remix-menu-submenu-chevron-Default')),
+            findsOneWidget,
+          );
+          final chevron = tester.widget<RemixPathIcon>(
+            find.byKey(const ValueKey('remix-menu-submenu-chevron-Default')),
+          );
+          expect(chevron.glyph, RemixPathGlyph.thickChevronRight);
+          expect(chevron.matchTextDirection, isTrue);
+          expect(
+            find.byKey(const ValueKey('remix-menu-submenu-chevron-Custom')),
+            findsNothing,
+          );
+          expect(find.byIcon(Icons.star), findsOneWidget);
+        }
+      },
+    );
+
+    testWidgets('open submenus resolve existing selected-state recipes', (
+      tester,
+    ) async {
+      final itemStyle = MenuItemStyler()
+          .label(TextStyler().color(Colors.red))
+          .onSelected(MenuItemStyler().label(TextStyler().color(Colors.green)));
+      await tester.pumpRemixApp(
+        RemixMenu<String>(
+          trigger: const RemixMenuTrigger(label: 'Options'),
+          style: MenuStyler().item(itemStyle),
+          items: const [
+            RemixMenuSubmenu(
+              label: 'More',
+              items: [RemixMenuItem(value: 'archive', label: 'Archive')],
+            ),
+          ],
+        ),
+      );
+      await tester.tap(find.text('Options'));
+      await tester.pump();
+      expect(tester.widget<Text>(find.text('More')).style?.color, Colors.red);
+      await tester.tap(find.text('More'));
+      await tester.pump();
+      expect(tester.widget<Text>(find.text('More')).style?.color, Colors.green);
+    });
+
+    for (final variant in FortalMenuVariant.values) {
+      testWidgets(
+        '${variant.name} distinguishes checked, highlighted, and submenu-open surfaces',
+        (tester) async {
+          final menuController = MenuController();
+          final submenuController = MenuController();
+          await tester.pumpRemixApp(
+            FortalMenu<String>(
+              variant: variant,
+              controller: menuController,
+              trigger: const RemixMenuTrigger(label: 'Options'),
+              onSelected: (_) {},
+              items: [
+                const RemixMenuCheckboxItem(
+                  value: 'checked',
+                  label: 'Checked',
+                  checked: true,
+                  closeOnActivate: false,
+                ),
+                const RemixMenuRadioGroup(
+                  value: 'compact',
+                  items: [
+                    RemixMenuRadioItem(
+                      value: 'compact',
+                      label: 'Compact',
+                      closeOnActivate: false,
+                    ),
+                    RemixMenuRadioItem(
+                      value: 'comfortable',
+                      label: 'Comfortable',
+                      closeOnActivate: false,
+                    ),
+                  ],
+                ),
+                RemixMenuSubmenu(
+                  controller: submenuController,
+                  label: 'More',
+                  items: const [
+                    RemixMenuItem(value: 'archive', label: 'Archive'),
+                  ],
+                ),
+                const RemixMenuItem(
+                  value: 'locked',
+                  label: 'Locked',
+                  enabled: false,
+                ),
+              ],
+            ),
+          );
+
+          menuController.open();
+          await tester.pump();
+
+          final context = tester.element(find.text('Checked'));
+          final highlighted = switch (variant) {
+            .solid => FortalTokens.accent9.resolve(context),
+            .soft => FortalTokens.accentA4.resolve(context),
+          };
+          final submenuOpen = switch (variant) {
+            .solid => FortalTokens.grayA3.resolve(context),
+            .soft => FortalTokens.accentA3.resolve(context),
+          };
+
+          expect(_menuRowColor(tester, 'Checked'), isNull);
+          expect(_menuRowColor(tester, 'Compact'), isNull);
+          expect(_menuRowColor(tester, 'Comfortable'), isNull);
+          expect(_menuRowColor(tester, 'More'), isNull);
+
+          submenuController.open();
+          await tester.pump();
+          expect(_menuRowColor(tester, 'More'), submenuOpen);
+
+          final mouse = await tester.createGesture(
+            kind: PointerDeviceKind.mouse,
+          );
+          await mouse.addPointer(location: Offset.zero);
+          addTearDown(mouse.removePointer);
+
+          await mouse.moveTo(tester.getCenter(find.text('Checked')));
+          await tester.pump();
+          expect(_menuRowColor(tester, 'Checked'), highlighted);
+
+          await mouse.moveTo(tester.getCenter(find.text('Compact')));
+          await tester.pump();
+          expect(_menuRowColor(tester, 'Compact'), highlighted);
+
+          await mouse.moveTo(tester.getCenter(find.text('Comfortable')));
+          await tester.pump();
+          expect(_menuRowColor(tester, 'Comfortable'), highlighted);
+
+          await mouse.moveTo(tester.getCenter(find.text('More')));
+          await tester.pump();
+          expect(_menuRowColor(tester, 'More'), highlighted);
+
+          await mouse.moveTo(tester.getCenter(find.text('Locked')));
+          await tester.pump();
+          expect(_menuRowColor(tester, 'Locked'), Colors.transparent);
+        },
+      );
+    }
+
+    for (final variant in FortalMenuVariant.values) {
+      for (final size in FortalMenuSize.values) {
+        for (final highContrast in [false, true]) {
+          testWidgets(
+            '${variant.name} ${size.name} indicators follow Radix foreground states'
+            '${highContrast ? ' at high contrast' : ''}',
+            (tester) async {
+              final controller = MenuController();
+              await tester.pumpRemixApp(
+                FortalMenu<String>(
+                  controller: controller,
+                  variant: variant,
+                  size: size,
+                  highContrast: highContrast,
+                  trigger: const RemixMenuTrigger(label: 'Options'),
+                  onSelected: (_) {},
+                  items: const [
+                    RemixMenuCheckboxItem(
+                      value: 'checked',
+                      label: 'Checked',
+                      checked: true,
+                      closeOnActivate: false,
+                    ),
+                    RemixMenuRadioGroup(
+                      value: 'compact',
+                      items: [
+                        RemixMenuRadioItem(
+                          value: 'compact',
+                          label: 'Compact',
+                          closeOnActivate: false,
+                        ),
+                      ],
+                    ),
+                    RemixMenuCheckboxItem(
+                      value: 'disabled',
+                      label: 'Disabled',
+                      checked: true,
+                      enabled: false,
+                    ),
+                  ],
+                ),
+              );
+
+              controller.open();
+              await tester.pump();
+
+              IconSpec indicatorSpec(String label) => tester
+                  .widget<RemixPathIcon>(
+                    find.byKey(ValueKey('remix-menu-indicator-$label')),
+                  )
+                  .styleSpec
+                  .spec;
+
+              final context = tester.element(find.text('Checked'));
+              final idleColor = FortalTokens.gray12.resolve(context);
+              final disabledColor = FortalTokens.grayA8.resolve(context);
+              final highlightedColor = switch (variant) {
+                .solid =>
+                  highContrast
+                      ? FortalTokens.accent1.resolve(context)
+                      : FortalTokens.accentContrast.resolve(context),
+                .soft => idleColor,
+              };
+              final expectedSize = switch (size) {
+                .size1 => FortalTokens.selectIndicatorSize1.resolve(context),
+                .size2 => FortalTokens.selectIndicatorSize2.resolve(context),
+              };
+
+              expect(indicatorSpec('Checked').color, idleColor);
+              expect(indicatorSpec('Checked').size, expectedSize);
+              expect(indicatorSpec('Compact').color, idleColor);
+              expect(indicatorSpec('Compact').size, expectedSize);
+              expect(indicatorSpec('Disabled').color, disabledColor);
+              expect(indicatorSpec('Disabled').size, expectedSize);
+
+              final mouse = await tester.createGesture(
+                kind: PointerDeviceKind.mouse,
+              );
+              await mouse.addPointer(location: Offset.zero);
+              addTearDown(mouse.removePointer);
+              await mouse.moveTo(tester.getCenter(find.text('Checked')));
+              await tester.pump();
+
+              expect(indicatorSpec('Checked').color, highlightedColor);
+              expect(indicatorSpec('Checked').size, expectedSize);
+            },
+          );
+        }
+      }
+    }
+
+    for (final size in FortalMenuSize.values) {
+      testWidgets('${size.name} pins the solid panel and Radix icon metrics', (
+        tester,
+      ) async {
+        final controller = MenuController();
+        await tester.pumpRemixApp(
+          FortalMenu<String>(
+            controller: controller,
+            size: size,
+            trigger: const RemixMenuTrigger(label: 'Options', icon: Icons.tune),
+            onSelected: (_) {},
+            items: const [
+              RemixMenuItem(
+                value: 'rename',
+                label: 'Rename',
+                leadingIcon: Icons.edit_outlined,
+              ),
+              RemixMenuSubmenu(
+                label: 'More',
+                items: [RemixMenuItem(value: 'nested', label: 'Nested')],
+              ),
+            ],
+          ),
+        );
+
+        controller.open();
+        await tester.pump();
+
+        final context = tester.element(find.text('Rename'));
+        final contentIconSize = switch (size) {
+          .size1 => FortalTokens.space3.resolve(context),
+          .size2 => FortalTokens.space4.resolve(context),
+        };
+        final subtriggerIconSize = switch (size) {
+          .size1 => FortalTokens.selectIndicatorSize1.resolve(context),
+          .size2 => FortalTokens.selectIndicatorSize2.resolve(context),
+        };
+        final triggerGap = switch (size) {
+          .size1 => FortalTokens.space1.resolve(context),
+          .size2 => FortalTokens.space2.resolve(context),
+        };
+
+        // Radix pins menus to the solid panel with no backdrop blur.
+        final resolved = fortalMenuStyle(size: size).resolve(context).spec;
+        expect(
+          (resolved.overlay.spec.box?.spec.decoration as BoxDecoration?)?.color,
+          FortalTokens.colorPanelSolid.resolve(context),
+        );
+        expect(resolved.containerEffects, isNull);
+
+        // Content icons are text-matched; the subtrigger chevron keeps the
+        // exact Radix icon size.
+        expect(
+          tester.getSize(find.byIcon(Icons.edit_outlined)),
+          Size.square(contentIconSize),
+        );
+        expect(
+          tester
+              .widget<RemixPathIcon>(
+                find.byKey(const ValueKey('remix-menu-submenu-chevron-More')),
+              )
+              .styleSpec
+              .spec
+              .size,
+          subtriggerIconSize,
+        );
+
+        // The trigger content mirrors the base Radix button gap and icon.
+        expect(
+          tester.getSize(find.byIcon(Icons.tune)),
+          Size.square(contentIconSize),
+        );
+        final triggerRow = tester.widget<RowBox>(
+          find
+              .ancestor(of: find.text('Options'), matching: find.byType(RowBox))
+              .first,
+        );
+        expect(triggerRow.styleSpec?.spec.flex?.spec.spacing, triggerGap);
+      });
+    }
+
+    testWidgets('visual labels produce exactly one semantics node', (
+      tester,
+    ) async {
+      final semantics = tester.ensureSemantics();
+      await tester.pumpRemixApp(
+        const RemixMenu<String>(
+          trigger: RemixMenuTrigger(label: 'Options'),
+          items: [
+            RemixMenuCheckboxItem(
+              value: 'notifications',
+              label: 'Notifications',
+              checked: true,
+              semanticLabel: 'Notification setting',
+            ),
+            RemixMenuRadioGroup(
+              value: 'compact',
+              items: [
+                RemixMenuRadioItem(
+                  value: 'compact',
+                  label: 'Compact',
+                  semanticLabel: 'Compact density',
+                ),
+              ],
+            ),
+            RemixMenuSubmenu(
+              label: 'More',
+              semanticLabel: 'More actions',
+              items: [RemixMenuItem(value: 'archive', label: 'Archive')],
+            ),
+          ],
+        ),
+      );
+      await tester.tap(find.text('Options'));
+      await tester.pump();
+
+      expect(find.bySemanticsLabel('Notification setting'), findsOneWidget);
+      expect(find.bySemanticsLabel('Compact density'), findsOneWidget);
+      expect(find.bySemanticsLabel('More actions'), findsOneWidget);
+      semantics.dispose();
+    });
+  });
+}
+
+Color? _menuRowColor(WidgetTester tester, String label) {
+  final row = tester.widget<FlexBox>(
+    find.ancestor(of: find.text(label), matching: find.byType(FlexBox)).first,
+  );
+  return (row.styleSpec?.spec.box?.spec.decoration as BoxDecoration?)?.color;
 }
 
 // Test enum for type safety testing

--- a/packages/remix/test/components/menu/menu_widget_test.dart
+++ b/packages/remix/test/components/menu/menu_widget_test.dart
@@ -1946,9 +1946,131 @@ void main() {
             .ancestor(of: find.text('Nested'), matching: find.byType(FlexBox))
             .first,
       );
-      expect(rootRow.children.first, isA<SizedBox>());
+      expect(rootRow.children.first, isA<Visibility>());
       expect(nestedRow.children.first, isA<Expanded>());
     });
+
+    testWidgets('default size-9 choice slots scale to 18 at 200%', (
+      tester,
+    ) async {
+      final controller = MenuController();
+      await tester.pumpRemixApp(
+        MediaQuery(
+          data: const MediaQueryData(textScaler: TextScaler.linear(2)),
+          child: RemixMenu<String>(
+            controller: controller,
+            trigger: const RemixMenuTrigger(label: 'Options'),
+            style: MenuStyler().item(
+              MenuItemStyler().indicator(IconStyler().applyTextScaling(true)),
+            ),
+            items: const [
+              RemixMenuCheckboxItem(
+                value: 'checked',
+                label: 'Checked',
+                checked: true,
+              ),
+              RemixMenuCheckboxItem(
+                value: 'unchecked',
+                label: 'Unchecked',
+                checked: false,
+              ),
+            ],
+          ),
+        ),
+      );
+
+      controller.open();
+      await tester.pump();
+
+      Finder slotFor(String label) {
+        final row = tester.widget<FlexBox>(
+          find
+              .ancestor(of: find.text(label), matching: find.byType(FlexBox))
+              .first,
+        );
+        return find.byWidget(row.children.first);
+      }
+
+      final checkedIndicator = tester.widget<RemixPathIcon>(
+        find.byKey(const ValueKey('remix-menu-indicator-Checked')),
+      );
+      expect(checkedIndicator.styleSpec.spec.size, 9);
+      expect(tester.getSize(slotFor('Checked')), const Size.square(18));
+      expect(tester.getSize(slotFor('Unchecked')), const Size.square(18));
+    });
+
+    testWidgets(
+      'maintained choice slots remain excluded from duplicate semantics',
+      (tester) async {
+        final semantics = tester.ensureSemantics();
+        final controller = MenuController();
+        await tester.pumpRemixApp(
+          RemixMenu<String>(
+            controller: controller,
+            trigger: const RemixMenuTrigger(label: 'Options'),
+            items: const [
+              RemixMenuCheckboxItem(
+                value: 'checked',
+                label: 'Checked',
+                checked: true,
+                semanticLabel: 'Checked choice',
+              ),
+              RemixMenuCheckboxItem(
+                value: 'unchecked',
+                label: 'Unchecked',
+                checked: false,
+                semanticLabel: 'Unchecked choice',
+              ),
+            ],
+          ),
+        );
+
+        controller.open();
+        await tester.pump();
+
+        for (final (label, visible) in [
+          ('Checked', true),
+          ('Unchecked', false),
+        ]) {
+          final row = find
+              .ancestor(of: find.text(label), matching: find.byType(FlexBox))
+              .first;
+          final slot = tester.widget<FlexBox>(row).children.first;
+
+          expect(
+            slot,
+            isA<Visibility>()
+                .having((slot) => slot.visible, 'visible', visible)
+                .having((slot) => slot.maintainState, 'maintainState', isTrue)
+                .having(
+                  (slot) => slot.maintainAnimation,
+                  'maintainAnimation',
+                  isTrue,
+                )
+                .having((slot) => slot.maintainSize, 'maintainSize', isTrue)
+                .having(
+                  (slot) => slot.maintainSemantics,
+                  'maintainSemantics',
+                  isTrue,
+                )
+                .having(
+                  (slot) => slot.maintainInteractivity,
+                  'maintainInteractivity',
+                  isTrue,
+                )
+                .having((slot) => slot.child, 'child', isA<RemixPathIcon>()),
+          );
+          expect(
+            find.ancestor(of: row, matching: find.byType(ExcludeSemantics)),
+            findsOneWidget,
+          );
+        }
+
+        expect(find.bySemanticsLabel('Checked choice'), findsOneWidget);
+        expect(find.bySemanticsLabel('Unchecked choice'), findsOneWidget);
+        semantics.dispose();
+      },
+    );
 
     testWidgets('raw and fluent indicator styles control the shared path', (
       tester,

--- a/packages/remix/test/components/menu/menu_widget_test.dart
+++ b/packages/remix/test/components/menu/menu_widget_test.dart
@@ -975,6 +975,10 @@ void main() {
 
     test('compound labels and semantic labels must not be empty', () {
       expect(
+        () => RemixMenuItem<String>(value: 'ordinary', label: ''),
+        throwsAssertionError,
+      );
+      expect(
         () => RemixMenuCheckboxItem<String>(
           value: 'checkbox',
           label: '',

--- a/packages/remix/test/components/menu/menu_widget_test.dart
+++ b/packages/remix/test/components/menu/menu_widget_test.dart
@@ -162,6 +162,147 @@ void main() {
     });
   });
 
+  group('RemixMenu item identity', () {
+    testWidgets('caller-owned keys reach every rendered item root', (
+      tester,
+    ) async {
+      const ordinaryKey = ValueKey<String>('ordinary-root');
+      const checkboxKey = ValueKey<String>('checkbox-root');
+      const radioGroupKey = ValueKey<String>('radio-group-root');
+      const radioItemKey = ValueKey<String>('radio-item-root');
+      const submenuKey = ValueKey<String>('submenu-root');
+      const dividerKey = ValueKey<String>('divider-root');
+      final controller = MenuController();
+
+      await tester.pumpRemixApp(
+        RemixMenu<String>(
+          controller: controller,
+          trigger: const RemixMenuTrigger(label: 'Options'),
+          onSelected: (_) {},
+          items: const [
+            RemixMenuItem(
+              key: ordinaryKey,
+              value: 'ordinary',
+              label: 'Ordinary',
+            ),
+            RemixMenuCheckboxItem(
+              key: checkboxKey,
+              value: 'checkbox',
+              label: 'Checkbox',
+              checked: true,
+            ),
+            RemixMenuRadioGroup(
+              key: radioGroupKey,
+              value: 'radio',
+              items: [
+                RemixMenuRadioItem(
+                  key: radioItemKey,
+                  value: 'radio',
+                  label: 'Radio',
+                ),
+              ],
+            ),
+            RemixMenuSubmenu(
+              key: submenuKey,
+              label: 'More',
+              items: [RemixMenuItem(value: 'nested', label: 'Nested')],
+            ),
+            RemixMenuDivider(key: dividerKey),
+          ],
+        ),
+      );
+
+      controller.open();
+      await tester.pump();
+
+      expect(
+        tester.widget(find.byKey(ordinaryKey)),
+        isA<NakedMenuItem<String>>(),
+      );
+      expect(
+        tester.widget(find.byKey(checkboxKey)),
+        isA<NakedMenuCheckboxItem<String>>(),
+      );
+      expect(
+        tester.widget(find.byKey(radioGroupKey)),
+        isA<NakedMenuRadioGroup<String>>(),
+      );
+      expect(
+        tester.widget(find.byKey(radioItemKey)),
+        isA<NakedMenuRadioItem<String>>(),
+      );
+      expect(
+        tester.widget(find.byKey(submenuKey)),
+        isA<NakedMenuSubmenu<String>>(),
+      );
+      expect(
+        tester.widget(find.byKey(dividerKey)),
+        isA<StyleSpecBuilder<DividerSpec>>(),
+      );
+    });
+
+    testWidgets('keyed open submenu retains state after sibling reorder', (
+      tester,
+    ) async {
+      const alphaKey = ValueKey<String>('alpha-submenu');
+      const betaKey = ValueKey<String>('beta-submenu');
+      final controller = MenuController();
+      late StateSetter reorder;
+      var reordered = false;
+
+      await tester.pumpRemixApp(
+        StatefulBuilder(
+          builder: (context, setState) {
+            reorder = setState;
+            final alpha = RemixMenuSubmenu<String>(
+              key: alphaKey,
+              label: 'Alpha',
+              items: const [
+                RemixMenuItem(value: 'alpha-child', label: 'Alpha child'),
+              ],
+            );
+            final beta = RemixMenuSubmenu<String>(
+              key: betaKey,
+              label: 'Beta',
+              items: const [
+                RemixMenuItem(value: 'beta-child', label: 'Beta child'),
+              ],
+            );
+
+            return RemixMenu<String>(
+              controller: controller,
+              trigger: const RemixMenuTrigger(label: 'Options'),
+              items: reordered ? [beta, alpha] : [alpha, beta],
+            );
+          },
+        ),
+      );
+
+      controller.open();
+      await tester.pump();
+      expect(
+        tester.getTopLeft(find.text('Alpha')).dy,
+        lessThan(tester.getTopLeft(find.text('Beta')).dy),
+      );
+
+      await tester.tap(find.text('Alpha'));
+      await tester.pump();
+      expect(find.text('Alpha child'), findsOneWidget);
+      expect(find.text('Beta child'), findsNothing);
+
+      reorder(() => reordered = true);
+      await tester.pump();
+      await tester.pump();
+
+      expect(
+        tester.getTopLeft(find.text('Beta')).dy,
+        lessThan(tester.getTopLeft(find.text('Alpha')).dy),
+      );
+      expect(find.text('Alpha child'), findsOneWidget);
+      expect(find.text('Beta child'), findsNothing);
+    });
+  });
+
   group('RemixMenu Interaction Tests', () {
     testWidgets('menu opens when trigger is tapped', (tester) async {
       await tester.pumpRemixApp(

--- a/packages/remix/test/public_api_compatibility_test.dart
+++ b/packages/remix/test/public_api_compatibility_test.dart
@@ -54,7 +54,6 @@ void main() {
 
   test('generated wrappers preserve generic and named constructors', () {
     const menu = FortalMenu<String>.soft(
-      style: MenuStyler.create(),
       trigger: RemixMenuTrigger(label: 'Actions'),
       items: [RemixMenuItem(value: 'save', label: 'Save')],
     );
@@ -66,7 +65,6 @@ void main() {
     const button = FortalButton.soft(label: 'Save');
 
     expect(menu.variant, FortalMenuVariant.soft);
-    expect(menu.style, isA<MenuStyler>());
     expect(select.variant, FortalSelectVariant.ghost);
     expect(radio.variant, FortalRadioVariant.soft);
     expect(button.variant, FortalButtonVariant.soft);

--- a/packages/remix/test/public_api_compatibility_test.dart
+++ b/packages/remix/test/public_api_compatibility_test.dart
@@ -8,7 +8,25 @@ void main() {
     const card = RemixCard(child: Text('Passive'));
     const menu = RemixMenu<String>(
       trigger: RemixMenuTrigger(label: 'Actions'),
-      items: [RemixMenuItem(value: 'save', label: 'Save')],
+      items: [
+        RemixMenuItem(value: 'save', label: 'Save'),
+        RemixMenuCheckboxItem(
+          value: 'notifications',
+          label: 'Notifications',
+          checked: true,
+        ),
+        RemixMenuRadioGroup(
+          value: 'compact',
+          items: [
+            RemixMenuRadioItem(value: 'compact', label: 'Compact'),
+            RemixMenuRadioItem(value: 'comfortable', label: 'Comfortable'),
+          ],
+        ),
+        RemixMenuSubmenu(
+          label: 'More',
+          items: [RemixMenuItem(value: 'archive', label: 'Archive')],
+        ),
+      ],
     );
     const select = RemixSelect<String>(
       trigger: RemixSelectTrigger(placeholder: 'Choose'),
@@ -22,7 +40,11 @@ void main() {
     expect(button.label, 'Save');
     expect(card.child, isA<Text>());
     expect(menu.trigger, isA<RemixMenuTrigger>());
-    expect(menu.items.single, isA<RemixMenuItem<String>>());
+    expect(menu.items, hasLength(4));
+    expect(menu.items[0], isA<RemixMenuItem<String>>());
+    expect(menu.items[1], isA<RemixMenuCheckboxItem<String>>());
+    expect(menu.items[2], isA<RemixMenuRadioGroup<String>>());
+    expect(menu.items[3], isA<RemixMenuSubmenu<String>>());
     expect(select.items.single, isA<RemixSelectItem<String>>());
     expect(slider.value, 0.5);
     expect(progress.value, 0.5);
@@ -32,6 +54,7 @@ void main() {
 
   test('generated wrappers preserve generic and named constructors', () {
     const menu = FortalMenu<String>.soft(
+      style: MenuStyler.create(),
       trigger: RemixMenuTrigger(label: 'Actions'),
       items: [RemixMenuItem(value: 'save', label: 'Save')],
     );
@@ -43,6 +66,7 @@ void main() {
     const button = FortalButton.soft(label: 'Save');
 
     expect(menu.variant, FortalMenuVariant.soft);
+    expect(menu.style, isA<MenuStyler>());
     expect(select.variant, FortalSelectVariant.ghost);
     expect(radio.variant, FortalRadioVariant.soft);
     expect(button.variant, FortalButtonVariant.soft);

--- a/packages/remix/test/public_api_compatibility_test.dart
+++ b/packages/remix/test/public_api_compatibility_test.dart
@@ -52,6 +52,49 @@ void main() {
     expect(spinner, isA<RemixSpinner>());
   });
 
+  test('menu data retains caller-owned identity', () {
+    const ordinaryKey = ValueKey<String>('ordinary');
+    const checkboxKey = ValueKey<String>('checkbox');
+    const radioGroupKey = ValueKey<String>('radio-group');
+    const radioItemKey = ValueKey<String>('radio-item');
+    const submenuKey = ValueKey<String>('submenu');
+    const dividerKey = ValueKey<String>('divider');
+    const items = <RemixMenuItemData<String>>[
+      RemixMenuItem(key: ordinaryKey, value: 'ordinary', label: 'Ordinary'),
+      RemixMenuCheckboxItem(
+        key: checkboxKey,
+        value: 'checkbox',
+        label: 'Checkbox',
+        checked: true,
+      ),
+      RemixMenuRadioGroup(
+        key: radioGroupKey,
+        value: 'radio',
+        items: [
+          RemixMenuRadioItem(key: radioItemKey, value: 'radio', label: 'Radio'),
+        ],
+      ),
+      RemixMenuSubmenu(
+        key: submenuKey,
+        label: 'Submenu',
+        items: [RemixMenuItem(value: 'nested', label: 'Nested')],
+      ),
+      RemixMenuDivider(key: dividerKey),
+    ];
+
+    expect(items.map((item) => item.key), [
+      ordinaryKey,
+      checkboxKey,
+      radioGroupKey,
+      submenuKey,
+      dividerKey,
+    ]);
+    expect(
+      (items[2] as RemixMenuRadioGroup<String>).items.single.key,
+      radioItemKey,
+    );
+  });
+
   test('generated wrappers preserve generic and named constructors', () {
     const menu = FortalMenu<String>.soft(
       trigger: RemixMenuTrigger(label: 'Actions'),

--- a/packages/remix/test/public_api_compatibility_test.dart
+++ b/packages/remix/test/public_api_compatibility_test.dart
@@ -95,6 +95,39 @@ void main() {
     );
   });
 
+  testWidgets('ordinary menu items remain accessible when icon-only', (
+    tester,
+  ) async {
+    final controller = MenuController();
+    final item = RemixMenuItem<String>(
+      value: 'favorite',
+      label: '',
+      leadingIcon: Icons.star,
+      semanticLabel: 'Favorite item',
+    );
+    final semantics = tester.ensureSemantics();
+
+    await tester.pumpWidget(
+      FortalScope(
+        child: MaterialApp(
+          home: Scaffold(
+            body: RemixMenu<String>(
+              controller: controller,
+              trigger: const RemixMenuTrigger(label: 'Actions'),
+              items: [item],
+            ),
+          ),
+        ),
+      ),
+    );
+    controller.open();
+    await tester.pump();
+
+    expect(find.byIcon(Icons.star), findsOneWidget);
+    expect(find.bySemanticsLabel('Favorite item'), findsOneWidget);
+    semantics.dispose();
+  });
+
   test('generated wrappers preserve generic and named constructors', () {
     const menu = FortalMenu<String>.soft(
       trigger: RemixMenuTrigger(label: 'Actions'),

--- a/packages/remix/test/public_api_test.dart
+++ b/packages/remix/test/public_api_test.dart
@@ -10,27 +10,4 @@ void main() {
 
     expect(modifier, isNotNull);
   });
-
-  test('compound menu item types are exported from remix.dart', () {
-    const checkbox = RemixMenuCheckboxItem<String>(
-      value: 'notifications',
-      label: 'Notifications',
-      checked: true,
-    );
-    const radioGroup = RemixMenuRadioGroup<String>(
-      value: 'compact',
-      items: [
-        RemixMenuRadioItem(value: 'compact', label: 'Compact'),
-        RemixMenuRadioItem(value: 'comfortable', label: 'Comfortable'),
-      ],
-    );
-    const submenu = RemixMenuSubmenu<String>(
-      label: 'More',
-      items: [RemixMenuItem(value: 'archive', label: 'Archive')],
-    );
-
-    expect(checkbox, isA<RemixMenuItemData<String>>());
-    expect(radioGroup, isA<RemixMenuItemData<String>>());
-    expect(submenu, isA<RemixMenuItemData<String>>());
-  });
 }

--- a/packages/remix/test/public_api_test.dart
+++ b/packages/remix/test/public_api_test.dart
@@ -10,4 +10,27 @@ void main() {
 
     expect(modifier, isNotNull);
   });
+
+  test('compound menu item types are exported from remix.dart', () {
+    const checkbox = RemixMenuCheckboxItem<String>(
+      value: 'notifications',
+      label: 'Notifications',
+      checked: true,
+    );
+    const radioGroup = RemixMenuRadioGroup<String>(
+      value: 'compact',
+      items: [
+        RemixMenuRadioItem(value: 'compact', label: 'Compact'),
+        RemixMenuRadioItem(value: 'comfortable', label: 'Comfortable'),
+      ],
+    );
+    const submenu = RemixMenuSubmenu<String>(
+      label: 'More',
+      items: [RemixMenuItem(value: 'archive', label: 'Archive')],
+    );
+
+    expect(checkbox, isA<RemixMenuItemData<String>>());
+    expect(radioGroup, isA<RemixMenuItemData<String>>());
+    expect(submenu, isA<RemixMenuItemData<String>>());
+  });
 }

--- a/packages/remix/test/utilities/remix_path_icon_test.dart
+++ b/packages/remix/test/utilities/remix_path_icon_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mix/mix.dart';
+import 'package:remix/src/utilities/remix_path_icon.dart';
+
+/// Captures the glyph path handed to [Canvas.drawPath] without transforms so
+/// assertions run against the raw pinned nine-unit coordinates.
+class _PathRecorder implements Canvas {
+  final List<Path> paths = [];
+
+  @override
+  void drawPath(Path path, Paint paint) => paths.add(path);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+Future<Path> _recordGlyphPath(WidgetTester tester, RemixPathGlyph glyph) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Center(
+        child: RemixPathIcon(
+          glyph: glyph,
+          styleSpec: const StyleSpec(spec: IconSpec(size: 9)),
+        ),
+      ),
+    ),
+  );
+  final custom = tester.widget<CustomPaint>(
+    find.descendant(
+      of: find.byType(RemixPathIcon),
+      matching: find.byType(CustomPaint),
+    ),
+  );
+  final recorder = _PathRecorder();
+  custom.painter!.paint(recorder, const Size(9, 9));
+
+  expect(recorder.paths, hasLength(1));
+
+  return recorder.paths.single;
+}
+
+double _perimeter(Path path) => path
+    .computeMetrics()
+    .fold(0.0, (total, metric) => total + metric.length);
+
+void main() {
+  // The parity manifest promises the exact Radix Themes 3.3.0 vector paths.
+  // Bounds and perimeter fingerprint the pinned nine-unit coordinates, so any
+  // edit to a path constant fails here.
+  const pinnedGeometry = {
+    RemixPathGlyph.chevronDown: (
+      bounds: Rect.fromLTRB(-0.0536285, 2.9463699, 9.0536003, 7.7951002),
+      perimeter: 24.5066948,
+    ),
+    RemixPathGlyph.thickCheck: (
+      bounds: Rect.fromLTRB(0.2852460, 0.3964140, 8.9797602, 8.5216703),
+      perimeter: 26.7144108,
+    ),
+    RemixPathGlyph.thickChevronRight: (
+      bounds: Rect.fromLTRB(2.9190900, -0.0809141, 8.0672398, 9.0809202),
+      perimeter: 24.3844013,
+    ),
+  };
+
+  for (final MapEntry(key: glyph, value: expected) in pinnedGeometry.entries) {
+    testWidgets('${glyph.name} keeps the pinned Radix path geometry', (
+      tester,
+    ) async {
+      final path = await _recordGlyphPath(tester, glyph);
+      final bounds = path.getBounds();
+
+      expect(bounds.left, closeTo(expected.bounds.left, 1e-3));
+      expect(bounds.top, closeTo(expected.bounds.top, 1e-3));
+      expect(bounds.right, closeTo(expected.bounds.right, 1e-3));
+      expect(bounds.bottom, closeTo(expected.bounds.bottom, 1e-3));
+      expect(_perimeter(path), closeTo(expected.perimeter, 1e-2));
+    });
+  }
+}

--- a/packages/remix/tool/fortal_parity/check.dart
+++ b/packages/remix/tool/fortal_parity/check.dart
@@ -74,7 +74,6 @@ void main() {
     testSourceCache,
     failures,
   );
-  _checkMenuCompoundContract(manifest, evidence, failures);
   _checkFixtures(manifest, packageRoot, failures);
   _checkNakedPin(
     pubspec,
@@ -85,114 +84,6 @@ void main() {
   _checkVariantConstructors(packageRoot, failures);
   _checkApproximations(manifest, failures);
   _finish(failures);
-}
-
-void _checkMenuCompoundContract(
-  Map<String, Object?> manifest,
-  Map<String, Object?> evidence,
-  List<String> failures,
-) {
-  final familyValues = manifest['families'];
-  if (familyValues is! List<Object?>) return;
-  final menu = familyValues.whereType<Map<String, Object?>>().where(
-    (family) => family['id'] == 'menu',
-  );
-  if (menu.length != 1) {
-    failures.add(
-      'The menu compound contract requires exactly one menu family.',
-    );
-    return;
-  }
-
-  const compoundStates = {'checked', 'unchecked', 'submenuOpen', 'rtl'};
-  for (final key in ['states', 'supportedVisualStates']) {
-    final values = _strings(menu.single[key], 'menu.$key', failures).toSet();
-    _expect(
-      values.containsAll(compoundStates),
-      'menu.$key must include all compound states: $compoundStates.',
-      failures,
-    );
-  }
-  final coverage = _object(menu.single['coverage'], 'menu.coverage', failures);
-  if (coverage != null) {
-    final states = _strings(
-      coverage['states'],
-      'menu.coverage.states',
-      failures,
-    ).toSet();
-    _expect(
-      states.containsAll(compoundStates),
-      'menu.coverage.states must include all compound states: $compoundStates.',
-      failures,
-    );
-  }
-
-  final deferrals = _strings(
-    menu.single['deferredCapabilities'],
-    'menu.deferredCapabilities',
-    failures,
-  ).toSet();
-  _expect(
-    deferrals.contains('compositional items'),
-    'menu must keep the out-of-scope compositional items deferral.',
-    failures,
-  );
-  _expect(
-    !deferrals.any({'checkbox items', 'radio items', 'submenus'}.contains),
-    'menu must not defer shipped checkbox, radio, or submenu behavior.',
-    failures,
-  );
-  final globalDeferrals = _object(
-    manifest['deferredCapabilities'],
-    'deferredCapabilities',
-    failures,
-  );
-  if (globalDeferrals != null) {
-    final globalMenuDeferrals = _strings(
-      globalDeferrals['menu'],
-      'deferredCapabilities.menu',
-      failures,
-    ).toSet();
-    _expect(
-      _sameSet(globalMenuDeferrals, {'compositional items'}),
-      'The global menu deferral index must retain only compositional items.',
-      failures,
-    );
-  }
-
-  final evidenceValues = evidence['menu'];
-  final covered = <String>{};
-  if (evidenceValues is List<Object?>) {
-    for (final value in evidenceValues.whereType<Map<String, Object?>>()) {
-      final covers = value['covers'];
-      if (covers is List<Object?>) covered.addAll(covers.whereType<String>());
-    }
-  }
-  final requiredEvidence = compoundStates
-      .map((state) => 'state:$state')
-      .toSet();
-  _expect(
-    covered.containsAll(requiredEvidence),
-    'menu evidence must cite every compound state: $requiredEvidence.',
-    failures,
-  );
-
-  final approximations = manifest['approximations'];
-  final menuApproximations = approximations is List<Object?>
-      ? approximations.whereType<Map<String, Object?>>().where(
-          (value) => value['family'] == 'menu',
-        )
-      : const Iterable<Map<String, Object?>>.empty();
-  final approximationReason = menuApproximations.length == 1
-      ? menuApproximations.single['reason']
-      : null;
-  _expect(
-    menuApproximations.length == 1 &&
-        approximationReason is String &&
-        approximationReason.contains('MenuItemStyler'),
-    'menu must retain one documented standard-flex layout approximation.',
-    failures,
-  );
 }
 
 Map<String, Object?>? _readObject(File file, List<String> failures) {

--- a/packages/remix/tool/fortal_parity/check.dart
+++ b/packages/remix/tool/fortal_parity/check.dart
@@ -74,6 +74,7 @@ void main() {
     testSourceCache,
     failures,
   );
+  _checkMenuCompoundContract(manifest, evidence, failures);
   _checkFixtures(manifest, packageRoot, failures);
   _checkNakedPin(
     pubspec,
@@ -84,6 +85,114 @@ void main() {
   _checkVariantConstructors(packageRoot, failures);
   _checkApproximations(manifest, failures);
   _finish(failures);
+}
+
+void _checkMenuCompoundContract(
+  Map<String, Object?> manifest,
+  Map<String, Object?> evidence,
+  List<String> failures,
+) {
+  final familyValues = manifest['families'];
+  if (familyValues is! List<Object?>) return;
+  final menu = familyValues.whereType<Map<String, Object?>>().where(
+    (family) => family['id'] == 'menu',
+  );
+  if (menu.length != 1) {
+    failures.add(
+      'The menu compound contract requires exactly one menu family.',
+    );
+    return;
+  }
+
+  const compoundStates = {'checked', 'unchecked', 'submenuOpen', 'rtl'};
+  for (final key in ['states', 'supportedVisualStates']) {
+    final values = _strings(menu.single[key], 'menu.$key', failures).toSet();
+    _expect(
+      values.containsAll(compoundStates),
+      'menu.$key must include all compound states: $compoundStates.',
+      failures,
+    );
+  }
+  final coverage = _object(menu.single['coverage'], 'menu.coverage', failures);
+  if (coverage != null) {
+    final states = _strings(
+      coverage['states'],
+      'menu.coverage.states',
+      failures,
+    ).toSet();
+    _expect(
+      states.containsAll(compoundStates),
+      'menu.coverage.states must include all compound states: $compoundStates.',
+      failures,
+    );
+  }
+
+  final deferrals = _strings(
+    menu.single['deferredCapabilities'],
+    'menu.deferredCapabilities',
+    failures,
+  ).toSet();
+  _expect(
+    deferrals.contains('compositional items'),
+    'menu must keep the out-of-scope compositional items deferral.',
+    failures,
+  );
+  _expect(
+    !deferrals.any({'checkbox items', 'radio items', 'submenus'}.contains),
+    'menu must not defer shipped checkbox, radio, or submenu behavior.',
+    failures,
+  );
+  final globalDeferrals = _object(
+    manifest['deferredCapabilities'],
+    'deferredCapabilities',
+    failures,
+  );
+  if (globalDeferrals != null) {
+    final globalMenuDeferrals = _strings(
+      globalDeferrals['menu'],
+      'deferredCapabilities.menu',
+      failures,
+    ).toSet();
+    _expect(
+      _sameSet(globalMenuDeferrals, {'compositional items'}),
+      'The global menu deferral index must retain only compositional items.',
+      failures,
+    );
+  }
+
+  final evidenceValues = evidence['menu'];
+  final covered = <String>{};
+  if (evidenceValues is List<Object?>) {
+    for (final value in evidenceValues.whereType<Map<String, Object?>>()) {
+      final covers = value['covers'];
+      if (covers is List<Object?>) covered.addAll(covers.whereType<String>());
+    }
+  }
+  final requiredEvidence = compoundStates
+      .map((state) => 'state:$state')
+      .toSet();
+  _expect(
+    covered.containsAll(requiredEvidence),
+    'menu evidence must cite every compound state: $requiredEvidence.',
+    failures,
+  );
+
+  final approximations = manifest['approximations'];
+  final menuApproximations = approximations is List<Object?>
+      ? approximations.whereType<Map<String, Object?>>().where(
+          (value) => value['family'] == 'menu',
+        )
+      : const Iterable<Map<String, Object?>>.empty();
+  final approximationReason = menuApproximations.length == 1
+      ? menuApproximations.single['reason']
+      : null;
+  _expect(
+    menuApproximations.length == 1 &&
+        approximationReason is String &&
+        approximationReason.contains('MenuItemStyler'),
+    'menu must retain one documented standard-flex layout approximation.',
+    failures,
+  );
 }
 
 Map<String, Object?>? _readObject(File file, List<String> failures) {


### PR DESCRIPTION
## Description

### Overview

This adds compound menu items to `RemixMenu`: controlled checkboxes,
controlled radio groups, and recursively nested submenus. Menus can now model
settings, mutually exclusive choices, and multi-level actions through one
sealed, data-driven API.

The feature also brings the Fortal menu recipe in line with the pinned Radix
Themes 3.3.0 reference and adds menu-wide styling slots for each compound item
kind.

### Feature highlights

- **Controlled checkbox items.** `RemixMenuCheckboxItem<T>` exposes a
  controlled `checked` value and an `onChanged` callback. Set
  `closeOnActivate: false` to toggle several options without reopening the
  menu.
- **Controlled radio groups.** `RemixMenuRadioGroup<T>` owns the selected value
  for a set of `RemixMenuRadioItem<T>` entries. Group changes and root menu
  selections are both reported.
- **Recursive submenus.** `RemixMenuSubmenu<T>` can contain ordinary items,
  choice items, dividers, and more submenus. It supports programmatic control,
  configurable hover delay, focus restoration, and direction-aware keyboard
  navigation and placement.
- **Stable dynamic-menu identity.** Every item kind and individual radio item
  accepts a caller-owned key, so filtered, inserted, or reordered menus keep
  state with the correct entry, including open submenus.
- **Consistent panel layout.** Root and nested panels share one renderer,
  including aligned, text-scaled choice indicators and `closeOnActivate`
  behavior.

### Preview

#### Compound menu items

The root panel combines ordinary and disabled actions, a checkbox, a radio
group, dividers, and a submenu.

![Compound menu items in light mode](https://github.com/user-attachments/assets/bad50f67-2ef1-4b9a-bb2a-053e14df43f6)

#### Recursive submenus

Nested panels reuse the same renderer and Fortal recipe at every depth.

![Recursive submenus in dark mode](https://github.com/user-attachments/assets/31ce8778-2681-4e39-adc7-e8c78845abf0)

### Usage

```dart
RemixMenu<String>(
  trigger: const RemixMenuTrigger(
    label: 'View options',
    icon: Icons.tune,
  ),
  onSelected: (value) => debugPrint('Selected: $value'),
  items: [
    RemixMenuCheckboxItem(
      value: 'show-status',
      label: 'Show status',
      checked: showStatus,
      closeOnActivate: false,
      onChanged: (next) => setState(() => showStatus = next),
    ),
    RemixMenuRadioGroup(
      value: density,
      onChanged: (next) => setState(() => density = next),
      items: const [
        RemixMenuRadioItem(
          value: 'compact',
          label: 'Compact',
          closeOnActivate: false,
        ),
        RemixMenuRadioItem(
          value: 'comfortable',
          label: 'Comfortable',
          closeOnActivate: false,
        ),
      ],
    ),
    const RemixMenuSubmenu(
      label: 'Share',
      items: [
        RemixMenuItem(value: 'copy-link', label: 'Copy link'),
        RemixMenuSubmenu(
          label: 'Send with',
          items: [
            RemixMenuItem(value: 'email', label: 'Email'),
            RemixMenuItem(value: 'messages', label: 'Messages'),
          ],
        ),
      ],
    ),
  ],
)
```

### Styling and visual parity

- Adds menu-wide `checkboxItem`, `radioItem`, and `submenuItem` style slots.
- Applies styles in the order `item` → semantic item kind → per-item
  override.
- Keeps generated Fortal constructors recipe-only; custom styles compose with
  `fortalMenuStyle(...).merge(customStyle)` on `RemixMenu`.
- Pins Fortal menus to the solid panel color without backdrop blur.
- Uses text-matched content-icon sizes while preserving the pinned Radix check
  and submenu-chevron geometry.
- Documents the intentional flex-row approximation for Radix's absolute
  indicator gutter in the parity manifest.

### Accessibility and interaction

The compound items use the pinned Naked UI beta.8 menu primitives for menu
roles, checked and expanded state, activation, hover timing, focus restoration,
and RTL-aware submenu navigation and placement. Visible row contents are
excluded from the semantics subtree so each actionable item exposes one
accessible name.

### Verification

- Focused menu suite: 229 passing tests on this branch, compared with 151 on
  `main` (+78).
- CI: 2,255 Remix tests and 20 dashboard tests passed on commit `9a489e5`.
- Generated-source, documentation, and Fortal parity checks passed in CI.
- The final compound and recursive menu states were visually verified in
  Chrome in light and dark themes.

## Related Issues

None.

---

## Checklist

**Note**: Updating the `pubspec.yaml` and `CHANGELOG.md` is not required. These
are handled automatically during the release process.

- [x] My PR includes unit or integration tests for *all* changed/updated/fixed
  behaviors.
- [x] I have updated or added relevant documentation (doc comments with `///`).
- [x] I am prepared to follow up on review comments in a timely manner.

## Breaking Change

Does this PR require users of the package to manually update their code?

- [x] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

Downstream exhaustive `switch` statements over `RemixMenuItemData` must handle
`RemixMenuCheckboxItem`, `RemixMenuRadioGroup`, and `RemixMenuSubmenu`, or add a
wildcard case. No runtime data migration is required.
