### PR TITLE
chore(remix): harden package publish foundation

### DIFF
--- a/packages/remix/.pubignore
+++ b/packages/remix/.pubignore
@@ -6,3 +6,6 @@ demo/macos/Podfile.lock
 docs/*
 scripts/*
 test/*
+reference/*
+tool/*
+radix_colors.generated.json

--- a/packages/remix/CHANGELOG.md
+++ b/packages/remix/CHANGELOG.md
@@ -28,8 +28,9 @@
 - **FEAT**: Expose every Fortal recipe parameter on its generated widget,
   including `highContrast` and Avatar's `fallbackLength`, while retaining both
   the unnamed `variant:` constructor and generated named variant constructors.
-- **FIX**: Pin `naked_ui 1.0.0-beta.8` so open labelled tooltips retain one
-  interactive semantics node without hiding unlabelled overlay semantics.
+- **FIX**: Allow `naked_ui` releases compatible with `^1.0.0-beta.8` so open
+  labelled tooltips retain one interactive semantics node without hiding
+  unlabelled overlay semantics.
 - **FIX**: Keep dialog titles and actions fixed while structured descriptions
   and body content scroll within bounded dialogs.
 - **FIX**: Resolve Fortal Avatar icon geometry through scaled design tokens for

--- a/packages/remix/README.md
+++ b/packages/remix/README.md
@@ -65,14 +65,14 @@ With Remix, you get:
 Add Remix to your project:
 
 ```bash
-flutter pub add remix
+flutter pub add remix:^1.0.0-beta.1
 ```
 
 Or add it to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  remix: ^1.0.0
+  remix: ^1.0.0-beta.1
 ```
 
 ### Your First Component

--- a/packages/remix/pubspec.yaml
+++ b/packages/remix/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
     sdk: flutter
   mix: ^2.2.0-beta.1
   mix_annotations: ^2.2.0-beta.1
-  naked_ui: 1.0.0-beta.8
+  naked_ui: ^1.0.0-beta.8
 
 dev_dependencies:
   flutter_test:

--- a/packages/remix/tool/fortal_parity/check.dart
+++ b/packages/remix/tool/fortal_parity/check.dart
@@ -5,6 +5,7 @@ import 'dart:typed_data';
 const _expectedIntegrity =
     'sha512-I0/h2CRNTpYNB7Mi3xFIvSsQq5a108d7kK8dTO5zp5b9HR5QJXKag6B8tjpz2ITkVYkFdkGk45doNkSr7OxwNw==';
 const _expectedNakedUiVersion = '1.0.0-beta.8';
+const _expectedNakedUiConstraint = '^1.0.0-beta.8';
 const _expectedMappedFamilies = <String>{
   'avatar',
   'badge',
@@ -632,11 +633,10 @@ void _checkNakedPin(
   final packageSource = packagePubspec.readAsStringSync();
   _expect(
     RegExp(
-      '^  naked_ui: ${RegExp.escape(_expectedNakedUiVersion)}\\s*\$',
+      '^  naked_ui: ${RegExp.escape(_expectedNakedUiConstraint)}\\s*\$',
       multiLine: true,
     ).hasMatch(packageSource),
-    'Remix must declare the exact naked_ui $_expectedNakedUiVersion '
-    'dependency.',
+    'Remix must constrain naked_ui to $_expectedNakedUiConstraint.',
     failures,
   );
   final workspaceSource = workspacePubspec.readAsStringSync();
@@ -831,7 +831,7 @@ Never _finish(List<String> failures) {
   stdout.writeln(
     'Verified @radix-ui/themes 3.3.0 contract: '
     '20 mapped families, 3 Fortal extensions, Chromium fixtures, '
-    'coverage ledger, hosted Naked $_expectedNakedUiVersion pin, and no '
+    'coverage ledger, hosted Naked $_expectedNakedUiVersion resolution, and no '
     'undocumented approximations.',
   );
   exit(0);


### PR DESCRIPTION
## Description

Makes the Remix package archive and dependency declaration publish-ready before the component PRs land.

The package previously pinned exactly one `naked_ui` prerelease, which pub validation rejects as overly restrictive and which would block the forthcoming press-state/semantics release. It now declares the standard compatible range `^1.0.0-beta.8`; the workspace lock and parity validator still prove the currently reviewed hosted resolution is beta.8, while compatible beta.9+ releases can be adopted without rewriting every component branch.

The package archive now excludes repository-only reference fixtures, package tooling, and the generated Radix source ledger. Installation guidance also names the actually published Remix prerelease instead of the unavailable stable version.

This changes packaging and dependency metadata only; there is no rendered UI change, so screenshots are not applicable.

### Validation

- `fvm dart pub publish --dry-run` — passed with 0 warnings; nothing was published
- `fvm dart run tool/fortal_parity/check.dart` — passed; hosted Naked beta.8 resolution and compatible constraint verified
- `fvm dart run melos run mix:consumer:check` — passed; hosted Mix `2.2.0-beta.1` resolution verified
- Full generation parity, documentation validation, Flutter tests, and repository CI passed for this five-file foundation diff before the final equivalent caret-constraint substitution
- `fvm dart format --output=none --set-exit-if-changed packages/remix/tool/fortal_parity/check.dart` — 0 changed
- `git diff --check` — clean

## Related Issues

Prerequisite for the reviewed Remix component PR series and `conceptadev/naked_ui#84`.

---

## Checklist

- [x] Existing tests and parity validators cover the changed packaging/dependency contracts.
- [x] README and changelog installation/dependency guidance are updated.
- [x] I am prepared to follow up on review comments in a timely manner.

## Breaking Change

Does this PR require users of the package to manually update their code?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.
