### PR TITLE
feat(remix): add data list component

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -106,6 +106,10 @@
           "href": "/components/checkbox"
         },
         {
+          "title": "Data List",
+          "href": "/components/data_list"
+        },
+        {
           "title": "Dialog",
           "href": "/components/dialog"
         },

--- a/docs/components/data_list.mdx
+++ b/docs/components/data_list.mdx
@@ -1,0 +1,305 @@
+---
+title: Data List
+description: A semantic label/value list with a shared horizontal label column or a stacked vertical layout
+keywords: [flutter, remix, data list, definition list, metadata, label, value, dl, dt, dd]
+---
+
+A semantic label/value list for metadata such as account details, order
+summaries, and configuration values. Horizontal orientation lays every row
+out in one shared two-column table, so labels align across all items;
+vertical orientation stacks each label above its value.
+
+## When to use this
+
+- **Account or profile metadata**: Name, email, company, and similar pairs
+- **Order and record summaries**: Ids, dates, totals, and statuses
+- **Configuration readouts**: Setting names with their current values
+- **Definition-style content**: Any display-only term/description pairing
+
+## Basic implementation
+
+<CodeGroup title="Basic implementation" defaultLanguage="dart">
+```dart
+import 'package:flutter/material.dart';
+import 'package:remix/remix.dart';
+
+class DataListExample extends StatelessWidget {
+  const DataListExample({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return RemixDataList(
+      semanticLabel: 'Account details',
+      items: const [
+        RemixDataListItem(label: 'Name', value: 'Leo Farias'),
+        RemixDataListItem(label: 'Email', value: 'leo@example.com'),
+        RemixDataListItem(label: 'Company', value: 'Bitwild'),
+      ],
+      style: style,
+    );
+  }
+
+  DataListStyler get style {
+    return DataListStyler()
+        .minLabelWidth(120)
+        .columnSpacing(24)
+        .rowSpacing(12)
+        .labelColor(Colors.grey);
+  }
+}
+```
+</CodeGroup>
+
+## Orientation and narrow widths
+
+The constructor's `orientation` always wins over styles, and the renderer
+never switches orientation on its own. A bounded horizontal list needs at
+least the resolved label column minimum (the greater of `minLabelWidth` and
+the widest label) plus `columnSpacing` plus the value column's minimum
+intrinsic width; below that bound, rebuild with `Axis.vertical`.
+
+<CodeGroup title="Caller-owned vertical fallback" defaultLanguage="dart">
+```dart
+import 'package:flutter/material.dart';
+import 'package:remix/remix.dart';
+
+class ResponsiveDataListExample extends StatelessWidget {
+  const ResponsiveDataListExample({super.key});
+
+  static const items = [
+    RemixDataListItem(label: 'Name', value: 'Leo Farias'),
+    RemixDataListItem(label: 'Email', value: 'leo@example.com'),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final vertical = constraints.maxWidth < 240;
+
+        return RemixDataList(
+          orientation: vertical ? Axis.vertical : Axis.horizontal,
+          items: items,
+          style: DataListStyler()
+              .minLabelWidth(120)
+              .columnSpacing(24)
+              .rowSpacing(12)
+              .labelValueSpacing(4),
+        );
+      },
+    );
+  }
+}
+```
+</CodeGroup>
+
+## Custom value widgets
+
+An item takes either a string `value` or one custom `child` widget. A custom
+child inherits the resolved value typography and keeps its own semantics, so
+interactive values stay actionable. A display-only child can opt into a
+single summarized announcement with `semanticValue`, which excludes the
+child's own semantics entirely — never combine `semanticValue` with an
+interactive child.
+
+<CodeGroup title="Custom value widgets" defaultLanguage="dart">
+```dart
+import 'package:flutter/material.dart';
+import 'package:remix/remix.dart';
+
+class DataListCustomValueExample extends StatelessWidget {
+  const DataListCustomValueExample({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return RemixDataList(
+      items: [
+        const RemixDataListItem(
+          label: 'Status',
+          semanticValue: 'Authorized',
+          alignment: RemixDataListItemAlignment.center,
+          child: RemixBadge(label: 'Authorized'),
+        ),
+        RemixDataListItem(
+          label: 'API key',
+          alignment: RemixDataListItemAlignment.center,
+          child: RemixButton(label: 'Reveal key', onPressed: () {}),
+        ),
+      ],
+    );
+  }
+}
+```
+</CodeGroup>
+
+## Per-item alignment
+
+Each item aligns its label and value cells with `start`, `center`, `end`,
+`baseline`, or `stretch`. `baseline` is the default and applies to string
+values, where both cells expose a text baseline; two deterministic
+adaptations are documented Radix deltas:
+
+- A custom-child row requesting `baseline` maps to `start`/top, because an
+  arbitrary widget may expose no text baseline.
+- Vertical orientation maps `baseline` to `start`, because stacked cells
+  share no horizontal baseline.
+
+## Semantics
+
+- The root exposes one `list` node, named by `semanticLabel` when provided.
+- Every row is one `listItem` node. A string row announces its label and
+  value from that single node; the visible texts are excluded so nothing is
+  read twice.
+- A custom child without `semanticValue` keeps its own semantics — including
+  actions — as children of the row node.
+- `excludeSemantics` removes the entire list from the semantics tree.
+
+Flutter has no definition-list role, so the list/list-item pairing is the
+documented adaptation of Radix's `dl`/`dt`/`dd` structure.
+
+## Constructor
+
+<CodeGroup title="Constructor" defaultLanguage="dart">
+```dart
+import 'package:flutter/material.dart';
+import 'package:remix/remix.dart';
+
+RemixDataList remixDataListConstructor({
+  Key? key,
+  required List<RemixDataListItem> items,
+  Axis orientation = Axis.horizontal,
+  String? semanticLabel,
+  bool excludeSemantics = false,
+  DataListStyler style = const DataListStyler.create(),
+  DataListSpec? styleSpec,
+}) => throw UnimplementedError();
+
+RemixDataListItem remixDataListItemConstructor({
+  required String label,
+  String? value,
+  Widget? child,
+  String? semanticValue,
+  RemixDataListItemAlignment alignment = RemixDataListItemAlignment.baseline,
+}) => throw UnimplementedError();
+```
+</CodeGroup>
+
+## Properties
+
+### Widget Properties
+
+#### `items` → `List<RemixDataListItem>`
+
+Required. The rows to display; may be empty. The list is retained as
+supplied, so do not mutate it during build — each build reads one immutable
+snapshot of the current contents.
+
+#### `orientation` → `Axis`
+
+Optional. Layout axis, defaulting to `Axis.horizontal`. The constructor
+always wins; orientation is intentionally absent from `DataListSpec`.
+
+#### `semanticLabel` → `String?`
+
+Optional. Accessible name announced for the list itself.
+
+#### `excludeSemantics` → `bool`
+
+Optional. Removes the entire list, rows included, from semantics. Defaults
+to `false`.
+
+#### `style` → `DataListStyler`
+
+Optional. The style configuration for typography, cell containers, and
+layout metrics.
+
+#### `styleSpec` → `DataListSpec?`
+
+Optional. A pre-resolved style spec that bypasses style resolution. Useful
+for performance when sharing resolved styles across multiple instances.
+
+#### `key` → `Key?`
+
+Optional. Controls how one widget replaces another widget in the tree.
+
+### Item Properties
+
+#### `label` → `String`
+
+Required and nonempty. The visible label, also announced as the row's
+semantic label.
+
+#### `value` → `String?`
+
+The string value, rendered with the value typography. Exactly one of
+`value` or `child` must be provided; a provided `value` must be nonempty.
+
+#### `child` → `Widget?`
+
+A custom value widget that inherits the resolved value typography and keeps
+its own semantics unless `semanticValue` summarizes it.
+
+#### `semanticValue` → `String?`
+
+Optional noninteractive summary announced instead of the child's semantics.
+Valid only together with `child` and must be nonempty when provided.
+
+#### `alignment` → `RemixDataListItemAlignment`
+
+Optional. Cross-cell alignment for this row, defaulting to
+`RemixDataListItemAlignment.baseline`.
+
+### Style Methods
+
+#### `label(TextStyler value)` / `value(TextStyler value)`
+
+Sets the label or value text slot.
+
+#### `labelTextStyle(TextStyleMix style)` / `valueTextStyle(TextStyleMix style)`
+
+Sets the label or value text style.
+
+#### `labelColor(Color color)` / `valueColor(Color color)`
+
+Sets the label or value text color.
+
+#### `labelContainer(BoxStyler value)` / `valueContainer(BoxStyler value)`
+
+Styles the cell containers around the label or value without coupling the
+text styles.
+
+#### `rowSpacing(double value)`
+
+Sets the gap between items along the list's main axis.
+
+#### `columnSpacing(double value)`
+
+Sets the directional horizontal gap between the label and value columns.
+
+#### `labelValueSpacing(double value)`
+
+Sets the inner vertical gap between label and value in vertical orientation.
+
+#### `minLabelWidth(double value)`
+
+Sets the minimum width of the shared horizontal label column.
+
+#### `padding(EdgeInsetsGeometryMix value)` / `margin(EdgeInsetsGeometryMix value)`
+
+Sets outer container padding or margin.
+
+#### `color(Color value)` / `decoration(DecorationMix value)`
+
+Sets the outer container background or decoration.
+
+#### `wrap(WidgetModifierConfig value)`
+
+Applies widget modifiers such as clipping, opacity, or scaling.
+
+#### `animate(AnimationConfig value)`
+
+Configures implicit animation for style transitions.
+
+#### `call({Key? key, required List<RemixDataListItem> items, Axis orientation, String? semanticLabel, bool excludeSemantics})`
+
+Creates a `RemixDataList` widget with this style applied.

--- a/docs/components/data_list.mdx
+++ b/docs/components/data_list.mdx
@@ -53,12 +53,19 @@ class DataListExample extends StatelessWidget {
 ## Orientation and narrow widths
 
 The constructor's `orientation` always wins over styles, and the renderer
-never switches orientation on its own. A bounded horizontal list needs at
-least the resolved label column minimum (the greater of `minLabelWidth` and
-every label's minimum intrinsic width) plus `columnSpacing` plus the value
-column's minimum intrinsic width. Down to that bound a long label wraps
-rather than starving the value column, which never shrinks below its minimum
-intrinsic width; below the bound, rebuild with `Axis.vertical`.
+never switches orientation on its own. In a bounded horizontal list, string
+values can shrink to their widest Unicode grapheme cluster. Long identifiers
+without spaces then wrap at grapheme-safe character boundaries instead of
+overflowing, including under text scaling and RTL; the accessible value stays
+exactly as supplied. Custom value widgets retain their normal minimum intrinsic
+width.
+
+The narrowest supported width is the resolved label column minimum (the greater
+of `minLabelWidth` and every label's minimum intrinsic width), plus
+`columnSpacing`, plus the greatest value minimum across the rows. For a string
+that minimum is its widest grapheme cluster; for a custom child it is the
+child's intrinsic minimum. Below that structural bound, rebuild with
+`Axis.vertical`.
 
 <CodeGroup title="Caller-owned vertical fallback" defaultLanguage="dart">
 ```dart

--- a/docs/components/data_list.mdx
+++ b/docs/components/data_list.mdx
@@ -55,8 +55,10 @@ class DataListExample extends StatelessWidget {
 The constructor's `orientation` always wins over styles, and the renderer
 never switches orientation on its own. A bounded horizontal list needs at
 least the resolved label column minimum (the greater of `minLabelWidth` and
-the widest label) plus `columnSpacing` plus the value column's minimum
-intrinsic width; below that bound, rebuild with `Axis.vertical`.
+every label's minimum intrinsic width) plus `columnSpacing` plus the value
+column's minimum intrinsic width. Down to that bound a long label wraps
+rather than starving the value column, which never shrinks below its minimum
+intrinsic width; below the bound, rebuild with `Axis.vertical`.
 
 <CodeGroup title="Caller-owned vertical fallback" defaultLanguage="dart">
 ```dart
@@ -170,11 +172,12 @@ RemixDataList remixDataListConstructor({
   Axis orientation = Axis.horizontal,
   String? semanticLabel,
   bool excludeSemantics = false,
-  DataListStyler style = const DataListStyler.create(),
-  DataListSpec? styleSpec,
+  Style<DataListSpec> style = const DataListStyler.create(),
+  StyleSpec<DataListSpec>? styleSpec,
 }) => throw UnimplementedError();
 
 RemixDataListItem remixDataListItemConstructor({
+  LocalKey? key,
   required String label,
   String? value,
   Widget? child,
@@ -201,22 +204,24 @@ always wins; orientation is intentionally absent from `DataListSpec`.
 
 #### `semanticLabel` → `String?`
 
-Optional. Accessible name announced for the list itself.
+Optional. Accessible name announced for the list itself. When provided it
+must not be whitespace-only (asserted in debug builds).
 
 #### `excludeSemantics` → `bool`
 
 Optional. Removes the entire list, rows included, from semantics. Defaults
 to `false`.
 
-#### `style` → `DataListStyler`
+#### `style` → `Style<DataListSpec>`
 
 Optional. The style configuration for typography, cell containers, and
 layout metrics.
 
-#### `styleSpec` → `DataListSpec?`
+#### `styleSpec` → `StyleSpec<DataListSpec>?`
 
 Optional. A pre-resolved style spec that bypasses style resolution. Useful
-for performance when sharing resolved styles across multiple instances.
+for performance when sharing resolved styles across multiple instances. Pass
+the resolved data as `const StyleSpec(spec: DataListSpec(...))`.
 
 #### `key` → `Key?`
 
@@ -224,15 +229,25 @@ Optional. Controls how one widget replaces another widget in the tree.
 
 ### Item Properties
 
+#### `key` → `LocalKey?`
+
+Optional stable identity for the row. Without a key, rows are matched by
+position, so a stateful custom `child` keeps its state at the old position
+after a reorder and can end up attached to the wrong label. Provide a key
+whenever items with custom children are reordered, inserted, or removed.
+
 #### `label` → `String`
 
-Required and nonempty. The visible label, also announced as the row's
-semantic label.
+Required. The visible label, also announced as the row's semantic label. It
+must be nonempty and not whitespace-only: the constructor rejects the empty
+string and debug builds additionally reject trimmed-blank text. Displayed
+text is never trimmed.
 
 #### `value` → `String?`
 
 The string value, rendered with the value typography. Exactly one of
-`value` or `child` must be provided; a provided `value` must be nonempty.
+`value` or `child` must be provided; a provided `value` must be nonempty
+and not whitespace-only.
 
 #### `child` → `Widget?`
 
@@ -242,7 +257,8 @@ its own semantics unless `semanticValue` summarizes it.
 #### `semanticValue` → `String?`
 
 Optional noninteractive summary announced instead of the child's semantics.
-Valid only together with `child` and must be nonempty when provided.
+Valid only together with `child`; when provided it must be nonempty and not
+whitespace-only.
 
 #### `alignment` → `RemixDataListItemAlignment`
 

--- a/packages/playground/lib/registry/component_registry.dart
+++ b/packages/playground/lib/registry/component_registry.dart
@@ -9,6 +9,7 @@ import 'entries/button_entry.dart';
 import 'entries/callout_entry.dart';
 import 'entries/card_entry.dart';
 import 'entries/checkbox_entry.dart';
+import 'entries/data_list_entry.dart';
 import 'entries/divider_entry.dart';
 import 'entries/progress_entry.dart';
 import 'entries/radio_entry.dart';
@@ -69,6 +70,10 @@ final Map<String, WidgetBuilder> components = {
   'callout': (context) => FortalScope(
     brightness: Theme.of(context).brightness,
     child: PreviewShell(child: buildCalloutExample()),
+  ),
+  'data_list': (context) => FortalScope(
+    brightness: Theme.of(context).brightness,
+    child: PreviewShell(child: buildDataListExample()),
   ),
   'divider': (context) => FortalScope(
     brightness: Theme.of(context).brightness,

--- a/packages/playground/lib/registry/entries/data_list_entry.dart
+++ b/packages/playground/lib/registry/entries/data_list_entry.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+import 'package:remix/remix.dart';
+
+import '../../widgets/comparison_view.dart';
+
+Widget buildDataListExample() {
+  const metadata = [
+    RemixDataListItem(label: 'Name', value: 'Leo Farias'),
+    RemixDataListItem(label: 'Email', value: 'leo@example.com'),
+    RemixDataListItem(
+      label: 'Bio',
+      value: 'Building composable Flutter design systems with Mix and Remix.',
+    ),
+  ];
+
+  final style = DataListStyler()
+      .minLabelWidth(96)
+      .columnSpacing(24)
+      .rowSpacing(12)
+      .labelValueSpacing(4)
+      .labelColor(Colors.grey);
+
+  Widget materialRow(String label, String value) => Padding(
+    padding: const EdgeInsets.only(bottom: 12),
+    child: Row(
+      crossAxisAlignment: .start,
+      children: [
+        SizedBox(
+          width: 96,
+          child: Text(label, style: const TextStyle(color: Colors.grey)),
+        ),
+        const SizedBox(width: 24),
+        Expanded(child: Text(value)),
+      ],
+    ),
+  );
+
+  return SizedBox(
+    width: 640,
+    child: ComparisonView(
+      remix: [
+        // Horizontal: one shared label column, wrapping values, and custom
+        // value children (a display-only badge and an interactive button).
+        SizedBox(
+          width: 280,
+          child: RemixDataList(
+            semanticLabel: 'Account details',
+            items: [
+              ...metadata,
+              const RemixDataListItem(
+                label: 'Status',
+                semanticValue: 'Authorized',
+                alignment: RemixDataListItemAlignment.center,
+                child: FortalBadge(label: 'Authorized'),
+              ),
+              RemixDataListItem(
+                label: 'API key',
+                alignment: RemixDataListItemAlignment.center,
+                child: FortalButton.soft(
+                  size: .size1,
+                  label: 'Reveal',
+                  onPressed: () {},
+                ),
+              ),
+            ],
+            style: style,
+          ),
+        ),
+        // Vertical: the caller-owned fallback for narrow widths.
+        SizedBox(
+          width: 200,
+          child: RemixDataList(
+            orientation: Axis.vertical,
+            items: metadata,
+            style: style,
+          ),
+        ),
+      ],
+      material: [
+        SizedBox(
+          width: 280,
+          child: Column(
+            mainAxisSize: .min,
+            children: [
+              materialRow('Name', 'Leo Farias'),
+              materialRow('Email', 'leo@example.com'),
+              materialRow(
+                'Bio',
+                'Building composable Flutter design systems with Mix and '
+                    'Remix.',
+              ),
+            ],
+          ),
+        ),
+      ],
+    ),
+  );
+}

--- a/packages/playground/lib/routes/all_components.dart
+++ b/packages/playground/lib/routes/all_components.dart
@@ -6,6 +6,7 @@ import '../registry/entries/button_entry.dart';
 import '../registry/entries/card_entry.dart';
 import '../registry/entries/callout_entry.dart';
 import '../registry/entries/checkbox_entry.dart';
+import '../registry/entries/data_list_entry.dart';
 import '../registry/entries/divider_entry.dart';
 import '../registry/entries/progress_entry.dart';
 import '../registry/entries/radio_entry.dart';
@@ -46,6 +47,7 @@ class AllComponentsPage extends StatelessWidget {
         _section('Card', buildCardExample()),
         _section('Callout', buildCalloutExample()),
         _section('Checkbox', buildCheckboxExample()),
+        _section('Data List', buildDataListExample()),
         _section('Divider', buildDividerExample()),
         _section('Progress', buildProgressExample()),
         _section('Radio', buildRadioExample()),

--- a/packages/remix/CHANGELOG.md
+++ b/packages/remix/CHANGELOG.md
@@ -2,13 +2,14 @@
 
 - **FEAT**: Add `RemixDataList`, a semantic label/value list mapped from
   Radix DataList. Horizontal orientation shares one negotiated label column
-  across every row and keeps the value column at or above its minimum
-  intrinsic width so long labels wrap instead of collapsing values; vertical
-  orientation stacks label above value. Rows expose one `list`/`listItem`
-  semantics pair with full-row bounds, interactive custom values stay
-  actionable, `semanticValue` opts a display-only child into a summarized
-  announcement, and `RemixDataListItem.key` gives rows stable identity across
-  reorder, insertion, and removal.
+  across every row, supports intrinsic-width parents, and lets string values
+  wrap unbroken identifiers at grapheme-safe boundaries while custom value
+  widgets retain their intrinsic sizing; vertical orientation stacks label
+  above value. Rows expose one `list`/`listItem` semantics pair with full-row
+  bounds, interactive custom values stay actionable, `semanticValue` opts a
+  display-only child into a summarized announcement, and
+  `RemixDataListItem.key` gives rows stable identity across reorder, insertion,
+  and removal.
 - **FEAT**: Add the Remix rendering subsystem for layered inset and outer
   shadows, gradients, outlines, backdrop blur, blend modes, and ordered color
   filters used by the Radix-accurate Fortal recipes.

--- a/packages/remix/CHANGELOG.md
+++ b/packages/remix/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## Unreleased
 
+- **FEAT**: Add `RemixDataList`, a semantic label/value list mapped from
+  Radix DataList. Horizontal orientation shares one negotiated label column
+  across every row and keeps the value column at or above its minimum
+  intrinsic width so long labels wrap instead of collapsing values; vertical
+  orientation stacks label above value. Rows expose one `list`/`listItem`
+  semantics pair with full-row bounds, interactive custom values stay
+  actionable, `semanticValue` opts a display-only child into a summarized
+  announcement, and `RemixDataListItem.key` gives rows stable identity across
+  reorder, insertion, and removal.
 - **FEAT**: Add the Remix rendering subsystem for layered inset and outer
   shadows, gradients, outlines, backdrop blur, blend modes, and ordered color
   filters used by the Radix-accurate Fortal recipes.

--- a/packages/remix/README.md
+++ b/packages/remix/README.md
@@ -285,6 +285,7 @@ Remix provides a comprehensive set of production-ready components:
 - **Avatar** - User avatars and images
 - **Badge** - Status indicators and labels
 - **Card** - Content containers
+- **DataList** - Label/value metadata lists with a shared label column
 - **Divider** - Visual separators
 - **Progress** - Progress indicators
 - **Spinner** - Loading states

--- a/packages/remix/lib/remix.dart
+++ b/packages/remix/lib/remix.dart
@@ -11,6 +11,7 @@ export 'src/components/dialog/dialog.dart';
 export 'src/components/icon_button/icon_button.dart';
 export 'src/components/card/card.dart';
 export 'src/components/checkbox/checkbox.dart';
+export 'src/components/data_list/data_list.dart';
 export 'src/components/divider/divider.dart';
 export 'src/components/menu/menu.dart';
 export 'src/components/popover/popover.dart';

--- a/packages/remix/lib/src/components/data_list/data_list.dart
+++ b/packages/remix/lib/src/components/data_list/data_list.dart
@@ -1,0 +1,17 @@
+library remix_data_list;
+
+import 'dart:ui' show SemanticsRole;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart'
+    show RenderTable, SemanticsConfiguration, SemanticsNode, TableCellParentData;
+import 'package:mix/mix.dart';
+import 'package:mix_annotations/mix_annotations.dart';
+
+import '../../utilities/remix_style.dart';
+
+part 'data_list_spec.dart';
+part 'data_list_style.dart';
+part 'data_list_widget.dart';
+part 'data_list.g.dart';

--- a/packages/remix/lib/src/components/data_list/data_list.dart
+++ b/packages/remix/lib/src/components/data_list/data_list.dart
@@ -7,6 +7,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart'
     show
         BoxParentData,
+        RenderObject,
+        RenderParagraph,
         RenderProxyBox,
         RenderTable,
         SemanticsConfiguration,

--- a/packages/remix/lib/src/components/data_list/data_list.dart
+++ b/packages/remix/lib/src/components/data_list/data_list.dart
@@ -5,7 +5,13 @@ import 'dart:ui' show SemanticsRole;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart'
-    show RenderTable, SemanticsConfiguration, SemanticsNode, TableCellParentData;
+    show
+        BoxParentData,
+        RenderProxyBox,
+        RenderTable,
+        SemanticsConfiguration,
+        SemanticsNode,
+        TableCellParentData;
 import 'package:mix/mix.dart';
 import 'package:mix_annotations/mix_annotations.dart';
 

--- a/packages/remix/lib/src/components/data_list/data_list.g.dart
+++ b/packages/remix/lib/src/components/data_list/data_list.g.dart
@@ -754,6 +754,23 @@ class DataListStyler extends MixStyler<DataListStyler, DataListSpec>
     return merge(DataListStyler(modifier: value));
   }
 
+  RemixDataList call({
+    Key? key,
+    required List<RemixDataListItem> items,
+    Axis orientation = Axis.horizontal,
+    String? semanticLabel,
+    bool excludeSemantics = false,
+  }) {
+    return RemixDataList(
+      key: key,
+      style: this,
+      items: items,
+      orientation: orientation,
+      semanticLabel: semanticLabel,
+      excludeSemantics: excludeSemantics,
+    );
+  }
+
   /// Merges with another [DataListStyler].
   @override
   DataListStyler merge(DataListStyler? other) {

--- a/packages/remix/lib/src/components/data_list/data_list.g.dart
+++ b/packages/remix/lib/src/components/data_list/data_list.g.dart
@@ -1,0 +1,831 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'data_list.dart';
+
+// **************************************************************************
+// SpecGenerator
+// **************************************************************************
+
+mixin _$DataListSpec implements Spec<DataListSpec>, Diagnosticable {
+  StyleSpec<BoxSpec> get container;
+  StyleSpec<BoxSpec> get labelContainer;
+  StyleSpec<BoxSpec> get valueContainer;
+  StyleSpec<TextSpec> get label;
+  StyleSpec<TextSpec> get value;
+  double? get rowSpacing;
+  double? get columnSpacing;
+  double? get labelValueSpacing;
+  double? get minLabelWidth;
+
+  @override
+  Type get type => DataListSpec;
+
+  @override
+  DataListSpec copyWith({
+    StyleSpec<BoxSpec>? container,
+    StyleSpec<BoxSpec>? labelContainer,
+    StyleSpec<BoxSpec>? valueContainer,
+    StyleSpec<TextSpec>? label,
+    StyleSpec<TextSpec>? value,
+    double? rowSpacing,
+    double? columnSpacing,
+    double? labelValueSpacing,
+    double? minLabelWidth,
+  }) {
+    return DataListSpec(
+      container: container ?? this.container,
+      labelContainer: labelContainer ?? this.labelContainer,
+      valueContainer: valueContainer ?? this.valueContainer,
+      label: label ?? this.label,
+      value: value ?? this.value,
+      rowSpacing: rowSpacing ?? this.rowSpacing,
+      columnSpacing: columnSpacing ?? this.columnSpacing,
+      labelValueSpacing: labelValueSpacing ?? this.labelValueSpacing,
+      minLabelWidth: minLabelWidth ?? this.minLabelWidth,
+    );
+  }
+
+  @override
+  DataListSpec lerp(DataListSpec? other, double t) {
+    return DataListSpec(
+      container: container.lerp(other?.container, t),
+      labelContainer: labelContainer.lerp(other?.labelContainer, t),
+      valueContainer: valueContainer.lerp(other?.valueContainer, t),
+      label: label.lerp(other?.label, t),
+      value: value.lerp(other?.value, t),
+      rowSpacing: MixOps.lerp(rowSpacing, other?.rowSpacing, t),
+      columnSpacing: MixOps.lerp(columnSpacing, other?.columnSpacing, t),
+      labelValueSpacing: MixOps.lerp(
+        labelValueSpacing,
+        other?.labelValueSpacing,
+        t,
+      ),
+      minLabelWidth: MixOps.lerp(minLabelWidth, other?.minLabelWidth, t),
+    );
+  }
+
+  @override
+  List<Object?> get props => [
+    container,
+    labelContainer,
+    valueContainer,
+    label,
+    value,
+    rowSpacing,
+    columnSpacing,
+    labelValueSpacing,
+    minLabelWidth,
+  ];
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        other is DataListSpec &&
+            runtimeType == other.runtimeType &&
+            propsEquals(props, other.props);
+  }
+
+  @override
+  int get hashCode => propsHash(runtimeType, props);
+
+  @override
+  bool get stringify => true;
+
+  @override
+  Map<String, String> getDiff(Equatable other) {
+    if (this == other) return const {};
+
+    return propsDiff(props, other.props);
+  }
+
+  @override
+  String toStringShort() => '$runtimeType';
+
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) =>
+      toDiagnosticsNode(
+        style: DiagnosticsTreeStyle.singleLine,
+      ).toString(minLevel: minLevel);
+
+  @override
+  DiagnosticsNode toDiagnosticsNode({
+    String? name,
+    DiagnosticsTreeStyle? style,
+  }) =>
+      DiagnosticableNode<Diagnosticable>(name: name, value: this, style: style);
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    properties
+      ..add(DiagnosticsProperty('container', container))
+      ..add(DiagnosticsProperty('labelContainer', labelContainer))
+      ..add(DiagnosticsProperty('valueContainer', valueContainer))
+      ..add(DiagnosticsProperty('label', label))
+      ..add(DiagnosticsProperty('value', value))
+      ..add(DoubleProperty('rowSpacing', rowSpacing))
+      ..add(DoubleProperty('columnSpacing', columnSpacing))
+      ..add(DoubleProperty('labelValueSpacing', labelValueSpacing))
+      ..add(DoubleProperty('minLabelWidth', minLabelWidth));
+  }
+}
+
+@Deprecated(
+  'Rename to `_\$DataListSpec` and migrate the class declaration to `class DataListSpec with _\$DataListSpec`. The `_\$DataListSpecMethods` alias will be removed in mix_generator 3.0.',
+)
+typedef _$DataListSpecMethods = _$DataListSpec; // ignore: unused_element
+
+// **************************************************************************
+// SpecStylerGenerator
+// **************************************************************************
+
+class DataListStyler extends MixStyler<DataListStyler, DataListSpec>
+    with RemixBoxStylerMixin<DataListStyler> {
+  final Prop<StyleSpec<BoxSpec>>? $container;
+  final Prop<StyleSpec<BoxSpec>>? $labelContainer;
+  final Prop<StyleSpec<BoxSpec>>? $valueContainer;
+  final Prop<StyleSpec<TextSpec>>? $label;
+  final Prop<StyleSpec<TextSpec>>? $value;
+  final Prop<double>? $rowSpacing;
+  final Prop<double>? $columnSpacing;
+  final Prop<double>? $labelValueSpacing;
+  final Prop<double>? $minLabelWidth;
+
+  const DataListStyler.create({
+    Prop<StyleSpec<BoxSpec>>? container,
+    Prop<StyleSpec<BoxSpec>>? labelContainer,
+    Prop<StyleSpec<BoxSpec>>? valueContainer,
+    Prop<StyleSpec<TextSpec>>? label,
+    Prop<StyleSpec<TextSpec>>? value,
+    Prop<double>? rowSpacing,
+    Prop<double>? columnSpacing,
+    Prop<double>? labelValueSpacing,
+    Prop<double>? minLabelWidth,
+    super.variants,
+    super.modifier,
+    super.animation,
+  }) : $container = container,
+       $labelContainer = labelContainer,
+       $valueContainer = valueContainer,
+       $label = label,
+       $value = value,
+       $rowSpacing = rowSpacing,
+       $columnSpacing = columnSpacing,
+       $labelValueSpacing = labelValueSpacing,
+       $minLabelWidth = minLabelWidth;
+
+  DataListStyler({
+    BoxStyler? container,
+    BoxStyler? labelContainer,
+    BoxStyler? valueContainer,
+    TextStyler? label,
+    TextStyler? value,
+    double? rowSpacing,
+    double? columnSpacing,
+    double? labelValueSpacing,
+    double? minLabelWidth,
+    AnimationConfig? animation,
+    WidgetModifierConfig? modifier,
+    List<VariantStyle<DataListSpec>>? variants,
+  }) : this.create(
+         container: Prop.maybeMix(container),
+         labelContainer: Prop.maybeMix(labelContainer),
+         valueContainer: Prop.maybeMix(valueContainer),
+         label: Prop.maybeMix(label),
+         value: Prop.maybeMix(value),
+         rowSpacing: Prop.maybe(rowSpacing),
+         columnSpacing: Prop.maybe(columnSpacing),
+         labelValueSpacing: Prop.maybe(labelValueSpacing),
+         minLabelWidth: Prop.maybe(minLabelWidth),
+         variants: variants,
+         modifier: modifier,
+         animation: animation,
+       );
+
+  factory DataListStyler.container(BoxStyler value) =>
+      DataListStyler().container(value);
+  factory DataListStyler.labelContainer(BoxStyler value) =>
+      DataListStyler().labelContainer(value);
+  factory DataListStyler.valueContainer(BoxStyler value) =>
+      DataListStyler().valueContainer(value);
+  factory DataListStyler.label(TextStyler value) =>
+      DataListStyler().label(value);
+  factory DataListStyler.value(TextStyler value) =>
+      DataListStyler().value(value);
+  factory DataListStyler.rowSpacing(double value) =>
+      DataListStyler().rowSpacing(value);
+  factory DataListStyler.columnSpacing(double value) =>
+      DataListStyler().columnSpacing(value);
+  factory DataListStyler.labelValueSpacing(double value) =>
+      DataListStyler().labelValueSpacing(value);
+  factory DataListStyler.minLabelWidth(double value) =>
+      DataListStyler().minLabelWidth(value);
+  factory DataListStyler.alignment(AlignmentGeometry value) =>
+      DataListStyler().alignment(value);
+  factory DataListStyler.padding(EdgeInsetsGeometryMix value) =>
+      DataListStyler().padding(value);
+  factory DataListStyler.margin(EdgeInsetsGeometryMix value) =>
+      DataListStyler().margin(value);
+  factory DataListStyler.constraints(BoxConstraintsMix value) =>
+      DataListStyler().constraints(value);
+  factory DataListStyler.decoration(DecorationMix value) =>
+      DataListStyler().decoration(value);
+  factory DataListStyler.foregroundDecoration(DecorationMix value) =>
+      DataListStyler().foregroundDecoration(value);
+  factory DataListStyler.clipBehavior(Clip value) =>
+      DataListStyler().clipBehavior(value);
+  factory DataListStyler.color(Color value) => DataListStyler().color(value);
+  factory DataListStyler.gradient(GradientMix value) =>
+      DataListStyler().gradient(value);
+  factory DataListStyler.border(BoxBorderMix value) =>
+      DataListStyler().border(value);
+  factory DataListStyler.borderRadius(BorderRadiusGeometryMix value) =>
+      DataListStyler().borderRadius(value);
+  factory DataListStyler.elevation(ElevationShadow value) =>
+      DataListStyler().elevation(value);
+  factory DataListStyler.shadow(BoxShadowMix value) =>
+      DataListStyler().shadow(value);
+  factory DataListStyler.shadows(List<BoxShadowMix> value) =>
+      DataListStyler().shadows(value);
+  factory DataListStyler.width(double value) => DataListStyler().width(value);
+  factory DataListStyler.height(double value) => DataListStyler().height(value);
+  factory DataListStyler.size(double width, double height) =>
+      DataListStyler().size(width, height);
+  factory DataListStyler.minWidth(double value) =>
+      DataListStyler().minWidth(value);
+  factory DataListStyler.maxWidth(double value) =>
+      DataListStyler().maxWidth(value);
+  factory DataListStyler.minHeight(double value) =>
+      DataListStyler().minHeight(value);
+  factory DataListStyler.maxHeight(double value) =>
+      DataListStyler().maxHeight(value);
+  factory DataListStyler.scale(double scale, {Alignment alignment = .center}) =>
+      DataListStyler().scale(scale, alignment: alignment);
+  factory DataListStyler.rotate(
+    double radians, {
+    Alignment alignment = .center,
+  }) => DataListStyler().rotate(radians, alignment: alignment);
+  factory DataListStyler.translate(double x, double y, [double z = 0.0]) =>
+      DataListStyler().translate(x, y, z);
+  factory DataListStyler.skew(double skewX, double skewY) =>
+      DataListStyler().skew(skewX, skewY);
+  factory DataListStyler.textStyle(TextStyler value) =>
+      DataListStyler().textStyle(value);
+  factory DataListStyler.image(DecorationImageMix value) =>
+      DataListStyler().image(value);
+  factory DataListStyler.shape(ShapeBorderMix value) =>
+      DataListStyler().shape(value);
+  factory DataListStyler.backgroundImage(
+    ImageProvider image, {
+    BoxFit? fit,
+    AlignmentGeometry? alignment,
+    ImageRepeat repeat = .noRepeat,
+  }) => DataListStyler().backgroundImage(
+    image,
+    fit: fit,
+    alignment: alignment,
+    repeat: repeat,
+  );
+  factory DataListStyler.backgroundImageUrl(
+    String url, {
+    BoxFit? fit,
+    AlignmentGeometry? alignment,
+    ImageRepeat repeat = .noRepeat,
+  }) => DataListStyler().backgroundImageUrl(
+    url,
+    fit: fit,
+    alignment: alignment,
+    repeat: repeat,
+  );
+  factory DataListStyler.backgroundImageAsset(
+    String path, {
+    BoxFit? fit,
+    AlignmentGeometry? alignment,
+    ImageRepeat repeat = .noRepeat,
+  }) => DataListStyler().backgroundImageAsset(
+    path,
+    fit: fit,
+    alignment: alignment,
+    repeat: repeat,
+  );
+  factory DataListStyler.linearGradient({
+    required List<Color> colors,
+    List<double>? stops,
+    AlignmentGeometry? begin,
+    AlignmentGeometry? end,
+    TileMode? tileMode,
+  }) => DataListStyler().linearGradient(
+    colors: colors,
+    stops: stops,
+    begin: begin,
+    end: end,
+    tileMode: tileMode,
+  );
+  factory DataListStyler.radialGradient({
+    required List<Color> colors,
+    List<double>? stops,
+    AlignmentGeometry? center,
+    double? radius,
+    AlignmentGeometry? focal,
+    double? focalRadius,
+    TileMode? tileMode,
+  }) => DataListStyler().radialGradient(
+    colors: colors,
+    stops: stops,
+    center: center,
+    radius: radius,
+    focal: focal,
+    focalRadius: focalRadius,
+    tileMode: tileMode,
+  );
+  factory DataListStyler.sweepGradient({
+    required List<Color> colors,
+    List<double>? stops,
+    AlignmentGeometry? center,
+    double? startAngle,
+    double? endAngle,
+    TileMode? tileMode,
+  }) => DataListStyler().sweepGradient(
+    colors: colors,
+    stops: stops,
+    center: center,
+    startAngle: startAngle,
+    endAngle: endAngle,
+    tileMode: tileMode,
+  );
+  factory DataListStyler.foregroundLinearGradient({
+    required List<Color> colors,
+    List<double>? stops,
+    AlignmentGeometry? begin,
+    AlignmentGeometry? end,
+    TileMode? tileMode,
+  }) => DataListStyler().foregroundLinearGradient(
+    colors: colors,
+    stops: stops,
+    begin: begin,
+    end: end,
+    tileMode: tileMode,
+  );
+  factory DataListStyler.foregroundRadialGradient({
+    required List<Color> colors,
+    List<double>? stops,
+    AlignmentGeometry? center,
+    double? radius,
+    AlignmentGeometry? focal,
+    double? focalRadius,
+    TileMode? tileMode,
+  }) => DataListStyler().foregroundRadialGradient(
+    colors: colors,
+    stops: stops,
+    center: center,
+    radius: radius,
+    focal: focal,
+    focalRadius: focalRadius,
+    tileMode: tileMode,
+  );
+  factory DataListStyler.foregroundSweepGradient({
+    required List<Color> colors,
+    List<double>? stops,
+    AlignmentGeometry? center,
+    double? startAngle,
+    double? endAngle,
+    TileMode? tileMode,
+  }) => DataListStyler().foregroundSweepGradient(
+    colors: colors,
+    stops: stops,
+    center: center,
+    startAngle: startAngle,
+    endAngle: endAngle,
+    tileMode: tileMode,
+  );
+  factory DataListStyler.transform(
+    Matrix4 value, {
+    Alignment alignment = .center,
+  }) => DataListStyler().transform(value, alignment: alignment);
+
+  DataListStyler alignment(AlignmentGeometry value) {
+    return container(BoxStyler().alignment(value));
+  }
+
+  DataListStyler padding(EdgeInsetsGeometryMix value) {
+    return container(BoxStyler().padding(value));
+  }
+
+  DataListStyler margin(EdgeInsetsGeometryMix value) {
+    return container(BoxStyler().margin(value));
+  }
+
+  DataListStyler constraints(BoxConstraintsMix value) {
+    return container(BoxStyler().constraints(value));
+  }
+
+  DataListStyler decoration(DecorationMix value) {
+    return container(BoxStyler().decoration(value));
+  }
+
+  DataListStyler foregroundDecoration(DecorationMix value) {
+    return container(BoxStyler().foregroundDecoration(value));
+  }
+
+  DataListStyler clipBehavior(Clip value) {
+    return container(BoxStyler().clipBehavior(value));
+  }
+
+  DataListStyler color(Color value) {
+    return container(BoxStyler().color(value));
+  }
+
+  DataListStyler gradient(GradientMix value) {
+    return container(BoxStyler().gradient(value));
+  }
+
+  DataListStyler border(BoxBorderMix value) {
+    return container(BoxStyler().border(value));
+  }
+
+  DataListStyler borderRadius(BorderRadiusGeometryMix value) {
+    return container(BoxStyler().borderRadius(value));
+  }
+
+  DataListStyler elevation(ElevationShadow value) {
+    return container(BoxStyler().elevation(value));
+  }
+
+  DataListStyler shadow(BoxShadowMix value) {
+    return container(BoxStyler().shadow(value));
+  }
+
+  DataListStyler shadows(List<BoxShadowMix> value) {
+    return container(BoxStyler().shadows(value));
+  }
+
+  DataListStyler width(double value) {
+    return container(BoxStyler().width(value));
+  }
+
+  DataListStyler height(double value) {
+    return container(BoxStyler().height(value));
+  }
+
+  DataListStyler size(double width, double height) {
+    return container(BoxStyler().size(width, height));
+  }
+
+  DataListStyler minWidth(double value) {
+    return container(BoxStyler().minWidth(value));
+  }
+
+  DataListStyler maxWidth(double value) {
+    return container(BoxStyler().maxWidth(value));
+  }
+
+  DataListStyler minHeight(double value) {
+    return container(BoxStyler().minHeight(value));
+  }
+
+  DataListStyler maxHeight(double value) {
+    return container(BoxStyler().maxHeight(value));
+  }
+
+  DataListStyler scale(double scale, {Alignment alignment = .center}) {
+    return container(BoxStyler().scale(scale, alignment: alignment));
+  }
+
+  DataListStyler rotate(double radians, {Alignment alignment = .center}) {
+    return container(BoxStyler().rotate(radians, alignment: alignment));
+  }
+
+  DataListStyler translate(double x, double y, [double z = 0.0]) {
+    return container(BoxStyler().translate(x, y, z));
+  }
+
+  DataListStyler skew(double skewX, double skewY) {
+    return container(BoxStyler().skew(skewX, skewY));
+  }
+
+  DataListStyler textStyle(TextStyler value) {
+    return container(BoxStyler().textStyle(value));
+  }
+
+  DataListStyler image(DecorationImageMix value) {
+    return container(BoxStyler().image(value));
+  }
+
+  DataListStyler shape(ShapeBorderMix value) {
+    return container(BoxStyler().shape(value));
+  }
+
+  DataListStyler backgroundImage(
+    ImageProvider image, {
+    BoxFit? fit,
+    AlignmentGeometry? alignment,
+    ImageRepeat repeat = .noRepeat,
+  }) {
+    return container(
+      BoxStyler().backgroundImage(
+        image,
+        fit: fit,
+        alignment: alignment,
+        repeat: repeat,
+      ),
+    );
+  }
+
+  DataListStyler backgroundImageUrl(
+    String url, {
+    BoxFit? fit,
+    AlignmentGeometry? alignment,
+    ImageRepeat repeat = .noRepeat,
+  }) {
+    return container(
+      BoxStyler().backgroundImageUrl(
+        url,
+        fit: fit,
+        alignment: alignment,
+        repeat: repeat,
+      ),
+    );
+  }
+
+  DataListStyler backgroundImageAsset(
+    String path, {
+    BoxFit? fit,
+    AlignmentGeometry? alignment,
+    ImageRepeat repeat = .noRepeat,
+  }) {
+    return container(
+      BoxStyler().backgroundImageAsset(
+        path,
+        fit: fit,
+        alignment: alignment,
+        repeat: repeat,
+      ),
+    );
+  }
+
+  DataListStyler linearGradient({
+    required List<Color> colors,
+    List<double>? stops,
+    AlignmentGeometry? begin,
+    AlignmentGeometry? end,
+    TileMode? tileMode,
+  }) {
+    return container(
+      BoxStyler().linearGradient(
+        colors: colors,
+        stops: stops,
+        begin: begin,
+        end: end,
+        tileMode: tileMode,
+      ),
+    );
+  }
+
+  DataListStyler radialGradient({
+    required List<Color> colors,
+    List<double>? stops,
+    AlignmentGeometry? center,
+    double? radius,
+    AlignmentGeometry? focal,
+    double? focalRadius,
+    TileMode? tileMode,
+  }) {
+    return container(
+      BoxStyler().radialGradient(
+        colors: colors,
+        stops: stops,
+        center: center,
+        radius: radius,
+        focal: focal,
+        focalRadius: focalRadius,
+        tileMode: tileMode,
+      ),
+    );
+  }
+
+  DataListStyler sweepGradient({
+    required List<Color> colors,
+    List<double>? stops,
+    AlignmentGeometry? center,
+    double? startAngle,
+    double? endAngle,
+    TileMode? tileMode,
+  }) {
+    return container(
+      BoxStyler().sweepGradient(
+        colors: colors,
+        stops: stops,
+        center: center,
+        startAngle: startAngle,
+        endAngle: endAngle,
+        tileMode: tileMode,
+      ),
+    );
+  }
+
+  DataListStyler foregroundLinearGradient({
+    required List<Color> colors,
+    List<double>? stops,
+    AlignmentGeometry? begin,
+    AlignmentGeometry? end,
+    TileMode? tileMode,
+  }) {
+    return container(
+      BoxStyler().foregroundLinearGradient(
+        colors: colors,
+        stops: stops,
+        begin: begin,
+        end: end,
+        tileMode: tileMode,
+      ),
+    );
+  }
+
+  DataListStyler foregroundRadialGradient({
+    required List<Color> colors,
+    List<double>? stops,
+    AlignmentGeometry? center,
+    double? radius,
+    AlignmentGeometry? focal,
+    double? focalRadius,
+    TileMode? tileMode,
+  }) {
+    return container(
+      BoxStyler().foregroundRadialGradient(
+        colors: colors,
+        stops: stops,
+        center: center,
+        radius: radius,
+        focal: focal,
+        focalRadius: focalRadius,
+        tileMode: tileMode,
+      ),
+    );
+  }
+
+  DataListStyler foregroundSweepGradient({
+    required List<Color> colors,
+    List<double>? stops,
+    AlignmentGeometry? center,
+    double? startAngle,
+    double? endAngle,
+    TileMode? tileMode,
+  }) {
+    return container(
+      BoxStyler().foregroundSweepGradient(
+        colors: colors,
+        stops: stops,
+        center: center,
+        startAngle: startAngle,
+        endAngle: endAngle,
+        tileMode: tileMode,
+      ),
+    );
+  }
+
+  DataListStyler transform(Matrix4 value, {Alignment alignment = .center}) {
+    return container(BoxStyler().transform(value, alignment: alignment));
+  }
+
+  /// Sets the container.
+  DataListStyler container(BoxStyler value) {
+    return merge(DataListStyler(container: value));
+  }
+
+  /// Sets the labelContainer.
+  DataListStyler labelContainer(BoxStyler value) {
+    return merge(DataListStyler(labelContainer: value));
+  }
+
+  /// Sets the valueContainer.
+  DataListStyler valueContainer(BoxStyler value) {
+    return merge(DataListStyler(valueContainer: value));
+  }
+
+  /// Sets the label.
+  DataListStyler label(TextStyler value) {
+    return merge(DataListStyler(label: value));
+  }
+
+  /// Sets the value.
+  DataListStyler value(TextStyler value) {
+    return merge(DataListStyler(value: value));
+  }
+
+  /// Sets the rowSpacing.
+  DataListStyler rowSpacing(double value) {
+    return merge(DataListStyler(rowSpacing: value));
+  }
+
+  /// Sets the columnSpacing.
+  DataListStyler columnSpacing(double value) {
+    return merge(DataListStyler(columnSpacing: value));
+  }
+
+  /// Sets the labelValueSpacing.
+  DataListStyler labelValueSpacing(double value) {
+    return merge(DataListStyler(labelValueSpacing: value));
+  }
+
+  /// Sets the minLabelWidth.
+  DataListStyler minLabelWidth(double value) {
+    return merge(DataListStyler(minLabelWidth: value));
+  }
+
+  /// Sets the animation configuration.
+  @override
+  DataListStyler animate(AnimationConfig value) {
+    return merge(DataListStyler(animation: value));
+  }
+
+  /// Sets the style variants.
+  @override
+  DataListStyler variants(List<VariantStyle<DataListSpec>> value) {
+    return merge(DataListStyler(variants: value));
+  }
+
+  /// Wraps with a widget modifier.
+  @override
+  DataListStyler wrap(WidgetModifierConfig value) {
+    return merge(DataListStyler(modifier: value));
+  }
+
+  /// Sets the widget modifier.
+  DataListStyler modifier(WidgetModifierConfig value) {
+    return merge(DataListStyler(modifier: value));
+  }
+
+  /// Merges with another [DataListStyler].
+  @override
+  DataListStyler merge(DataListStyler? other) {
+    return DataListStyler.create(
+      container: MixOps.merge($container, other?.$container),
+      labelContainer: MixOps.merge($labelContainer, other?.$labelContainer),
+      valueContainer: MixOps.merge($valueContainer, other?.$valueContainer),
+      label: MixOps.merge($label, other?.$label),
+      value: MixOps.merge($value, other?.$value),
+      rowSpacing: MixOps.merge($rowSpacing, other?.$rowSpacing),
+      columnSpacing: MixOps.merge($columnSpacing, other?.$columnSpacing),
+      labelValueSpacing: MixOps.merge(
+        $labelValueSpacing,
+        other?.$labelValueSpacing,
+      ),
+      minLabelWidth: MixOps.merge($minLabelWidth, other?.$minLabelWidth),
+      variants: MixOps.mergeVariants($variants, other?.$variants),
+      modifier: MixOps.mergeModifier($modifier, other?.$modifier),
+      animation: MixOps.mergeAnimation($animation, other?.$animation),
+    );
+  }
+
+  /// Resolves to [StyleSpec<DataListSpec>] using [context].
+  @override
+  StyleSpec<DataListSpec> resolve(BuildContext context) {
+    final spec = DataListSpec(
+      container: MixOps.resolve(context, $container),
+      labelContainer: MixOps.resolve(context, $labelContainer),
+      valueContainer: MixOps.resolve(context, $valueContainer),
+      label: MixOps.resolve(context, $label),
+      value: MixOps.resolve(context, $value),
+      rowSpacing: MixOps.resolve(context, $rowSpacing),
+      columnSpacing: MixOps.resolve(context, $columnSpacing),
+      labelValueSpacing: MixOps.resolve(context, $labelValueSpacing),
+      minLabelWidth: MixOps.resolve(context, $minLabelWidth),
+    );
+
+    return StyleSpec(
+      spec: spec,
+      animation: $animation,
+      widgetModifiers: $modifier?.resolve(context),
+    );
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties
+      ..add(DiagnosticsProperty('container', $container))
+      ..add(DiagnosticsProperty('labelContainer', $labelContainer))
+      ..add(DiagnosticsProperty('valueContainer', $valueContainer))
+      ..add(DiagnosticsProperty('label', $label))
+      ..add(DiagnosticsProperty('value', $value))
+      ..add(DiagnosticsProperty('rowSpacing', $rowSpacing))
+      ..add(DiagnosticsProperty('columnSpacing', $columnSpacing))
+      ..add(DiagnosticsProperty('labelValueSpacing', $labelValueSpacing))
+      ..add(DiagnosticsProperty('minLabelWidth', $minLabelWidth));
+  }
+
+  @override
+  List<Object?> get props => [
+    $container,
+    $labelContainer,
+    $valueContainer,
+    $label,
+    $value,
+    $rowSpacing,
+    $columnSpacing,
+    $labelValueSpacing,
+    $minLabelWidth,
+    $animation,
+    $modifier,
+    $variants,
+  ];
+}

--- a/packages/remix/lib/src/components/data_list/data_list_spec.dart
+++ b/packages/remix/lib/src/components/data_list/data_list_spec.dart
@@ -1,0 +1,55 @@
+part of 'data_list.dart';
+
+/// Resolved visual values for a [RemixDataList].
+///
+/// Geometry scalars stay null here and default to zero at render time; the
+/// unopinionated Remix renderer carries no Radix metrics such as the 120 px
+/// label minimum. Orientation is deliberately not part of the spec: it is
+/// semantic layout behavior owned by the [RemixDataList] constructor, so
+/// styles cannot override it.
+@MixableSpec(extraStylerMixins: [RemixBoxStylerMixin])
+class DataListSpec with _$DataListSpec {
+  @override
+  @MixableField(forwardStyler: true)
+  final StyleSpec<BoxSpec> container;
+  @override
+  final StyleSpec<BoxSpec> labelContainer;
+  @override
+  final StyleSpec<BoxSpec> valueContainer;
+  @override
+  final StyleSpec<TextSpec> label;
+  @override
+  final StyleSpec<TextSpec> value;
+
+  /// Gap between items along the list's main axis.
+  @override
+  final double? rowSpacing;
+
+  /// Directional horizontal gap between the label and value columns.
+  @override
+  final double? columnSpacing;
+
+  /// Inner vertical gap between label and value in vertical orientation.
+  @override
+  final double? labelValueSpacing;
+
+  /// Minimum width of the shared horizontal label column.
+  @override
+  final double? minLabelWidth;
+
+  const DataListSpec({
+    StyleSpec<BoxSpec>? container,
+    StyleSpec<BoxSpec>? labelContainer,
+    StyleSpec<BoxSpec>? valueContainer,
+    StyleSpec<TextSpec>? label,
+    StyleSpec<TextSpec>? value,
+    this.rowSpacing,
+    this.columnSpacing,
+    this.labelValueSpacing,
+    this.minLabelWidth,
+  }) : container = container ?? const StyleSpec(spec: BoxSpec()),
+       labelContainer = labelContainer ?? const StyleSpec(spec: BoxSpec()),
+       valueContainer = valueContainer ?? const StyleSpec(spec: BoxSpec()),
+       label = label ?? const StyleSpec(spec: TextSpec()),
+       value = value ?? const StyleSpec(spec: TextSpec());
+}

--- a/packages/remix/lib/src/components/data_list/data_list_spec.dart
+++ b/packages/remix/lib/src/components/data_list/data_list_spec.dart
@@ -7,7 +7,10 @@ part of 'data_list.dart';
 /// label minimum. Orientation is deliberately not part of the spec: it is
 /// semantic layout behavior owned by the [RemixDataList] constructor, so
 /// styles cannot override it.
-@MixableSpec(extraStylerMixins: [RemixBoxStylerMixin])
+@MixableSpec(
+  target: RemixDataList.new,
+  extraStylerMixins: [RemixBoxStylerMixin],
+)
 class DataListSpec with _$DataListSpec {
   @override
   @MixableField(forwardStyler: true)

--- a/packages/remix/lib/src/components/data_list/data_list_style.dart
+++ b/packages/remix/lib/src/components/data_list/data_list_style.dart
@@ -1,0 +1,42 @@
+part of 'data_list.dart';
+
+/// Style helpers for [RemixDataList] label/value typography.
+extension RemixDataListStylerRemixHelpers on DataListStyler {
+  /// Sets the label text style.
+  DataListStyler labelTextStyle(TextStyleMix style) {
+    return label(TextStyler(style: style));
+  }
+
+  /// Sets the label text color.
+  DataListStyler labelColor(Color color) {
+    return label(TextStyler(style: TextStyleMix(color: color)));
+  }
+
+  /// Sets the value text style.
+  DataListStyler valueTextStyle(TextStyleMix style) {
+    return value(TextStyler(style: style));
+  }
+
+  /// Sets the value text color.
+  DataListStyler valueColor(Color color) {
+    return value(TextStyler(style: TextStyleMix(color: color)));
+  }
+
+  /// Creates a [RemixDataList] widget with this style applied.
+  RemixDataList call({
+    Key? key,
+    required List<RemixDataListItem> items,
+    Axis orientation = Axis.horizontal,
+    String? semanticLabel,
+    bool excludeSemantics = false,
+  }) {
+    return RemixDataList(
+      key: key,
+      items: items,
+      orientation: orientation,
+      semanticLabel: semanticLabel,
+      excludeSemantics: excludeSemantics,
+      style: this,
+    );
+  }
+}

--- a/packages/remix/lib/src/components/data_list/data_list_style.dart
+++ b/packages/remix/lib/src/components/data_list/data_list_style.dart
@@ -21,22 +21,4 @@ extension RemixDataListStylerRemixHelpers on DataListStyler {
   DataListStyler valueColor(Color color) {
     return value(TextStyler(style: TextStyleMix(color: color)));
   }
-
-  /// Creates a [RemixDataList] widget with this style applied.
-  RemixDataList call({
-    Key? key,
-    required List<RemixDataListItem> items,
-    Axis orientation = Axis.horizontal,
-    String? semanticLabel,
-    bool excludeSemantics = false,
-  }) {
-    return RemixDataList(
-      key: key,
-      items: items,
-      orientation: orientation,
-      semanticLabel: semanticLabel,
-      excludeSemantics: excludeSemantics,
-      style: this,
-    );
-  }
 }

--- a/packages/remix/lib/src/components/data_list/data_list_widget.dart
+++ b/packages/remix/lib/src/components/data_list/data_list_widget.dart
@@ -13,6 +13,7 @@ enum RemixDataListItemAlignment { start, center, end, baseline, stretch }
 @immutable
 class RemixDataListItem {
   const RemixDataListItem({
+    this.key,
     required this.label,
     this.value,
     this.child,
@@ -36,10 +37,25 @@ class RemixDataListItem {
          'RemixDataListItem.semanticValue must be nonempty when provided.',
        );
 
+  /// Stable identity for this row across list mutations.
+  ///
+  /// Without a key, rows are matched by position, so a stateful [child]
+  /// keeps its state at the old position after a reorder and can end up
+  /// attached to the wrong label. Provide a key whenever items with custom
+  /// children are reordered, inserted, or removed.
+  final LocalKey? key;
+
   /// Visible label text, also announced as the row's semantic label.
+  ///
+  /// Must be nonempty and not whitespace-only: the const constructor rejects
+  /// the empty string, and the renderer additionally rejects trimmed-blank
+  /// text in debug builds. The text itself is never trimmed.
   final String label;
 
   /// String value rendered with the data list's value typography.
+  ///
+  /// When provided, must be nonempty and not whitespace-only; it is
+  /// announced as the row's accessible value verbatim.
   final String? value;
 
   /// Custom value widget that keeps its own semantics unless [semanticValue]
@@ -50,7 +66,7 @@ class RemixDataListItem {
   ///
   /// Only for display-only children: it excludes the child's semantics
   /// entirely, so an interactive child must omit it to keep its actions
-  /// reachable.
+  /// reachable. When provided, must be nonempty and not whitespace-only.
   final String? semanticValue;
 
   /// Cross-cell alignment for this row.
@@ -74,9 +90,11 @@ class RemixDataListItem {
 /// For a bounded horizontal list, the supported width is at least the
 /// resolved label column minimum (the greater of `minLabelWidth` and every
 /// label's minimum intrinsic width) plus `columnSpacing` plus the value
-/// column's minimum intrinsic width. Below that bound the pinned label column
-/// cannot fit and content overflows; the renderer never switches orientation
-/// on its own, so rebuild with [orientation] set to [Axis.vertical] when the
+/// column's minimum intrinsic width. Down to that bound, a long label wraps
+/// rather than starving the value column, which never shrinks below its
+/// minimum intrinsic width. Below the bound the pinned label column cannot
+/// fit and content overflows; the renderer never switches orientation on its
+/// own, so rebuild with [orientation] set to [Axis.vertical] when the
 /// available width is below the minimum.
 ///
 /// ## Example
@@ -95,7 +113,7 @@ class RemixDataListItem {
 // `Table` is reused as the horizontal layout because it is the one primitive
 // that negotiates a single shared label-column width across every row;
 // independent per-item Rows would let the columns drift.
-class RemixDataList extends StatelessWidget {
+class RemixDataList extends StyleWidget<DataListSpec> {
   /// Creates a data list from [items].
   const RemixDataList({
     super.key,
@@ -103,8 +121,8 @@ class RemixDataList extends StatelessWidget {
     this.orientation = Axis.horizontal,
     this.semanticLabel,
     this.excludeSemantics = false,
-    this.style = const DataListStyler.create(),
-    this.styleSpec,
+    super.style = const DataListStyler.create(),
+    super.styleSpec,
   });
 
   static final styleFrom = DataListStyler.new;
@@ -121,53 +139,72 @@ class RemixDataList extends StatelessWidget {
   final Axis orientation;
 
   /// Optional accessible name for the list itself.
+  ///
+  /// When provided, must not be whitespace-only (asserted in debug builds).
   final String? semanticLabel;
 
   /// Whether to remove the entire list, rows included, from semantics.
   final bool excludeSemantics;
 
-  /// The style configuration for the data list.
-  final DataListStyler style;
-
-  /// Optional raw style spec that bypasses fluent style resolution.
-  final DataListSpec? styleSpec;
-
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, DataListSpec spec) {
     // One immutable snapshot per build enforces the no-mutation-during-build
     // contract for everything rendered below.
     final rows = List<RemixDataListItem>.unmodifiable(items);
+    assert(_debugItemsHaveAccessibleText(rows));
+    assert(
+      semanticLabel == null || semanticLabel!.trim().isNotEmpty,
+      'RemixDataList.semanticLabel must not be blank when provided: it '
+      'becomes the accessible name of the list.',
+    );
 
-    return RemixStyleSpecBuilder<DataListSpec>(
-      style: style,
-      styleSpec: styleSpec,
-      builder: (context, spec) {
-        final metrics = _DataListMetrics.resolve(spec);
+    final metrics = _DataListMetrics.resolve(spec);
 
-        final Widget layout = orientation == Axis.horizontal
-            ? _HorizontalDataListLayout(
-                items: rows,
-                spec: spec,
-                metrics: metrics,
-              )
-            : _VerticalDataListLayout(
-                items: rows,
-                spec: spec,
-                metrics: metrics,
-              );
+    final Widget layout = orientation == Axis.horizontal
+        ? _HorizontalDataListLayout(items: rows, spec: spec, metrics: metrics)
+        : _VerticalDataListLayout(items: rows, spec: spec, metrics: metrics);
 
-        final content = Semantics(
-          role: SemanticsRole.list,
-          container: true,
-          explicitChildNodes: true,
-          label: semanticLabel,
-          child: Box(styleSpec: spec.container, child: layout),
-        );
+    final content = Semantics(
+      role: SemanticsRole.list,
+      container: true,
+      explicitChildNodes: true,
+      label: semanticLabel,
+      child: Box(styleSpec: spec.container, child: layout),
+    );
 
-        return excludeSemantics ? ExcludeSemantics(child: content) : content;
-      },
+    return excludeSemantics ? ExcludeSemantics(child: content) : content;
+  }
+}
+
+/// Debug guard for accessible names: [RemixDataListItem.label],
+/// [RemixDataListItem.value], and [RemixDataListItem.semanticValue] are
+/// announced by assistive technology, so a whitespace-only string would
+/// produce a silently unlabeled row. The const item constructor can only
+/// reject exactly empty strings (trimming is not constant-evaluable), so the
+/// renderer rejects trimmed-blank strings here. Displayed caller text is
+/// never trimmed or rewritten.
+bool _debugItemsHaveAccessibleText(List<RemixDataListItem> items) {
+  for (final item in items) {
+    assert(
+      item.label.trim().isNotEmpty,
+      'RemixDataListItem.label must not be blank: it is announced as the '
+      'accessible row label.',
+    );
+    final value = item.value;
+    assert(
+      value == null || value.trim().isNotEmpty,
+      'RemixDataListItem.value must not be blank when provided: it is '
+      'announced as the accessible row value.',
+    );
+    final semanticValue = item.semanticValue;
+    assert(
+      semanticValue == null || semanticValue.trim().isNotEmpty,
+      'RemixDataListItem.semanticValue must not be blank when provided: it '
+      'replaces the announcement of the child.',
     );
   }
+
+  return true;
 }
 
 /// Resolved non-negative geometry, defaulting every absent scalar to zero.
@@ -253,16 +290,17 @@ Widget _valueCell(
   return Box(styleSpec: spec.valueContainer, child: content);
 }
 
-/// One list-item semantics node per row.
+/// One list-item semantics node per vertical row.
 ///
 /// A string value or a [RemixDataListItem.semanticValue] summary collapses
 /// the row to a single label/value node and excludes the visible descendants.
 /// A custom child without a summary keeps its own semantics — including
 /// actions — as explicit child nodes of the row.
 ///
-/// In horizontal orientation this wraps only the value cell, because a
-/// [Table] offers no shared widget ancestor spanning both cells of a row;
-/// the excluded label cell keeps announcements nonduplicated either way.
+/// Horizontal rows use [_HorizontalRowSemantics] instead: a [Table] offers no
+/// shared widget ancestor spanning both cells of a row, so the row node is
+/// attached to the value cell and its bounds are expanded at the render level
+/// to cover the full row.
 class _RowSemantics extends StatelessWidget {
   const _RowSemantics({required this.item, required this.child});
 
@@ -329,8 +367,12 @@ class _HorizontalDataListLayout extends StatelessWidget {
           final alignment = _cellAlignment(item);
           final rowGap = index == items.length - 1 ? 0.0 : metrics.rowSpacing;
 
+          final summarized = item.value != null || item.semanticValue != null;
+          final valueCell = _valueCell(item, spec, alignChildStart: true);
+
           rows.add(
             TableRow(
+              key: item.key,
               children: [
                 _DataListCellAlignment(
                   verticalAlignment: alignment,
@@ -346,9 +388,11 @@ class _HorizontalDataListLayout extends StatelessWidget {
                       start: metrics.columnSpacing,
                       bottom: rowGap,
                     ),
-                    child: _RowSemantics(
+                    child: _HorizontalRowSemantics(
                       item: item,
-                      child: _valueCell(item, spec, alignChildStart: true),
+                      child: summarized
+                          ? ExcludeSemantics(child: valueCell)
+                          : valueCell,
                     ),
                   ),
                 ),
@@ -363,11 +407,16 @@ class _HorizontalDataListLayout extends StatelessWidget {
               FixedColumnWidth(metrics.minLabelWidth),
               const IntrinsicColumnWidth(),
             ),
-            // Bounded width: flex, so long values wrap and shrink. Unbounded
+            // Bounded width: flex, so long values wrap and shrink — floored
+            // at the value content's minimum intrinsic width so a long label
+            // wraps instead of collapsing the value column to zero. Unbounded
             // width: intrinsic, because a flex column cannot resolve without a
             // finite width.
             1: constraints.hasBoundedWidth
-                ? const FlexColumnWidth()
+                ? const MaxColumnWidth(
+                    FlexColumnWidth(),
+                    IntrinsicColumnWidth(),
+                  )
                 : const IntrinsicColumnWidth(),
           },
           textDirection: Directionality.of(context),
@@ -452,6 +501,123 @@ class _RenderDataListTable extends RenderTable {
   }
 }
 
+/// Announces one list-item node per horizontal row, bounded to the full row.
+///
+/// Same announcement contract as [_RowSemantics]; summarized rows exclude
+/// their visible value content at the widget layer, so this widget only
+/// carries the row node itself.
+class _HorizontalRowSemantics extends SingleChildRenderObjectWidget {
+  const _HorizontalRowSemantics({required this.item, super.child});
+
+  final RemixDataListItem item;
+
+  @override
+  _RenderDataListRowSemantics createRenderObject(BuildContext context) {
+    return _RenderDataListRowSemantics(
+      label: item.label,
+      summary: item.value ?? item.semanticValue,
+      textDirection: Directionality.of(context),
+    );
+  }
+
+  @override
+  void updateRenderObject(
+    BuildContext context,
+    _RenderDataListRowSemantics renderObject,
+  ) {
+    renderObject
+      ..label = item.label
+      ..summary = item.value ?? item.semanticValue
+      ..textDirection = Directionality.of(context);
+  }
+}
+
+/// The render side of [_HorizontalRowSemantics]: a semantics boundary with
+/// the listItem role whose bounds expand from the value cell to the full
+/// table row.
+///
+/// The visible label cell is excluded from semantics, so without the
+/// expansion, touch exploration over the label would fall outside the row's
+/// semantic rect. Expanding [semanticBounds] in this node's own coordinate
+/// space leaves every descendant transform untouched, so nested interactive
+/// value semantics keep their true geometry.
+class _RenderDataListRowSemantics extends RenderProxyBox {
+  _RenderDataListRowSemantics({
+    required String label,
+    required String? summary,
+    required TextDirection textDirection,
+  }) : _label = label,
+       _summary = summary,
+       _textDirection = textDirection;
+
+  String _label;
+  set label(String value) {
+    if (value == _label) return;
+    _label = value;
+    markNeedsSemanticsUpdate();
+  }
+
+  String? _summary;
+  set summary(String? value) {
+    if (value == _summary) return;
+    _summary = value;
+    markNeedsSemanticsUpdate();
+  }
+
+  TextDirection _textDirection;
+  set textDirection(TextDirection value) {
+    if (value == _textDirection) return;
+    _textDirection = value;
+    markNeedsSemanticsUpdate();
+  }
+
+  @override
+  Rect get semanticBounds {
+    // Translate the enclosing table row's box into this node's coordinate
+    // space by accumulating the parent-data offsets up to the table cell.
+    var offset = Offset.zero;
+    RenderObject? node = this;
+    while (node != null) {
+      final parentData = node.parentData;
+      final parent = node.parent;
+      if (parentData is TableCellParentData && parent is RenderTable) {
+        offset += parentData.offset;
+        final rowBox = parent.getRowBox(parentData.y!);
+
+        return Rect.fromLTRB(
+          -offset.dx,
+          rowBox.top - offset.dy,
+          rowBox.width - offset.dx,
+          rowBox.bottom - offset.dy,
+        );
+      }
+      if (parentData is BoxParentData) {
+        offset += parentData.offset;
+        node = parent;
+        continue;
+      }
+      break;
+    }
+
+    return super.semanticBounds;
+  }
+
+  @override
+  void describeSemanticsConfiguration(SemanticsConfiguration config) {
+    super.describeSemanticsConfiguration(config);
+    config
+      ..isSemanticBoundary = true
+      ..explicitChildNodes = true
+      ..role = SemanticsRole.listItem
+      ..textDirection = _textDirection
+      ..label = _label;
+    final summary = _summary;
+    if (summary != null) {
+      config.value = summary;
+    }
+  }
+}
+
 /// Applies per-cell vertical alignment without [TableCell]'s built-in
 /// `cell`-role [Semantics] wrapper.
 class _DataListCellAlignment extends ParentDataWidget<TableCellParentData> {
@@ -503,24 +669,28 @@ class _VerticalDataListLayout extends StatelessWidget {
     }
   }
 
+  Widget _row(RemixDataListItem item) {
+    final row = _RowSemantics(
+      item: item,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: _itemAlignment(item),
+        spacing: metrics.labelValueSpacing,
+        children: [_labelCell(item, spec), _valueCell(item, spec)],
+      ),
+    );
+    final key = item.key;
+
+    return key == null ? row : KeyedSubtree(key: key, child: row);
+  }
+
   @override
   Widget build(BuildContext context) {
     return Column(
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.start,
       spacing: metrics.rowSpacing,
-      children: [
-        for (final item in items)
-          _RowSemantics(
-            item: item,
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: _itemAlignment(item),
-              spacing: metrics.labelValueSpacing,
-              children: [_labelCell(item, spec), _valueCell(item, spec)],
-            ),
-          ),
-      ],
+      children: [for (final item in items) _row(item)],
     );
   }
 }

--- a/packages/remix/lib/src/components/data_list/data_list_widget.dart
+++ b/packages/remix/lib/src/components/data_list/data_list_widget.dart
@@ -87,15 +87,16 @@ class RemixDataListItem {
 ///
 /// ## Layout contract
 ///
-/// For a bounded horizontal list, the supported width is at least the
-/// resolved label column minimum (the greater of `minLabelWidth` and every
-/// label's minimum intrinsic width) plus `columnSpacing` plus the value
-/// column's minimum intrinsic width. Down to that bound, a long label wraps
-/// rather than starving the value column, which never shrinks below its
-/// minimum intrinsic width. Below the bound the pinned label column cannot
-/// fit and content overflows; the renderer never switches orientation on its
-/// own, so rebuild with [orientation] set to [Axis.vertical] when the
-/// available width is below the minimum.
+/// In a bounded horizontal list, textual values can shrink to their widest
+/// grapheme cluster and break long tokens only between grapheme clusters.
+/// Their announced value remains the caller's original string. Custom value
+/// widgets keep their normal minimum intrinsic width instead. The narrowest
+/// supported width is therefore the resolved label column minimum (the greater
+/// of `minLabelWidth` and every label's minimum intrinsic width), plus
+/// `columnSpacing`, plus the greatest value minimum for the rows. Below that
+/// structural bound content can overflow; the renderer never switches
+/// orientation on its own, so rebuild with [orientation] set to [Axis.vertical]
+/// when the available width is below the minimum.
 ///
 /// ## Example
 ///
@@ -269,8 +270,11 @@ Widget _valueCell(
   final value = item.value;
   Widget content;
   if (value != null) {
-    // String values keep the full column width so long text can wrap.
-    content = StyledText(value, styleSpec: spec.value);
+    // String values keep the full column width and expose a grapheme-level
+    // minimum intrinsic width so unbroken identifiers can wrap.
+    content = _BreakableDataListValue(
+      child: StyledText(value, styleSpec: spec.value),
+    );
   } else {
     // Arbitrary children inherit the resolved value typography the same way
     // Radix cascades `dd` styles onto custom markup.
@@ -359,72 +363,133 @@ class _HorizontalDataListLayout extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        final rows = <TableRow>[];
-        for (var index = 0; index < items.length; index += 1) {
-          final item = items[index];
-          final alignment = _cellAlignment(item);
-          final rowGap = index == items.length - 1 ? 0.0 : metrics.rowSpacing;
+    final rows = <TableRow>[];
+    for (var index = 0; index < items.length; index += 1) {
+      final item = items[index];
+      final alignment = _cellAlignment(item);
+      final rowGap = index == items.length - 1 ? 0.0 : metrics.rowSpacing;
 
-          final summarized = item.value != null || item.semanticValue != null;
-          final valueCell = _valueCell(item, spec, alignChildStart: true);
+      final summarized = item.value != null || item.semanticValue != null;
+      final valueCell = _valueCell(item, spec, alignChildStart: true);
 
-          rows.add(
-            TableRow(
-              key: item.key,
-              children: [
-                _DataListCellAlignment(
-                  verticalAlignment: alignment,
-                  child: Padding(
-                    padding: EdgeInsets.only(bottom: rowGap),
-                    child: _labelCell(item, spec),
-                  ),
-                ),
-                _DataListCellAlignment(
-                  verticalAlignment: alignment,
-                  child: Padding(
-                    padding: EdgeInsetsDirectional.only(
-                      start: metrics.columnSpacing,
-                      bottom: rowGap,
-                    ),
-                    child: _HorizontalRowSemantics(
-                      item: item,
-                      child: summarized
-                          ? ExcludeSemantics(child: valueCell)
-                          : valueCell,
-                    ),
-                  ),
-                ),
-              ],
+      rows.add(
+        TableRow(
+          key: item.key,
+          children: [
+            _DataListCellAlignment(
+              verticalAlignment: alignment,
+              child: Padding(
+                padding: EdgeInsets.only(bottom: rowGap),
+                child: _labelCell(item, spec),
+              ),
             ),
-          );
-        }
-
-        return _DataListTable(
-          columnWidths: <int, TableColumnWidth>{
-            0: MaxColumnWidth(
-              FixedColumnWidth(metrics.minLabelWidth),
-              const IntrinsicColumnWidth(),
+            _DataListCellAlignment(
+              verticalAlignment: alignment,
+              child: Padding(
+                padding: EdgeInsetsDirectional.only(
+                  start: metrics.columnSpacing,
+                  bottom: rowGap,
+                ),
+                child: _HorizontalRowSemantics(
+                  item: item,
+                  child: summarized
+                      ? ExcludeSemantics(child: valueCell)
+                      : valueCell,
+                ),
+              ),
             ),
-            // Bounded width: flex, so long values wrap and shrink — floored
-            // at the value content's minimum intrinsic width so a long label
-            // wraps instead of collapsing the value column to zero. Unbounded
-            // width: intrinsic, because a flex column cannot resolve without a
-            // finite width.
-            1: constraints.hasBoundedWidth
-                ? const MaxColumnWidth(
-                    FlexColumnWidth(),
-                    IntrinsicColumnWidth(),
-                  )
-                : const IntrinsicColumnWidth(),
-          },
-          textDirection: Directionality.of(context),
-          textBaseline: TextBaseline.alphabetic,
-          children: rows,
-        );
+          ],
+        ),
+      );
+    }
+
+    return _DataListTable(
+      columnWidths: <int, TableColumnWidth>{
+        0: MaxColumnWidth(
+          FixedColumnWidth(metrics.minLabelWidth),
+          const IntrinsicColumnWidth(),
+        ),
+        // Intrinsic sizing preserves natural width under an unbounded parent;
+        // flex fills a finite parent. Text values report one grapheme cluster
+        // as their minimum while custom children retain their own minimum.
+        1: const IntrinsicColumnWidth(flex: 1.0),
       },
+      textDirection: Directionality.of(context),
+      textBaseline: TextBaseline.alphabetic,
+      children: rows,
     );
+  }
+}
+
+/// Lets a textual value shrink to its widest grapheme cluster.
+///
+/// Flutter's paragraph layout already performs emergency line breaks only at
+/// grapheme boundaries. Its minimum intrinsic width is word-based, though,
+/// which prevents a table column from becoming narrow enough to use those
+/// breaks for an identifier without spaces. This render proxy changes only
+/// that intrinsic-width signal; layout, painting, baselines, and semantics
+/// continue to come from the original [StyledText].
+class _BreakableDataListValue extends SingleChildRenderObjectWidget {
+  const _BreakableDataListValue({required super.child});
+
+  @override
+  RenderObject createRenderObject(BuildContext context) {
+    return _RenderBreakableDataListValue();
+  }
+}
+
+class _RenderBreakableDataListValue extends RenderProxyBox {
+  @override
+  double computeMinIntrinsicWidth(double height) {
+    final paragraph = _findParagraph(child);
+    if (paragraph == null) return super.computeMinIntrinsicWidth(height);
+
+    final plainText = paragraph.text.toPlainText(
+      includeSemanticsLabels: false,
+      includePlaceholders: false,
+    );
+    if (plainText.isEmpty) return 0.0;
+
+    final painter = TextPainter(
+      text: paragraph.text,
+      textAlign: paragraph.textAlign,
+      textDirection: paragraph.textDirection,
+      textScaler: paragraph.textScaler,
+      locale: paragraph.locale,
+      strutStyle: paragraph.strutStyle,
+      textWidthBasis: paragraph.textWidthBasis,
+      textHeightBehavior: paragraph.textHeightBehavior,
+    )..layout();
+
+    var widestCluster = 0.0;
+    var offset = 0;
+    for (final cluster in plainText.characters) {
+      final end = offset + cluster.length;
+      final boxes = painter.getBoxesForSelection(
+        TextSelection(baseOffset: offset, extentOffset: end),
+      );
+      final width = boxes.fold<double>(
+        0.0,
+        (total, box) => total + box.right - box.left,
+      );
+      if (width > widestCluster) widestCluster = width;
+      offset = end;
+    }
+    painter.dispose();
+
+    return widestCluster;
+  }
+
+  static RenderParagraph? _findParagraph(RenderObject? root) {
+    if (root == null) return null;
+    if (root is RenderParagraph) return root;
+
+    RenderParagraph? paragraph;
+    root.visitChildren((child) {
+      paragraph ??= _findParagraph(child);
+    });
+
+    return paragraph;
   }
 }
 

--- a/packages/remix/lib/src/components/data_list/data_list_widget.dart
+++ b/packages/remix/lib/src/components/data_list/data_list_widget.dart
@@ -1,0 +1,526 @@
+part of 'data_list.dart';
+
+/// How a [RemixDataListItem] aligns its label and value against each other.
+enum RemixDataListItemAlignment { start, center, end, baseline, stretch }
+
+/// One label/value pair displayed by a [RemixDataList].
+///
+/// Exactly one of [value] or [child] must be provided. This data-driven item
+/// model is deliberately narrower than Radix's compositional
+/// Root/Item/Label/Value children: it keeps the shared label column and the
+/// one-node-per-row semantics deterministic while still admitting one custom
+/// [child] widget as the value.
+@immutable
+class RemixDataListItem {
+  const RemixDataListItem({
+    required this.label,
+    this.value,
+    this.child,
+    this.semanticValue,
+    this.alignment = RemixDataListItemAlignment.baseline,
+  }) : assert(
+         (value == null) != (child == null),
+         'Provide exactly one of value or child to RemixDataListItem.',
+       ),
+       assert(label != '', 'RemixDataListItem.label must be nonempty.'),
+       assert(
+         value != '',
+         'RemixDataListItem.value must be nonempty when provided.',
+       ),
+       assert(
+         semanticValue == null || child != null,
+         'RemixDataListItem.semanticValue is only valid together with child.',
+       ),
+       assert(
+         semanticValue != '',
+         'RemixDataListItem.semanticValue must be nonempty when provided.',
+       );
+
+  /// Visible label text, also announced as the row's semantic label.
+  final String label;
+
+  /// String value rendered with the data list's value typography.
+  final String? value;
+
+  /// Custom value widget that keeps its own semantics unless [semanticValue]
+  /// summarizes it.
+  final Widget? child;
+
+  /// Opt-in noninteractive summary announced instead of [child]'s semantics.
+  ///
+  /// Only for display-only children: it excludes the child's semantics
+  /// entirely, so an interactive child must omit it to keep its actions
+  /// reachable.
+  final String? semanticValue;
+
+  /// Cross-cell alignment for this row.
+  ///
+  /// [RemixDataListItemAlignment.baseline] is meaningful for string values,
+  /// where both cells expose a text baseline. A [child] row requesting
+  /// baseline deterministically maps to top/start, and vertical orientation
+  /// maps baseline to start; both adaptations are documented Radix deltas.
+  final RemixDataListItemAlignment alignment;
+}
+
+/// A semantic label/value list with a shared horizontal label column or a
+/// stacked vertical layout.
+///
+/// Horizontal orientation lays every row out in one two-column [Table], so
+/// labels align across all items exactly like Radix's shared `auto 1fr` grid
+/// columns. Vertical orientation stacks label above value per item.
+///
+/// ## Layout contract
+///
+/// For a bounded horizontal list, the supported width is at least the
+/// resolved label column minimum (the greater of `minLabelWidth` and every
+/// label's minimum intrinsic width) plus `columnSpacing` plus the value
+/// column's minimum intrinsic width. Below that bound the pinned label column
+/// cannot fit and content overflows; the renderer never switches orientation
+/// on its own, so rebuild with [orientation] set to [Axis.vertical] when the
+/// available width is below the minimum.
+///
+/// ## Example
+///
+/// ```dart
+/// RemixDataList(
+///   items: const [
+///     RemixDataListItem(label: 'Name', value: 'Leo Farias'),
+///     RemixDataListItem(label: 'Email', value: 'leo@example.com'),
+///   ],
+/// )
+/// ```
+// Deliberate: Radix DataList is display-only (`dl`/`dt`/`dd`) with no
+// interaction behavior, so there is no Naked primitive to headlessly
+// coordinate and this widget composes Flutter primitives directly. A Flutter
+// `Table` is reused as the horizontal layout because it is the one primitive
+// that negotiates a single shared label-column width across every row;
+// independent per-item Rows would let the columns drift.
+class RemixDataList extends StatelessWidget {
+  /// Creates a data list from [items].
+  const RemixDataList({
+    super.key,
+    required this.items,
+    this.orientation = Axis.horizontal,
+    this.semanticLabel,
+    this.excludeSemantics = false,
+    this.style = const DataListStyler.create(),
+    this.styleSpec,
+  });
+
+  static final styleFrom = DataListStyler.new;
+
+  /// The rows to display. May be empty.
+  ///
+  /// The list is retained as supplied — a const constructor cannot copy — so
+  /// callers must not mutate it during build. Each build reads one immutable
+  /// snapshot of the current contents.
+  final List<RemixDataListItem> items;
+
+  /// Layout axis. The constructor always wins over styles; orientation is
+  /// intentionally absent from [DataListSpec].
+  final Axis orientation;
+
+  /// Optional accessible name for the list itself.
+  final String? semanticLabel;
+
+  /// Whether to remove the entire list, rows included, from semantics.
+  final bool excludeSemantics;
+
+  /// The style configuration for the data list.
+  final DataListStyler style;
+
+  /// Optional raw style spec that bypasses fluent style resolution.
+  final DataListSpec? styleSpec;
+
+  @override
+  Widget build(BuildContext context) {
+    // One immutable snapshot per build enforces the no-mutation-during-build
+    // contract for everything rendered below.
+    final rows = List<RemixDataListItem>.unmodifiable(items);
+
+    return RemixStyleSpecBuilder<DataListSpec>(
+      style: style,
+      styleSpec: styleSpec,
+      builder: (context, spec) {
+        final metrics = _DataListMetrics.resolve(spec);
+
+        final Widget layout = orientation == Axis.horizontal
+            ? _HorizontalDataListLayout(
+                items: rows,
+                spec: spec,
+                metrics: metrics,
+              )
+            : _VerticalDataListLayout(
+                items: rows,
+                spec: spec,
+                metrics: metrics,
+              );
+
+        final content = Semantics(
+          role: SemanticsRole.list,
+          container: true,
+          explicitChildNodes: true,
+          label: semanticLabel,
+          child: Box(styleSpec: spec.container, child: layout),
+        );
+
+        return excludeSemantics ? ExcludeSemantics(child: content) : content;
+      },
+    );
+  }
+}
+
+/// Resolved non-negative geometry, defaulting every absent scalar to zero.
+class _DataListMetrics {
+  const _DataListMetrics({
+    required this.rowSpacing,
+    required this.columnSpacing,
+    required this.labelValueSpacing,
+    required this.minLabelWidth,
+  });
+
+  factory _DataListMetrics.resolve(DataListSpec spec) {
+    final metrics = _DataListMetrics(
+      rowSpacing: spec.rowSpacing ?? 0.0,
+      columnSpacing: spec.columnSpacing ?? 0.0,
+      labelValueSpacing: spec.labelValueSpacing ?? 0.0,
+      minLabelWidth: spec.minLabelWidth ?? 0.0,
+    );
+    assert(
+      metrics.rowSpacing >= 0,
+      'DataList rowSpacing must resolve to a non-negative value.',
+    );
+    assert(
+      metrics.columnSpacing >= 0,
+      'DataList columnSpacing must resolve to a non-negative value.',
+    );
+    assert(
+      metrics.labelValueSpacing >= 0,
+      'DataList labelValueSpacing must resolve to a non-negative value.',
+    );
+    assert(
+      metrics.minLabelWidth >= 0,
+      'DataList minLabelWidth must resolve to a non-negative value.',
+    );
+
+    return metrics;
+  }
+
+  final double rowSpacing;
+  final double columnSpacing;
+  final double labelValueSpacing;
+  final double minLabelWidth;
+}
+
+/// The visual label of every row form: the row's semantics node carries the
+/// label text, so the visible label is always excluded to avoid a second
+/// announcement.
+Widget _labelCell(RemixDataListItem item, DataListSpec spec) {
+  return ExcludeSemantics(
+    child: Box(
+      styleSpec: spec.labelContainer,
+      child: StyledText(item.label, styleSpec: spec.label),
+    ),
+  );
+}
+
+Widget _valueCell(
+  RemixDataListItem item,
+  DataListSpec spec, {
+  bool alignChildStart = false,
+}) {
+  final value = item.value;
+  Widget content;
+  if (value != null) {
+    // String values keep the full column width so long text can wrap.
+    content = StyledText(value, styleSpec: spec.value);
+  } else {
+    // Arbitrary children inherit the resolved value typography the same way
+    // Radix cascades `dd` styles onto custom markup.
+    content = RemixDefaultContentStyle(text: spec.value, child: item.child!);
+    if (alignChildStart) {
+      // In the horizontal table the cell width is tight; without this a
+      // custom child would stretch across the whole value column instead of
+      // sitting inline at the start like Radix `dd` content.
+      content = Align(
+        alignment: AlignmentDirectional.topStart,
+        heightFactor: 1.0,
+        child: content,
+      );
+    }
+  }
+
+  return Box(styleSpec: spec.valueContainer, child: content);
+}
+
+/// One list-item semantics node per row.
+///
+/// A string value or a [RemixDataListItem.semanticValue] summary collapses
+/// the row to a single label/value node and excludes the visible descendants.
+/// A custom child without a summary keeps its own semantics — including
+/// actions — as explicit child nodes of the row.
+///
+/// In horizontal orientation this wraps only the value cell, because a
+/// [Table] offers no shared widget ancestor spanning both cells of a row;
+/// the excluded label cell keeps announcements nonduplicated either way.
+class _RowSemantics extends StatelessWidget {
+  const _RowSemantics({required this.item, required this.child});
+
+  final RemixDataListItem item;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final summary = item.value ?? item.semanticValue;
+
+    return Semantics(
+      role: SemanticsRole.listItem,
+      container: true,
+      explicitChildNodes: summary == null,
+      excludeSemantics: summary != null,
+      label: item.label,
+      value: summary,
+      child: child,
+    );
+  }
+}
+
+class _HorizontalDataListLayout extends StatelessWidget {
+  const _HorizontalDataListLayout({
+    required this.items,
+    required this.spec,
+    required this.metrics,
+  });
+
+  final List<RemixDataListItem> items;
+  final DataListSpec spec;
+  final _DataListMetrics metrics;
+
+  static TableCellVerticalAlignment _cellAlignment(RemixDataListItem item) {
+    switch (item.alignment) {
+      case RemixDataListItemAlignment.start:
+        return TableCellVerticalAlignment.top;
+      case RemixDataListItemAlignment.center:
+        return TableCellVerticalAlignment.middle;
+      case RemixDataListItemAlignment.end:
+        return TableCellVerticalAlignment.bottom;
+      case RemixDataListItemAlignment.stretch:
+        // Deliberate: `fill` on every cell of a row leaves RenderTable no
+        // height source and collapses the row to zero height, so stretch maps
+        // to intrinsicHeight, which sizes both cells to the tallest cell.
+        return TableCellVerticalAlignment.intrinsicHeight;
+      case RemixDataListItemAlignment.baseline:
+        // Deliberate: an arbitrary child may expose no text baseline, so a
+        // custom-child baseline row maps to top instead of relying on
+        // RenderTable's silent per-cell fallback.
+        return item.child == null
+            ? TableCellVerticalAlignment.baseline
+            : TableCellVerticalAlignment.top;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final rows = <TableRow>[];
+        for (var index = 0; index < items.length; index += 1) {
+          final item = items[index];
+          final alignment = _cellAlignment(item);
+          final rowGap = index == items.length - 1 ? 0.0 : metrics.rowSpacing;
+
+          rows.add(
+            TableRow(
+              children: [
+                _DataListCellAlignment(
+                  verticalAlignment: alignment,
+                  child: Padding(
+                    padding: EdgeInsets.only(bottom: rowGap),
+                    child: _labelCell(item, spec),
+                  ),
+                ),
+                _DataListCellAlignment(
+                  verticalAlignment: alignment,
+                  child: Padding(
+                    padding: EdgeInsetsDirectional.only(
+                      start: metrics.columnSpacing,
+                      bottom: rowGap,
+                    ),
+                    child: _RowSemantics(
+                      item: item,
+                      child: _valueCell(item, spec, alignChildStart: true),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          );
+        }
+
+        return _DataListTable(
+          columnWidths: <int, TableColumnWidth>{
+            0: MaxColumnWidth(
+              FixedColumnWidth(metrics.minLabelWidth),
+              const IntrinsicColumnWidth(),
+            ),
+            // Bounded width: flex, so long values wrap and shrink. Unbounded
+            // width: intrinsic, because a flex column cannot resolve without a
+            // finite width.
+            1: constraints.hasBoundedWidth
+                ? const FlexColumnWidth()
+                : const IntrinsicColumnWidth(),
+          },
+          textDirection: Directionality.of(context),
+          textBaseline: TextBaseline.alphabetic,
+          children: rows,
+        );
+      },
+    );
+  }
+}
+
+/// A [Table] that reuses [RenderTable]'s shared-column layout but contributes
+/// no semantics of its own.
+///
+/// Deliberate: Flutter's [Table] and [TableCell] hard-code `table`/`row`/
+/// `cell` semantics roles. A data list is a definition list, not a data
+/// table — its contract is one `list` node with one `listItem` node per row,
+/// and the framework rejects a `listItem` whose parent is not a `list`. This
+/// subclass keeps the layout contract (one negotiated label column across
+/// every row) while restoring the render-object default of exposing no
+/// semantics structure.
+class _DataListTable extends Table {
+  _DataListTable({
+    super.children,
+    super.columnWidths,
+    super.textDirection,
+    super.textBaseline,
+  });
+
+  @override
+  RenderTable createRenderObject(BuildContext context) {
+    assert(debugCheckHasDirectionality(context));
+
+    return _RenderDataListTable(
+      columns: children.isNotEmpty ? children[0].children.length : 0,
+      rows: children.length,
+      columnWidths: columnWidths,
+      defaultColumnWidth: defaultColumnWidth,
+      textDirection: textDirection ?? Directionality.of(context),
+      border: border,
+      configuration: createLocalImageConfiguration(context),
+      defaultVerticalAlignment: defaultVerticalAlignment,
+      textBaseline: textBaseline,
+    );
+  }
+}
+
+class _RenderDataListTable extends RenderTable {
+  _RenderDataListTable({
+    super.columns,
+    super.rows,
+    super.columnWidths,
+    super.defaultColumnWidth,
+    required super.textDirection,
+    super.border,
+    super.configuration,
+    super.defaultVerticalAlignment,
+    super.textBaseline,
+  });
+
+  // ignore: must_call_super
+  @override
+  void describeSemanticsConfiguration(SemanticsConfiguration config) {
+    // Intentionally skip RenderTable's table-role annotation: even a reset
+    // configuration stays flagged as annotated and forms an empty node
+    // between the list and its rows. The RenderObject default contributes
+    // nothing, which is exactly what this presentation-only table needs.
+  }
+
+  @override
+  void assembleSemanticsNode(
+    SemanticsNode node,
+    SemanticsConfiguration config,
+    Iterable<SemanticsNode> children,
+  ) {
+    // RenderObject's default assembly; RenderTable's override would
+    // synthesize row/cell nodes.
+    node.updateWith(
+      config: config,
+      childrenInInversePaintOrder: children.toList(),
+    );
+  }
+}
+
+/// Applies per-cell vertical alignment without [TableCell]'s built-in
+/// `cell`-role [Semantics] wrapper.
+class _DataListCellAlignment extends ParentDataWidget<TableCellParentData> {
+  const _DataListCellAlignment({
+    required this.verticalAlignment,
+    required super.child,
+  });
+
+  final TableCellVerticalAlignment verticalAlignment;
+
+  @override
+  void applyParentData(RenderObject renderObject) {
+    final parentData = renderObject.parentData! as TableCellParentData;
+    if (parentData.verticalAlignment != verticalAlignment) {
+      parentData.verticalAlignment = verticalAlignment;
+      renderObject.parent?.markNeedsLayout();
+    }
+  }
+
+  @override
+  Type get debugTypicalAncestorWidgetClass => Table;
+}
+
+class _VerticalDataListLayout extends StatelessWidget {
+  const _VerticalDataListLayout({
+    required this.items,
+    required this.spec,
+    required this.metrics,
+  });
+
+  final List<RemixDataListItem> items;
+  final DataListSpec spec;
+  final _DataListMetrics metrics;
+
+  static CrossAxisAlignment _itemAlignment(RemixDataListItem item) {
+    switch (item.alignment) {
+      case RemixDataListItemAlignment.start:
+        return CrossAxisAlignment.start;
+      case RemixDataListItemAlignment.center:
+        return CrossAxisAlignment.center;
+      case RemixDataListItemAlignment.end:
+        return CrossAxisAlignment.end;
+      case RemixDataListItemAlignment.stretch:
+        return CrossAxisAlignment.stretch;
+      case RemixDataListItemAlignment.baseline:
+        // Deliberate: stacked label/value share no horizontal text baseline,
+        // so vertical baseline maps to start.
+        return CrossAxisAlignment.start;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      spacing: metrics.rowSpacing,
+      children: [
+        for (final item in items)
+          _RowSemantics(
+            item: item,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: _itemAlignment(item),
+              spacing: metrics.labelValueSpacing,
+              children: [_labelCell(item, spec), _valueCell(item, spec)],
+            ),
+          ),
+      ],
+    );
+  }
+}

--- a/packages/remix/test/components/data_list/data_list_spec_test.dart
+++ b/packages/remix/test/components/data_list/data_list_spec_test.dart
@@ -1,0 +1,281 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:remix/remix.dart';
+
+void main() {
+  group('DataListSpec', () {
+    group('Constructor', () {
+      test('creates spec with default values when no parameters provided', () {
+        const spec = DataListSpec();
+
+        expect(spec.container, isA<StyleSpec<BoxSpec>>());
+        expect(spec.labelContainer, isA<StyleSpec<BoxSpec>>());
+        expect(spec.valueContainer, isA<StyleSpec<BoxSpec>>());
+        expect(spec.label, isA<StyleSpec<TextSpec>>());
+        expect(spec.value, isA<StyleSpec<TextSpec>>());
+        expect(spec.rowSpacing, isNull);
+        expect(spec.columnSpacing, isNull);
+        expect(spec.labelValueSpacing, isNull);
+        expect(spec.minLabelWidth, isNull);
+      });
+
+      test('creates spec with custom slots and metrics', () {
+        final container = StyleSpec(
+          spec: BoxSpec(decoration: BoxDecoration(color: Colors.red)),
+        );
+        final labelContainer = StyleSpec(
+          spec: BoxSpec(padding: const EdgeInsets.all(2)),
+        );
+        final valueContainer = StyleSpec(
+          spec: BoxSpec(padding: const EdgeInsets.all(4)),
+        );
+        const label = StyleSpec(spec: TextSpec(maxLines: 1));
+        const value = StyleSpec(spec: TextSpec(maxLines: 3));
+
+        final spec = DataListSpec(
+          container: container,
+          labelContainer: labelContainer,
+          valueContainer: valueContainer,
+          label: label,
+          value: value,
+          rowSpacing: 12.0,
+          columnSpacing: 24.0,
+          labelValueSpacing: 4.0,
+          minLabelWidth: 120.0,
+        );
+
+        expect(spec.container, equals(container));
+        expect(spec.labelContainer, equals(labelContainer));
+        expect(spec.valueContainer, equals(valueContainer));
+        expect(spec.label, equals(label));
+        expect(spec.value, equals(value));
+        expect(spec.rowSpacing, equals(12.0));
+        expect(spec.columnSpacing, equals(24.0));
+        expect(spec.labelValueSpacing, equals(4.0));
+        expect(spec.minLabelWidth, equals(120.0));
+      });
+
+      test('retains negative metrics for the renderer to reject', () {
+        const spec = DataListSpec(rowSpacing: -1.0);
+
+        expect(spec.rowSpacing, equals(-1.0));
+      });
+    });
+
+    group('copyWith', () {
+      test('returns new instance with updated slots', () {
+        const originalSpec = DataListSpec();
+        final newContainer = StyleSpec(
+          spec: BoxSpec(decoration: BoxDecoration(color: Colors.blue)),
+        );
+        final newLabelContainer = StyleSpec(
+          spec: BoxSpec(padding: const EdgeInsets.all(6)),
+        );
+        final newValueContainer = StyleSpec(
+          spec: BoxSpec(padding: const EdgeInsets.all(8)),
+        );
+        const newLabel = StyleSpec(spec: TextSpec(maxLines: 2));
+        const newValue = StyleSpec(spec: TextSpec(maxLines: 4));
+
+        final updatedSpec = originalSpec.copyWith(
+          container: newContainer,
+          labelContainer: newLabelContainer,
+          valueContainer: newValueContainer,
+          label: newLabel,
+          value: newValue,
+        );
+
+        expect(updatedSpec, isNot(same(originalSpec)));
+        expect(updatedSpec.container, equals(newContainer));
+        expect(updatedSpec.labelContainer, equals(newLabelContainer));
+        expect(updatedSpec.valueContainer, equals(newValueContainer));
+        expect(updatedSpec.label, equals(newLabel));
+        expect(updatedSpec.value, equals(newValue));
+      });
+
+      test('returns new instance with updated metrics', () {
+        const originalSpec = DataListSpec();
+
+        final updatedSpec = originalSpec.copyWith(
+          rowSpacing: 10.0,
+          columnSpacing: 20.0,
+          labelValueSpacing: 2.0,
+          minLabelWidth: 96.0,
+        );
+
+        expect(updatedSpec.rowSpacing, equals(10.0));
+        expect(updatedSpec.columnSpacing, equals(20.0));
+        expect(updatedSpec.labelValueSpacing, equals(2.0));
+        expect(updatedSpec.minLabelWidth, equals(96.0));
+      });
+
+      test(
+        'returns new instance with no changes when no parameters provided',
+        () {
+          const originalSpec = DataListSpec(rowSpacing: 8.0);
+
+          final updatedSpec = originalSpec.copyWith();
+
+          expect(updatedSpec, isNot(same(originalSpec)));
+          expect(updatedSpec, equals(originalSpec));
+        },
+      );
+
+      test('preserves immutability - original spec unchanged', () {
+        const originalSpec = DataListSpec(minLabelWidth: 50.0);
+
+        final updatedSpec = originalSpec.copyWith(minLabelWidth: 90.0);
+
+        expect(originalSpec.minLabelWidth, equals(50.0));
+        expect(updatedSpec.minLabelWidth, equals(90.0));
+      });
+    });
+
+    group('lerp', () {
+      test('keeps slots and eases scalars toward zero when other is null', () {
+        const spec = DataListSpec(rowSpacing: 8.0, columnSpacing: 16.0);
+
+        final result = spec.lerp(null, 0.5);
+
+        expect(result.container, equals(spec.container));
+        expect(result.label, equals(spec.label));
+        expect(result.value, equals(spec.value));
+        // Generated MixOps.lerp treats an absent scalar endpoint as zero.
+        expect(result.rowSpacing, equals(4.0));
+        expect(result.columnSpacing, equals(8.0));
+      });
+
+      test('interpolates every metric at t=0.5', () {
+        const spec1 = DataListSpec(
+          rowSpacing: 0.0,
+          columnSpacing: 10.0,
+          labelValueSpacing: 2.0,
+          minLabelWidth: 100.0,
+        );
+        const spec2 = DataListSpec(
+          rowSpacing: 10.0,
+          columnSpacing: 30.0,
+          labelValueSpacing: 6.0,
+          minLabelWidth: 140.0,
+        );
+
+        final result = spec1.lerp(spec2, 0.5);
+
+        expect(result.rowSpacing, equals(5.0));
+        expect(result.columnSpacing, equals(20.0));
+        expect(result.labelValueSpacing, equals(4.0));
+        expect(result.minLabelWidth, equals(120.0));
+      });
+
+      test('returns start and end values at t=0.0 and t=1.0', () {
+        const spec1 = DataListSpec(rowSpacing: 4.0);
+        const spec2 = DataListSpec(rowSpacing: 12.0);
+
+        expect(spec1.lerp(spec2, 0.0).rowSpacing, equals(4.0));
+        expect(spec1.lerp(spec2, 1.0).rowSpacing, equals(12.0));
+      });
+
+      test('interpolates nested slots', () {
+        final spec1 = DataListSpec(container: StyleSpec(spec: BoxSpec()));
+        final spec2 = DataListSpec(container: StyleSpec(spec: BoxSpec()));
+
+        final result = spec1.lerp(spec2, 0.5);
+
+        expect(result, isA<DataListSpec>());
+        expect(result.container, isA<StyleSpec<BoxSpec>>());
+        expect(result.label, isA<StyleSpec<TextSpec>>());
+      });
+    });
+
+    group('Equality and Props', () {
+      test('two specs with same properties are equal', () {
+        const spec1 = DataListSpec(rowSpacing: 8.0);
+        const spec2 = DataListSpec(rowSpacing: 8.0);
+
+        expect(spec1, equals(spec2));
+        expect(spec1.hashCode, equals(spec2.hashCode));
+      });
+
+      test('specs with different slots are not equal', () {
+        const spec1 = DataListSpec();
+        final spec2 = DataListSpec(
+          labelContainer: StyleSpec(
+            spec: BoxSpec(decoration: BoxDecoration(color: Colors.red)),
+          ),
+        );
+
+        expect(spec1, isNot(equals(spec2)));
+      });
+
+      test('specs with different metrics are not equal', () {
+        const spec1 = DataListSpec(minLabelWidth: 100.0);
+        const spec2 = DataListSpec(minLabelWidth: 120.0);
+
+        expect(spec1, isNot(equals(spec2)));
+      });
+
+      test('props list contains all properties', () {
+        const spec = DataListSpec();
+
+        expect(spec.props, hasLength(9));
+        expect(spec.props, contains(spec.container));
+        expect(spec.props, contains(spec.labelContainer));
+        expect(spec.props, contains(spec.valueContainer));
+        expect(spec.props, contains(spec.label));
+        expect(spec.props, contains(spec.value));
+      });
+    });
+
+    group('Diagnostic Support', () {
+      test('debugFillProperties works without throwing', () {
+        const spec = DataListSpec();
+
+        expect(
+          () => spec.debugFillProperties(DiagnosticPropertiesBuilder()),
+          returnsNormally,
+        );
+      });
+
+      test('can be converted to string for debugging', () {
+        const spec = DataListSpec();
+
+        expect(spec.toString(), isA<String>());
+        expect(spec.toString(), isNotEmpty);
+      });
+
+      test('diagnostic properties are properly formatted', () {
+        const spec = DataListSpec();
+        final builder = DiagnosticPropertiesBuilder();
+
+        spec.debugFillProperties(builder);
+
+        final propertyNames = builder.properties.map((p) => p.name).toList();
+        expect(
+          propertyNames,
+          containsAll([
+            'container',
+            'labelContainer',
+            'valueContainer',
+            'label',
+            'value',
+            'rowSpacing',
+            'columnSpacing',
+            'labelValueSpacing',
+            'minLabelWidth',
+          ]),
+        );
+      });
+    });
+
+    group('Edge Cases', () {
+      test('copyWith handles null parameters correctly', () {
+        const spec = DataListSpec(rowSpacing: 8.0);
+
+        final updatedSpec = spec.copyWith(rowSpacing: null);
+
+        expect(updatedSpec.rowSpacing, equals(8.0));
+      });
+    });
+  });
+}

--- a/packages/remix/test/components/data_list/data_list_style_test.dart
+++ b/packages/remix/test/components/data_list/data_list_style_test.dart
@@ -103,7 +103,10 @@ void main() {
         initial: DataListStyler(),
         modify: (style) => style.label(TextStyler().fontSize(12)),
         expect: (style) {
-          expect(style, equals(DataListStyler.label(TextStyler().fontSize(12))));
+          expect(
+            style,
+            equals(DataListStyler.label(TextStyler().fontSize(12))),
+          );
         },
       );
 
@@ -112,7 +115,10 @@ void main() {
         initial: DataListStyler(),
         modify: (style) => style.value(TextStyler().fontSize(14)),
         expect: (style) {
-          expect(style, equals(DataListStyler.value(TextStyler().fontSize(14))));
+          expect(
+            style,
+            equals(DataListStyler.value(TextStyler().fontSize(14))),
+          );
         },
       );
 
@@ -199,7 +205,9 @@ void main() {
           expect(
             style.$label,
             equals(
-              Prop.maybeMix(TextStyler(style: TextStyleMix(color: Colors.grey))),
+              Prop.maybeMix(
+                TextStyler(style: TextStyleMix(color: Colors.grey)),
+              ),
             ),
           );
         },
@@ -235,20 +243,26 @@ void main() {
         },
       );
 
-      test('call creates a RemixDataList with this style', () {
+      test('generated call forwards widget arguments and this style', () {
         final style = DataListStyler().rowSpacing(8.0);
+        const key = ValueKey('account-data');
+        const items = [RemixDataListItem(label: 'Name', value: 'Leo')];
 
         final widget = style(
-          items: const [RemixDataListItem(label: 'Name', value: 'Leo')],
+          key: key,
+          items: items,
           orientation: Axis.vertical,
           semanticLabel: 'Account',
+          excludeSemantics: true,
         );
 
         expect(widget, isA<RemixDataList>());
+        expect(widget.key, same(key));
         expect(widget.style, same(style));
+        expect(widget.items, same(items));
         expect(widget.orientation, equals(Axis.vertical));
         expect(widget.semanticLabel, equals('Account'));
-        expect(widget.items, hasLength(1));
+        expect(widget.excludeSemantics, isTrue);
       });
     });
 

--- a/packages/remix/test/components/data_list/data_list_style_test.dart
+++ b/packages/remix/test/components/data_list/data_list_style_test.dart
@@ -1,0 +1,457 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:remix/remix.dart';
+
+import '../../helpers/test_methods.dart';
+
+void main() {
+  group('DataListStyler', () {
+    group('Constructors', () {
+      test('default constructor creates valid instance', () {
+        final style = DataListStyler();
+
+        expect(style, isNotNull);
+        expect(style, isA<DataListStyler>());
+      });
+
+      test('create constructor with all parameters', () {
+        final container = Prop.maybeMix(BoxStyler());
+        final labelContainer = Prop.maybeMix(BoxStyler());
+        final valueContainer = Prop.maybeMix(BoxStyler());
+        final label = Prop.maybeMix(TextStyler());
+        final value = Prop.maybeMix(TextStyler());
+        final rowSpacing = Prop.maybe(8.0);
+        final variants = <VariantStyle<DataListSpec>>[];
+
+        final style = DataListStyler.create(
+          container: container,
+          labelContainer: labelContainer,
+          valueContainer: valueContainer,
+          label: label,
+          value: value,
+          rowSpacing: rowSpacing,
+          variants: variants,
+        );
+
+        expect(style.$container, equals(container));
+        expect(style.$labelContainer, equals(labelContainer));
+        expect(style.$valueContainer, equals(valueContainer));
+        expect(style.$label, equals(label));
+        expect(style.$value, equals(value));
+        expect(style.$rowSpacing, equals(rowSpacing));
+        expect(style.$variants, equals(variants));
+      });
+
+      test('constructor with styler parameters', () {
+        final style = DataListStyler(
+          container: BoxStyler(),
+          labelContainer: BoxStyler(),
+          valueContainer: BoxStyler(),
+          label: TextStyler(),
+          value: TextStyler(),
+          rowSpacing: 8.0,
+          columnSpacing: 16.0,
+          labelValueSpacing: 4.0,
+          minLabelWidth: 120.0,
+        );
+
+        expect(style.$container, isNotNull);
+        expect(style.$labelContainer, isNotNull);
+        expect(style.$valueContainer, isNotNull);
+        expect(style.$label, isNotNull);
+        expect(style.$value, isNotNull);
+        expect(style.$rowSpacing, isNotNull);
+        expect(style.$columnSpacing, isNotNull);
+        expect(style.$labelValueSpacing, isNotNull);
+        expect(style.$minLabelWidth, isNotNull);
+      });
+    });
+
+    group('Slot Methods', () {
+      styleMethodTest(
+        'labelContainer',
+        initial: DataListStyler(),
+        modify: (style) =>
+            style.labelContainer(BoxStyler().color(Colors.black12)),
+        expect: (style) {
+          expect(
+            style,
+            equals(
+              DataListStyler.labelContainer(BoxStyler().color(Colors.black12)),
+            ),
+          );
+        },
+      );
+
+      styleMethodTest(
+        'valueContainer',
+        initial: DataListStyler(),
+        modify: (style) =>
+            style.valueContainer(BoxStyler().color(Colors.black26)),
+        expect: (style) {
+          expect(
+            style,
+            equals(
+              DataListStyler.valueContainer(BoxStyler().color(Colors.black26)),
+            ),
+          );
+        },
+      );
+
+      styleMethodTest(
+        'label',
+        initial: DataListStyler(),
+        modify: (style) => style.label(TextStyler().fontSize(12)),
+        expect: (style) {
+          expect(style, equals(DataListStyler.label(TextStyler().fontSize(12))));
+        },
+      );
+
+      styleMethodTest(
+        'value',
+        initial: DataListStyler(),
+        modify: (style) => style.value(TextStyler().fontSize(14)),
+        expect: (style) {
+          expect(style, equals(DataListStyler.value(TextStyler().fontSize(14))));
+        },
+      );
+
+      styleMethodTest(
+        'container via forwarded Box surface',
+        initial: DataListStyler(),
+        modify: (style) => style.padding(EdgeInsetsGeometryMix.all(16.0)),
+        expect: (style) {
+          expect(
+            style,
+            equals(DataListStyler.padding(EdgeInsetsGeometryMix.all(16.0))),
+          );
+        },
+      );
+
+      styleMethodTest(
+        'color',
+        initial: DataListStyler(),
+        modify: (style) => style.color(Colors.red),
+        expect: (style) {
+          expect(style, equals(DataListStyler.color(Colors.red)));
+        },
+      );
+    });
+
+    group('Metric Methods', () {
+      styleMethodTest(
+        'rowSpacing',
+        initial: DataListStyler(),
+        modify: (style) => style.rowSpacing(12.0),
+        expect: (style) {
+          expect(style, equals(DataListStyler.rowSpacing(12.0)));
+        },
+      );
+
+      styleMethodTest(
+        'columnSpacing',
+        initial: DataListStyler(),
+        modify: (style) => style.columnSpacing(24.0),
+        expect: (style) {
+          expect(style, equals(DataListStyler.columnSpacing(24.0)));
+        },
+      );
+
+      styleMethodTest(
+        'labelValueSpacing',
+        initial: DataListStyler(),
+        modify: (style) => style.labelValueSpacing(4.0),
+        expect: (style) {
+          expect(style, equals(DataListStyler.labelValueSpacing(4.0)));
+        },
+      );
+
+      styleMethodTest(
+        'minLabelWidth',
+        initial: DataListStyler(),
+        modify: (style) => style.minLabelWidth(120.0),
+        expect: (style) {
+          expect(style, equals(DataListStyler.minLabelWidth(120.0)));
+        },
+      );
+    });
+
+    group('Remix Helpers', () {
+      styleMethodTest(
+        'labelTextStyle',
+        initial: DataListStyler(),
+        modify: (style) => style.labelTextStyle(TextStyleMix(fontSize: 11)),
+        expect: (style) {
+          expect(
+            style.$label,
+            equals(
+              Prop.maybeMix(TextStyler(style: TextStyleMix(fontSize: 11))),
+            ),
+          );
+        },
+      );
+
+      styleMethodTest(
+        'labelColor',
+        initial: DataListStyler(),
+        modify: (style) => style.labelColor(Colors.grey),
+        expect: (style) {
+          expect(
+            style.$label,
+            equals(
+              Prop.maybeMix(TextStyler(style: TextStyleMix(color: Colors.grey))),
+            ),
+          );
+        },
+      );
+
+      styleMethodTest(
+        'valueTextStyle',
+        initial: DataListStyler(),
+        modify: (style) => style.valueTextStyle(TextStyleMix(fontSize: 15)),
+        expect: (style) {
+          expect(
+            style.$value,
+            equals(
+              Prop.maybeMix(TextStyler(style: TextStyleMix(fontSize: 15))),
+            ),
+          );
+        },
+      );
+
+      styleMethodTest(
+        'valueColor',
+        initial: DataListStyler(),
+        modify: (style) => style.valueColor(Colors.black),
+        expect: (style) {
+          expect(
+            style.$value,
+            equals(
+              Prop.maybeMix(
+                TextStyler(style: TextStyleMix(color: Colors.black)),
+              ),
+            ),
+          );
+        },
+      );
+
+      test('call creates a RemixDataList with this style', () {
+        final style = DataListStyler().rowSpacing(8.0);
+
+        final widget = style(
+          items: const [RemixDataListItem(label: 'Name', value: 'Leo')],
+          orientation: Axis.vertical,
+          semanticLabel: 'Account',
+        );
+
+        expect(widget, isA<RemixDataList>());
+        expect(widget.style, same(style));
+        expect(widget.orientation, equals(Axis.vertical));
+        expect(widget.semanticLabel, equals('Account'));
+        expect(widget.items, hasLength(1));
+      });
+    });
+
+    group('Modifier Methods', () {
+      styleMethodTest(
+        'wrap',
+        initial: DataListStyler(),
+        modify: (style) => style.wrap(.opacity(0.5)),
+        expect: (style) {
+          expect(style.$modifier, equals(WidgetModifierConfig.opacity(0.5)));
+        },
+      );
+
+      styleMethodTest(
+        'variants',
+        initial: DataListStyler(),
+        modify: (style) => style.variants(<VariantStyle<DataListSpec>>[]),
+        expect: (style) {
+          expect(style.$variants, equals(<VariantStyle<DataListSpec>>[]));
+        },
+      );
+
+      styleMethodTest(
+        'animate',
+        initial: DataListStyler(),
+        modify: (style) => style.animate(
+          AnimationConfig.linear(const Duration(milliseconds: 300)),
+        ),
+        expect: (style) {
+          expect(
+            style.$animation,
+            equals(AnimationConfig.linear(const Duration(milliseconds: 300))),
+          );
+        },
+      );
+    });
+
+    group('Core Methods', () {
+      testWidgets('resolve method returns StyleSpec with every field', (
+        tester,
+      ) async {
+        final style = DataListStyler()
+            .rowSpacing(8.0)
+            .columnSpacing(16.0)
+            .labelValueSpacing(4.0)
+            .minLabelWidth(120.0);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Builder(
+              builder: (context) {
+                final spec = style.resolve(context);
+
+                expect(spec, isA<StyleSpec<DataListSpec>>());
+                expect(spec.spec.container, isA<StyleSpec<BoxSpec>>());
+                expect(spec.spec.labelContainer, isA<StyleSpec<BoxSpec>>());
+                expect(spec.spec.valueContainer, isA<StyleSpec<BoxSpec>>());
+                expect(spec.spec.label, isA<StyleSpec<TextSpec>>());
+                expect(spec.spec.value, isA<StyleSpec<TextSpec>>());
+                expect(spec.spec.rowSpacing, equals(8.0));
+                expect(spec.spec.columnSpacing, equals(16.0));
+                expect(spec.spec.labelValueSpacing, equals(4.0));
+                expect(spec.spec.minLabelWidth, equals(120.0));
+
+                return Container();
+              },
+            ),
+          ),
+        );
+      });
+
+      test('merge with null returns style equal to original', () {
+        final originalStyle = DataListStyler().rowSpacing(8.0);
+
+        final mergedStyle = originalStyle.merge(null);
+
+        expect(mergedStyle, equals(originalStyle));
+      });
+
+      testWidgets('merge resolves with last-wins scalars', (tester) async {
+        final merged = DataListStyler()
+            .rowSpacing(8.0)
+            .minLabelWidth(100.0)
+            .merge(DataListStyler().rowSpacing(12.0).columnSpacing(24.0));
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Builder(
+              builder: (context) {
+                final spec = merged.resolve(context).spec;
+
+                expect(spec.rowSpacing, equals(12.0));
+                expect(spec.minLabelWidth, equals(100.0));
+                expect(spec.columnSpacing, equals(24.0));
+
+                return Container();
+              },
+            ),
+          ),
+        );
+      });
+
+      testWidgets('merge accumulates nested slot styles', (tester) async {
+        final merged = DataListStyler()
+            .label(TextStyler().fontSize(12))
+            .merge(DataListStyler().labelColor(Colors.grey));
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Builder(
+              builder: (context) {
+                final spec = merged.resolve(context).spec;
+                final textStyle = spec.label.spec.style;
+
+                expect(textStyle?.fontSize, equals(12.0));
+                expect(textStyle?.color, equals(Colors.grey));
+
+                return Container();
+              },
+            ),
+          ),
+        );
+      });
+    });
+
+    group('Variants', () {
+      testWidgets('context variant resolves for the surrounding Mix context', (
+        tester,
+      ) async {
+        final style = DataListStyler()
+            .rowSpacing(8.0)
+            .onDark(.rowSpacing(24.0));
+        double? resolved;
+
+        // Variants merge inside StyleBuilder, the widget resolution path.
+        await tester.pumpWidget(
+          MaterialApp(
+            home: MediaQuery(
+              data: const MediaQueryData(platformBrightness: Brightness.dark),
+              child: StyleBuilder<DataListSpec>(
+                style: style,
+                builder: (context, spec) {
+                  resolved = spec.rowSpacing;
+
+                  return const SizedBox();
+                },
+              ),
+            ),
+          ),
+        );
+
+        expect(resolved, equals(24.0));
+      });
+    });
+
+    group('Equality', () {
+      test('identical styles are equal', () {
+        final style1 = DataListStyler().rowSpacing(8.0);
+        final style2 = DataListStyler().rowSpacing(8.0);
+
+        expect(style1, equals(style2));
+        expect(style1.hashCode, equals(style2.hashCode));
+      });
+
+      test('styles with different properties are not equal', () {
+        final style1 = DataListStyler().rowSpacing(8.0);
+        final style2 = DataListStyler().rowSpacing(12.0);
+
+        expect(style1, isNot(equals(style2)));
+      });
+    });
+
+    group('Props', () {
+      test('props list contains all properties', () {
+        final style = DataListStyler();
+
+        expect(style.props, hasLength(12));
+        expect(style.props, contains(style.$container));
+        expect(style.props, contains(style.$labelContainer));
+        expect(style.props, contains(style.$valueContainer));
+        expect(style.props, contains(style.$label));
+        expect(style.props, contains(style.$value));
+        expect(style.props, contains(style.$rowSpacing));
+        expect(style.props, contains(style.$columnSpacing));
+        expect(style.props, contains(style.$labelValueSpacing));
+        expect(style.props, contains(style.$minLabelWidth));
+      });
+    });
+
+    group('Chaining', () {
+      test('multiple style methods can be chained', () {
+        final style = DataListStyler()
+            .labelColor(Colors.grey)
+            .valueColor(Colors.black)
+            .rowSpacing(8.0)
+            .columnSpacing(16.0)
+            .minLabelWidth(120.0);
+
+        expect(style, isA<DataListStyler>());
+        expect(style.$label, isNotNull);
+        expect(style.$value, isNotNull);
+        expect(style.$rowSpacing, isNotNull);
+      });
+    });
+  });
+}

--- a/packages/remix/test/components/data_list/data_list_widget_test.dart
+++ b/packages/remix/test/components/data_list/data_list_widget_test.dart
@@ -1,6 +1,7 @@
 import 'dart:ui' show SemanticsRole;
 
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart' show RenderParagraph;
 import 'package:flutter/semantics.dart' hide SemanticsRole;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:remix/remix.dart';
@@ -175,6 +176,48 @@ void main() {
         expect(_table, findsOneWidget);
         expect(find.text('Name'), findsOneWidget);
         expect(find.text('leo@example.com'), findsOneWidget);
+      });
+
+      testWidgets('horizontal orientation answers intrinsic dimensions', (
+        tester,
+      ) async {
+        await tester.pumpRemixApp(
+          IntrinsicWidth(
+            child: RemixDataList(
+              style: _metricStyle().columnSpacing(12.0),
+              items: const [
+                RemixDataListItem(label: 'Name', value: 'Leo'),
+                RemixDataListItem(label: 'Email', value: 'leo@example.com'),
+              ],
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(tester.takeException(), isNull);
+        expect(_table, findsOneWidget);
+        expect(tester.getSize(_table).width, isPositive);
+      });
+
+      testWidgets('horizontal orientation renders as AlertDialog content', (
+        tester,
+      ) async {
+        await tester.pumpRemixApp(
+          AlertDialog(
+            content: RemixDataList(
+              style: _metricStyle(),
+              items: const [
+                RemixDataListItem(label: 'Name', value: 'Leo'),
+                RemixDataListItem(label: 'Email', value: 'leo@example.com'),
+              ],
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(tester.takeException(), isNull);
+        expect(find.byType(AlertDialog), findsOneWidget);
+        expect(_table, findsOneWidget);
       });
 
       testWidgets('vertical orientation stacks items without a Table', (
@@ -883,11 +926,11 @@ void main() {
       });
 
       testWidgets(
-        'long label keeps a min-intrinsic value column and wraps at ~240px',
+        'long label leaves a grapheme-wide text value column at ~240px',
         (tester) async {
           // FlutterTest font: 10px/char. Label ideal 260px would eat the
-          // whole 240px bound; the value column must keep its min intrinsic
-          // width (longest word, 40px) while the label wraps.
+          // whole 240px bound; the textual value keeps one grapheme (10px)
+          // while both columns wrap.
           await tester.pumpRemixApp(
             SizedBox(
               width: 240,
@@ -908,19 +951,19 @@ void main() {
           expect(tester.getSize(_table).width, equals(240.0));
 
           final valueSize = tester.getSize(find.text('Dddd Eeee'));
-          expect(valueSize.width, equals(40.0));
+          expect(valueSize.width, equals(10.0));
           expect(valueSize.height, greaterThanOrEqualTo(20.0));
 
           final labelSize = tester.getSize(
             find.text('Aaaaaaaa Bbbbbbbb Cccccccc'),
           );
-          expect(labelSize.width, equals(200.0));
+          expect(labelSize.width, equals(230.0));
           expect(labelSize.height, greaterThanOrEqualTo(20.0));
         },
       );
 
       testWidgets(
-        'long label and long value keep both columns at 200% text scale',
+        'long label keeps a scaled grapheme-wide value minimum at 200%',
         (tester) async {
           await tester.pumpRemixApp(
             MediaQuery(
@@ -942,13 +985,13 @@ void main() {
           await tester.pumpAndSettle();
 
           expect(tester.takeException(), isNull);
-          // At 2x both columns land exactly on their min intrinsic widths:
-          // label 2 * 80 = 160, value 2 * 40 = 80.
+          // At 2x the textual value keeps one scaled grapheme (20px), and the
+          // label receives the rest of the bounded width.
           expect(tester.getSize(_table).width, equals(240.0));
-          expect(tester.getSize(find.text('Dddd Eeee')).width, equals(80.0));
+          expect(tester.getSize(find.text('Dddd Eeee')).width, equals(20.0));
           expect(
             tester.getSize(find.text('Aaaaaaaa Bbbbbbbb Cccccccc')).width,
-            equals(160.0),
+            equals(220.0),
           );
         },
       );
@@ -1317,6 +1360,139 @@ void main() {
     group('Text Scale and Width Bounds', () {
       const longValue =
           'Uma descrição razoavelmente longa que quebra em várias linhas';
+
+      testWidgets(
+        'bounded textual IDs break within the value column at scale and RTL',
+        (tester) async {
+          const value = 'usr_01JAVERYLONGIDENTIFIERWITHOUTBREAKS_987654321';
+
+          for (final textDirection in TextDirection.values) {
+            for (final scale in [1.0, 2.0]) {
+              await tester.pumpRemixApp(
+                MediaQuery(
+                  data: MediaQueryData(textScaler: TextScaler.linear(scale)),
+                  child: SizedBox(
+                    width: 180,
+                    child: RemixDataList(
+                      style: _metricStyle()
+                          .minLabelWidth(60.0)
+                          .columnSpacing(12.0),
+                      items: const [
+                        RemixDataListItem(label: 'ID', value: value),
+                      ],
+                    ),
+                  ),
+                ),
+                textDirection: textDirection,
+              );
+              await tester.pumpAndSettle();
+
+              expect(tester.takeException(), isNull);
+              final tableRect = tester.getRect(_table);
+              final valueRect = tester.getRect(find.text(value));
+              expect(
+                valueRect.left,
+                greaterThanOrEqualTo(tableRect.left),
+                reason:
+                    'the value must stay inside its table at ${scale}x '
+                    'in ${textDirection.name}',
+              );
+              expect(
+                valueRect.right,
+                lessThanOrEqualTo(tableRect.right),
+                reason:
+                    'the value must stay inside its table at ${scale}x '
+                    'in ${textDirection.name}',
+              );
+              expect(
+                valueRect.height,
+                greaterThan(10.0 * scale),
+                reason:
+                    'the unbroken value must wrap at ${scale}x '
+                    'in ${textDirection.name}',
+              );
+            }
+          }
+        },
+      );
+
+      testWidgets(
+        'bounded textual values preserve grapheme clusters and semantics',
+        (tester) async {
+          final handle = tester.ensureSemantics();
+          const cluster = 'e\u0301';
+          const value = '$cluster$cluster$cluster$cluster$cluster';
+
+          await tester.pumpRemixApp(
+            SizedBox(
+              width: 36,
+              child: RemixDataList(
+                style: _metricStyle().minLabelWidth(20.0).columnSpacing(4.0),
+                items: const [RemixDataListItem(label: 'I', value: value)],
+              ),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          expect(tester.takeException(), isNull);
+          final tableRect = tester.getRect(_table);
+          final valueFinder = find.text(value);
+          final valueRect = tester.getRect(valueFinder);
+          expect(valueRect.left, greaterThanOrEqualTo(tableRect.left));
+          expect(valueRect.right, lessThanOrEqualTo(tableRect.right));
+          expect(valueRect.height, greaterThan(10.0));
+
+          final paragraph = tester.renderObject<RenderParagraph>(valueFinder);
+          for (
+            var offset = 0;
+            offset < value.length;
+            offset += cluster.length
+          ) {
+            final boxes = paragraph.getBoxesForSelection(
+              TextSelection(
+                baseOffset: offset,
+                extentOffset: offset + cluster.length,
+              ),
+            );
+            expect(boxes, isNotEmpty);
+            expect(
+              boxes.map((box) => box.top).toSet(),
+              hasLength(1),
+              reason: 'a grapheme cluster must not cross a line boundary',
+            );
+          }
+
+          expect(
+            _rowNodes(tester).single.getSemanticsData().value,
+            equals(value),
+          );
+          handle.dispose();
+        },
+      );
+
+      testWidgets('bounded custom children keep their intrinsic width', (
+        tester,
+      ) async {
+        const probeKey = ValueKey('bounded-custom-value');
+        await tester.pumpRemixApp(
+          SizedBox(
+            width: 70,
+            child: RemixDataList(
+              style: _metricStyle().minLabelWidth(20.0).columnSpacing(10.0),
+              items: const [
+                RemixDataListItem(
+                  label: 'I',
+                  child: SizedBox(key: probeKey, width: 60, height: 10),
+                ),
+              ],
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(tester.takeException(), isNull);
+        expect(tester.getSize(find.byKey(probeKey)).width, equals(60.0));
+      });
 
       testWidgets('soft-wrappable values wrap at 200% and 300% scale', (
         tester,

--- a/packages/remix/test/components/data_list/data_list_widget_test.dart
+++ b/packages/remix/test/components/data_list/data_list_widget_test.dart
@@ -1,0 +1,970 @@
+import 'dart:ui' show SemanticsRole;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart' hide SemanticsRole;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:remix/remix.dart';
+
+import '../../helpers/test_helpers.dart';
+
+/// The horizontal renderer uses a private [Table] subclass, so match by
+/// subtype instead of by exact runtime type.
+final Finder _table = find.byWidgetPredicate((widget) => widget is Table);
+
+/// Deterministic typography for geometry assertions: the FlutterTest font has
+/// a 0.75em ascent and 0.25em descent, and `height: 1.0` pins the line height
+/// to the font size.
+DataListStyler _metricStyle({double labelSize = 10, double valueSize = 10}) {
+  return DataListStyler()
+      .labelTextStyle(TextStyleMix(fontSize: labelSize, height: 1.0))
+      .valueTextStyle(TextStyleMix(fontSize: valueSize, height: 1.0));
+}
+
+SemanticsNode? _findNode(
+  SemanticsNode root,
+  bool Function(SemanticsData data) predicate,
+) {
+  if (predicate(root.getSemanticsData())) return root;
+  SemanticsNode? found;
+  root.visitChildren((child) {
+    found ??= _findNode(child, predicate);
+    return found == null;
+  });
+  return found;
+}
+
+SemanticsNode? _listNode(WidgetTester tester) {
+  final anchor = tester.getSemantics(find.byType(RemixDataList));
+  return _findNode(anchor, (data) => data.role == SemanticsRole.list);
+}
+
+List<SemanticsNode> _rowNodes(WidgetTester tester) {
+  final list = _listNode(tester);
+  expect(list, isNotNull, reason: 'Expected a list semantics node.');
+  final rows = <SemanticsNode>[];
+  list!.visitChildren((node) {
+    rows.add(node);
+    return true;
+  });
+  return rows;
+}
+
+int _countNodesWithLabel(WidgetTester tester, String label) {
+  var count = 0;
+  void visit(SemanticsNode node) {
+    if (node.getSemanticsData().label == label) count += 1;
+    node.visitChildren((child) {
+      visit(child);
+      return true;
+    });
+  }
+
+  visit(tester.getSemantics(find.byType(RemixDataList)));
+  return count;
+}
+
+void main() {
+  group('RemixDataListItem', () {
+    test('accepts a string value or a custom child', () {
+      expect(
+        () => const RemixDataListItem(label: 'Name', value: 'Leo'),
+        returnsNormally,
+      );
+      expect(
+        () => const RemixDataListItem(label: 'Name', child: SizedBox()),
+        returnsNormally,
+      );
+    });
+
+    test('rejects providing both value and child', () {
+      expect(
+        () => RemixDataListItem(
+          label: 'Name',
+          value: 'Leo',
+          child: const SizedBox(),
+        ),
+        throwsAssertionError,
+      );
+    });
+
+    test('rejects providing neither value nor child', () {
+      expect(() => RemixDataListItem(label: 'Name'), throwsAssertionError);
+    });
+
+    test('rejects empty label', () {
+      expect(
+        () => RemixDataListItem(label: '', value: 'Leo'),
+        throwsAssertionError,
+      );
+    });
+
+    test('rejects empty value', () {
+      expect(
+        () => RemixDataListItem(label: 'Name', value: ''),
+        throwsAssertionError,
+      );
+    });
+
+    test('rejects semanticValue without child', () {
+      expect(
+        () => RemixDataListItem(
+          label: 'Name',
+          value: 'Leo',
+          semanticValue: 'Leo',
+        ),
+        throwsAssertionError,
+      );
+    });
+
+    test('rejects empty semanticValue', () {
+      expect(
+        () => RemixDataListItem(
+          label: 'Name',
+          child: const SizedBox(),
+          semanticValue: '',
+        ),
+        throwsAssertionError,
+      );
+    });
+  });
+
+  group('RemixDataList Widget Tests', () {
+    group('Basic Rendering', () {
+      testWidgets('horizontal orientation renders one shared Table', (
+        tester,
+      ) async {
+        await tester.pumpRemixApp(
+          const RemixDataList(
+            items: [
+              RemixDataListItem(label: 'Name', value: 'Leo'),
+              RemixDataListItem(label: 'Email', value: 'leo@example.com'),
+            ],
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.byType(RemixDataList), findsOneWidget);
+        expect(_table, findsOneWidget);
+        expect(find.text('Name'), findsOneWidget);
+        expect(find.text('leo@example.com'), findsOneWidget);
+      });
+
+      testWidgets('vertical orientation stacks items without a Table', (
+        tester,
+      ) async {
+        await tester.pumpRemixApp(
+          const RemixDataList(
+            orientation: Axis.vertical,
+            items: [
+              RemixDataListItem(label: 'Name', value: 'Leo'),
+              RemixDataListItem(label: 'Email', value: 'leo@example.com'),
+            ],
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(_table, findsNothing);
+        expect(find.text('Name'), findsOneWidget);
+        expect(find.text('leo@example.com'), findsOneWidget);
+      });
+
+      testWidgets('renders an empty item list', (tester) async {
+        final handle = tester.ensureSemantics();
+        await tester.pumpRemixApp(
+          const RemixDataList(semanticLabel: 'Account', items: []),
+        );
+        await tester.pumpAndSettle();
+
+        expect(tester.takeException(), isNull);
+        expect(_rowNodes(tester), isEmpty);
+        handle.dispose();
+      });
+
+      testWidgets('renders with raw styleSpec parameter', (tester) async {
+        await tester.pumpRemixApp(
+          const RemixDataList(
+            styleSpec: DataListSpec(),
+            items: [RemixDataListItem(label: 'Name', value: 'Leo')],
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.byType(RemixDataList), findsOneWidget);
+        expect(find.text('Leo'), findsOneWidget);
+      });
+
+      testWidgets('renders a custom child value', (tester) async {
+        await tester.pumpRemixApp(
+          const RemixDataList(
+            items: [
+              RemixDataListItem(
+                label: 'Status',
+                child: SizedBox(width: 20, height: 20),
+              ),
+            ],
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(tester.takeException(), isNull);
+        expect(find.text('Status'), findsOneWidget);
+      });
+    });
+
+    group('Item List Contract', () {
+      testWidgets('each build reads a fresh snapshot of the retained list', (
+        tester,
+      ) async {
+        final items = <RemixDataListItem>[
+          const RemixDataListItem(label: 'Name', value: 'Leo'),
+        ];
+
+        await tester.pumpRemixApp(RemixDataList(items: items));
+        await tester.pumpAndSettle();
+        expect(find.text('Name'), findsOneWidget);
+        expect(find.text('Email'), findsNothing);
+
+        items.add(const RemixDataListItem(label: 'Email', value: 'a@b.co'));
+        await tester.pumpRemixApp(RemixDataList(items: items));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Name'), findsOneWidget);
+        expect(find.text('Email'), findsOneWidget);
+      });
+
+      testWidgets('rejects negative resolved rowSpacing', (tester) async {
+        await tester.pumpRemixApp(
+          RemixDataList(
+            style: DataListStyler().rowSpacing(-4.0),
+            items: const [RemixDataListItem(label: 'Name', value: 'Leo')],
+          ),
+        );
+
+        expect(tester.takeException(), isAssertionError);
+      });
+
+      testWidgets('rejects negative resolved minLabelWidth', (tester) async {
+        await tester.pumpRemixApp(
+          RemixDataList(
+            style: DataListStyler().minLabelWidth(-1.0),
+            items: const [RemixDataListItem(label: 'Name', value: 'Leo')],
+          ),
+        );
+
+        expect(tester.takeException(), isAssertionError);
+      });
+    });
+
+    group('Semantics', () {
+      testWidgets('root exposes a list role with an optional label', (
+        tester,
+      ) async {
+        final handle = tester.ensureSemantics();
+        await tester.pumpRemixApp(
+          const RemixDataList(
+            semanticLabel: 'Account details',
+            items: [RemixDataListItem(label: 'Name', value: 'Leo')],
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final list = _listNode(tester);
+        expect(list, isNotNull);
+        expect(list!.getSemanticsData().label, equals('Account details'));
+        handle.dispose();
+      });
+
+      testWidgets('string row is one list-item node with label and value', (
+        tester,
+      ) async {
+        final handle = tester.ensureSemantics();
+        await tester.pumpRemixApp(
+          const RemixDataList(
+            items: [
+              RemixDataListItem(label: 'Name', value: 'Leo'),
+              RemixDataListItem(label: 'Email', value: 'leo@example.com'),
+            ],
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final rows = _rowNodes(tester);
+        expect(rows, hasLength(2));
+
+        final first = rows[0].getSemanticsData();
+        expect(first.role, equals(SemanticsRole.listItem));
+        expect(first.label, equals('Name'));
+        expect(first.value, equals('Leo'));
+
+        final second = rows[1].getSemanticsData();
+        expect(second.label, equals('Email'));
+        expect(second.value, equals('leo@example.com'));
+
+        // Both visible text nodes are excluded beneath the row node.
+        expect(_countNodesWithLabel(tester, 'Name'), equals(1));
+        expect(_countNodesWithLabel(tester, 'Leo'), isZero);
+        handle.dispose();
+      });
+
+      testWidgets('vertical orientation exposes the same row semantics', (
+        tester,
+      ) async {
+        final handle = tester.ensureSemantics();
+        await tester.pumpRemixApp(
+          const RemixDataList(
+            orientation: Axis.vertical,
+            items: [RemixDataListItem(label: 'Name', value: 'Leo')],
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final rows = _rowNodes(tester);
+        expect(rows, hasLength(1));
+        final data = rows.single.getSemanticsData();
+        expect(data.role, equals(SemanticsRole.listItem));
+        expect(data.label, equals('Name'));
+        expect(data.value, equals('Leo'));
+        expect(_countNodesWithLabel(tester, 'Name'), equals(1));
+        handle.dispose();
+      });
+
+      testWidgets(
+        'custom interactive child keeps its action and label once',
+        (tester) async {
+          final handle = tester.ensureSemantics();
+          var pressed = 0;
+          await tester.pumpRemixApp(
+            RemixDataList(
+              items: [
+                RemixDataListItem(
+                  label: 'Status',
+                  child: RemixButton(
+                    label: 'Copy',
+                    onPressed: () => pressed += 1,
+                  ),
+                ),
+              ],
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          final rows = _rowNodes(tester);
+          expect(rows, hasLength(1));
+          final row = rows.single.getSemanticsData();
+          expect(row.role, equals(SemanticsRole.listItem));
+          expect(row.label, equals('Status'));
+
+          // The button survives as its own actionable node under the row.
+          final button = _findNode(
+            rows.single,
+            (data) =>
+                data.label == 'Copy' && data.hasAction(SemanticsAction.tap),
+          );
+          expect(button, isNotNull);
+
+          // The visual label is not announced a second time.
+          expect(_countNodesWithLabel(tester, 'Status'), equals(1));
+
+          await tester.tap(find.text('Copy'));
+          await tester.pumpAndSettle();
+          expect(pressed, equals(1));
+          handle.dispose();
+        },
+      );
+
+      testWidgets(
+        'semanticValue summarizes a noninteractive child into one node',
+        (tester) async {
+          final handle = tester.ensureSemantics();
+          await tester.pumpRemixApp(
+            const RemixDataList(
+              items: [
+                RemixDataListItem(
+                  label: 'Status',
+                  semanticValue: 'Authorized',
+                  child: Text('Complex Widget'),
+                ),
+              ],
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          final rows = _rowNodes(tester);
+          expect(rows, hasLength(1));
+          final row = rows.single.getSemanticsData();
+          expect(row.role, equals(SemanticsRole.listItem));
+          expect(row.label, equals('Status'));
+          expect(row.value, equals('Authorized'));
+
+          // The child's own semantics are excluded by the summary.
+          expect(_countNodesWithLabel(tester, 'Complex Widget'), isZero);
+          handle.dispose();
+        },
+      );
+
+      testWidgets('excludeSemantics removes the full list', (tester) async {
+        final handle = tester.ensureSemantics();
+        await tester.pumpRemixApp(
+          const RemixDataList(
+            excludeSemantics: true,
+            semanticLabel: 'Account',
+            items: [RemixDataListItem(label: 'Name', value: 'Leo')],
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final anchor = tester.getSemantics(find.byType(RemixDataList));
+        expect(
+          _findNode(anchor, (data) => data.role == SemanticsRole.list),
+          isNull,
+        );
+        expect(find.bySemanticsLabel('Name'), findsNothing);
+        handle.dispose();
+      });
+
+      testWidgets('RTL keeps the logical row order in semantics', (
+        tester,
+      ) async {
+        final handle = tester.ensureSemantics();
+        await tester.pumpRemixApp(
+          const RemixDataList(
+            items: [
+              RemixDataListItem(label: 'Name', value: 'Leo'),
+              RemixDataListItem(label: 'Email', value: 'leo@example.com'),
+            ],
+          ),
+          textDirection: TextDirection.rtl,
+        );
+        await tester.pumpAndSettle();
+
+        final rows = _rowNodes(tester);
+        expect(
+          rows.map((node) => node.getSemanticsData().label).toList(),
+          equals(['Name', 'Email']),
+        );
+        handle.dispose();
+      });
+    });
+
+    group('Horizontal Layout', () {
+      testWidgets('labels share one column width regardless of length', (
+        tester,
+      ) async {
+        await tester.pumpRemixApp(
+          SizedBox(
+            width: 400,
+            child: RemixDataList(
+              style: _metricStyle().columnSpacing(12.0),
+              items: const [
+                RemixDataListItem(label: 'A', value: 'first'),
+                RemixDataListItem(label: 'BBBB', value: 'second'),
+                RemixDataListItem(label: 'CCCCCCCC', value: 'third'),
+              ],
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final labelWidths = ['A', 'BBBB', 'CCCCCCCC']
+            .map((label) => tester.getSize(find.text(label)).width)
+            .toList();
+        expect(labelWidths[0], equals(labelWidths[1]));
+        expect(labelWidths[1], equals(labelWidths[2]));
+
+        final valueLefts = ['first', 'second', 'third']
+            .map((value) => tester.getTopLeft(find.text(value)).dx)
+            .toList();
+        expect(valueLefts[0], equals(valueLefts[1]));
+        expect(valueLefts[1], equals(valueLefts[2]));
+
+        // The shared boundary sits after the label column plus the gap.
+        final tableLeft = tester.getTopLeft(_table).dx;
+        expect(valueLefts[0], equals(tableLeft + labelWidths[0] + 12.0));
+      });
+
+      testWidgets('label column respects minLabelWidth', (tester) async {
+        await tester.pumpRemixApp(
+          SizedBox(
+            width: 400,
+            child: RemixDataList(
+              style: _metricStyle().minLabelWidth(140.0).columnSpacing(24.0),
+              items: const [RemixDataListItem(label: 'A', value: 'v')],
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final tableLeft = tester.getTopLeft(_table).dx;
+        expect(tester.getSize(find.text('A')).width, equals(140.0));
+        expect(
+          tester.getTopLeft(find.text('v')).dx,
+          equals(tableLeft + 140.0 + 24.0),
+        );
+      });
+
+      testWidgets('label column grows past minLabelWidth for a wide label', (
+        tester,
+      ) async {
+        await tester.pumpRemixApp(
+          SizedBox(
+            width: 400,
+            child: RemixDataList(
+              style: _metricStyle().minLabelWidth(10.0).columnSpacing(12.0),
+              items: const [
+                RemixDataListItem(label: 'CCCCCCCC', value: 'v'),
+              ],
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final labelWidth = tester.getSize(find.text('CCCCCCCC')).width;
+        expect(labelWidth, greaterThan(10.0));
+
+        final tableLeft = tester.getTopLeft(_table).dx;
+        expect(
+          tester.getTopLeft(find.text('v')).dx,
+          equals(tableLeft + labelWidth + 12.0),
+        );
+      });
+
+      testWidgets('value column flexes to the bounded width', (tester) async {
+        await tester.pumpRemixApp(
+          SizedBox(
+            width: 400,
+            child: RemixDataList(
+              style: _metricStyle(),
+              items: const [RemixDataListItem(label: 'A', value: 'v')],
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(tester.getSize(_table).width, equals(400.0));
+      });
+
+      testWidgets('value column becomes intrinsic under unbounded width', (
+        tester,
+      ) async {
+        await tester.pumpRemixApp(
+          SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            child: RemixDataList(
+              style: _metricStyle().columnSpacing(12.0),
+              items: const [RemixDataListItem(label: 'AB', value: 'CDE')],
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(tester.takeException(), isNull);
+        final labelWidth = tester.getSize(find.text('AB')).width;
+        final valueWidth = tester.getSize(find.text('CDE')).width;
+        expect(
+          tester.getSize(_table).width,
+          equals(labelWidth + 12.0 + valueWidth),
+        );
+      });
+
+      testWidgets('rowSpacing separates consecutive rows only', (
+        tester,
+      ) async {
+        await tester.pumpRemixApp(
+          SizedBox(
+            width: 400,
+            child: RemixDataList(
+              style: _metricStyle().rowSpacing(12.0),
+              items: const [
+                RemixDataListItem(label: 'A', value: 'first'),
+                RemixDataListItem(label: 'B', value: 'second'),
+              ],
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final firstTop = tester.getTopLeft(find.text('A')).dy;
+        final secondTop = tester.getTopLeft(find.text('B')).dy;
+        // One 10 px line plus the 12 px gap.
+        expect(secondTop - firstTop, equals(22.0));
+
+        final tableHeight = tester.getSize(_table).height;
+        // No trailing gap after the last row: two lines plus one gap.
+        expect(tableHeight, equals(32.0));
+      });
+
+      testWidgets(
+        'custom child keeps its natural width at the value column start',
+        (tester) async {
+          const probeKey = ValueKey('inline');
+          await tester.pumpRemixApp(
+            SizedBox(
+              width: 400,
+              child: RemixDataList(
+                style: _metricStyle().minLabelWidth(100.0).columnSpacing(24.0),
+                items: const [
+                  RemixDataListItem(label: 'A', value: 'text value'),
+                  RemixDataListItem(
+                    label: 'B',
+                    alignment: RemixDataListItemAlignment.start,
+                    child: SizedBox(key: probeKey, width: 20, height: 10),
+                  ),
+                ],
+              ),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          final tableLeft = tester.getTopLeft(_table).dx;
+          // A string value fills the column so long text can wrap.
+          expect(
+            tester.getSize(find.text('text value')).width,
+            equals(400.0 - 100.0 - 24.0),
+          );
+          // A custom child sits inline at the column start at natural size.
+          expect(tester.getSize(find.byKey(probeKey)).width, equals(20.0));
+          expect(
+            tester.getTopLeft(find.byKey(probeKey)).dx,
+            equals(tableLeft + 100.0 + 24.0),
+          );
+        },
+      );
+
+      testWidgets('RTL reverses column order and directional gap', (
+        tester,
+      ) async {
+        await tester.pumpRemixApp(
+          SizedBox(
+            width: 400,
+            child: RemixDataList(
+              style: _metricStyle().minLabelWidth(140.0).columnSpacing(24.0),
+              items: const [RemixDataListItem(label: 'A', value: 'v')],
+            ),
+          ),
+          textDirection: TextDirection.rtl,
+        );
+        await tester.pumpAndSettle();
+
+        final tableRight = tester.getTopRight(_table).dx;
+        final labelCenter = tester.getCenter(find.text('A')).dx;
+        final valueCenter = tester.getCenter(find.text('v')).dx;
+
+        // Label column occupies the trailing (right) edge in RTL.
+        expect(labelCenter, greaterThan(valueCenter));
+        expect(tester.getTopRight(find.text('A')).dx, equals(tableRight));
+        // The directional gap moves to the value cell's right side.
+        expect(
+          tester.getTopRight(find.text('v')).dx,
+          equals(tableRight - 140.0 - 24.0),
+        );
+      });
+    });
+
+    group('Item Alignment', () {
+      const probeKey = ValueKey('probe');
+      const probe = SizedBox(key: probeKey, width: 20, height: 60);
+
+      Future<void> pumpAligned(
+        WidgetTester tester,
+        RemixDataListItemAlignment alignment,
+      ) async {
+        await tester.pumpRemixApp(
+          SizedBox(
+            width: 300,
+            child: RemixDataList(
+              style: _metricStyle(),
+              items: [
+                RemixDataListItem(
+                  label: 'L',
+                  alignment: alignment,
+                  child: probe,
+                ),
+              ],
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+      }
+
+      testWidgets('start aligns both cells to the row top', (tester) async {
+        await pumpAligned(tester, RemixDataListItemAlignment.start);
+
+        expect(
+          tester.getTopLeft(find.text('L')).dy,
+          equals(tester.getTopLeft(find.byKey(probeKey)).dy),
+        );
+      });
+
+      testWidgets('center aligns both cell centers', (tester) async {
+        await pumpAligned(tester, RemixDataListItemAlignment.center);
+
+        expect(
+          tester.getCenter(find.text('L')).dy,
+          equals(tester.getCenter(find.byKey(probeKey)).dy),
+        );
+      });
+
+      testWidgets('end aligns both cell bottoms', (tester) async {
+        await pumpAligned(tester, RemixDataListItemAlignment.end);
+
+        expect(
+          tester.getBottomLeft(find.text('L')).dy,
+          equals(tester.getBottomLeft(find.byKey(probeKey)).dy),
+        );
+      });
+
+      testWidgets('stretch sizes both cells to the tallest cell', (
+        tester,
+      ) async {
+        await pumpAligned(tester, RemixDataListItemAlignment.stretch);
+
+        expect(tester.getSize(find.text('L')).height, equals(60.0));
+        expect(tester.getSize(find.byKey(probeKey)).height, equals(60.0));
+      });
+
+      testWidgets('string baseline row aligns text baselines', (tester) async {
+        await tester.pumpRemixApp(
+          SizedBox(
+            width: 300,
+            child: RemixDataList(
+              style: _metricStyle(labelSize: 10, valueSize: 30),
+              items: const [
+                RemixDataListItem(
+                  label: 'L',
+                  value: 'V',
+                  alignment: RemixDataListItemAlignment.baseline,
+                ),
+              ],
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final labelTop = tester.getTopLeft(find.text('L')).dy;
+        final valueTop = tester.getTopLeft(find.text('V')).dy;
+        // FlutterTest font baselines: 0.75 * 10 = 7.5 and 0.75 * 30 = 22.5.
+        expect(labelTop + 7.5, moreOrLessEquals(valueTop + 22.5));
+      });
+
+      testWidgets('custom-child baseline row deterministically maps to top', (
+        tester,
+      ) async {
+        await pumpAligned(tester, RemixDataListItemAlignment.baseline);
+
+        expect(
+          tester.getTopLeft(find.text('L')).dy,
+          equals(tester.getTopLeft(find.byKey(probeKey)).dy),
+        );
+      });
+
+      testWidgets('vertical baseline maps to start', (tester) async {
+        await tester.pumpRemixApp(
+          SizedBox(
+            width: 300,
+            child: RemixDataList(
+              orientation: Axis.vertical,
+              style: _metricStyle(),
+              items: const [
+                RemixDataListItem(
+                  label: 'L',
+                  alignment: RemixDataListItemAlignment.baseline,
+                  child: probe,
+                ),
+              ],
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(
+          tester.getTopLeft(find.text('L')).dx,
+          equals(tester.getTopLeft(find.byKey(probeKey)).dx),
+        );
+      });
+    });
+
+    group('Vertical Layout', () {
+      testWidgets('stacks label above value with labelValueSpacing', (
+        tester,
+      ) async {
+        await tester.pumpRemixApp(
+          SizedBox(
+            width: 300,
+            child: RemixDataList(
+              orientation: Axis.vertical,
+              style: _metricStyle().labelValueSpacing(4.0).rowSpacing(16.0),
+              items: const [
+                RemixDataListItem(label: 'A', value: 'first'),
+                RemixDataListItem(label: 'B', value: 'second'),
+              ],
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final labelBottom = tester.getBottomLeft(find.text('A')).dy;
+        final valueTop = tester.getTopLeft(find.text('first')).dy;
+        expect(valueTop - labelBottom, equals(4.0));
+
+        final firstValueBottom = tester.getBottomLeft(find.text('first')).dy;
+        final secondLabelTop = tester.getTopLeft(find.text('B')).dy;
+        expect(secondLabelTop - firstValueBottom, equals(16.0));
+      });
+
+      testWidgets('maps center and end across the horizontal cross axis', (
+        tester,
+      ) async {
+        const probeKey = ValueKey('wide');
+        await tester.pumpRemixApp(
+          SizedBox(
+            width: 300,
+            child: RemixDataList(
+              orientation: Axis.vertical,
+              style: _metricStyle(),
+              items: const [
+                RemixDataListItem(
+                  label: 'C',
+                  alignment: RemixDataListItemAlignment.center,
+                  child: SizedBox(key: probeKey, width: 40, height: 10),
+                ),
+              ],
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(
+          tester.getCenter(find.text('C')).dx,
+          equals(tester.getCenter(find.byKey(probeKey)).dx),
+        );
+
+        await tester.pumpRemixApp(
+          SizedBox(
+            width: 300,
+            child: RemixDataList(
+              orientation: Axis.vertical,
+              style: _metricStyle(),
+              items: const [
+                RemixDataListItem(
+                  label: 'E',
+                  alignment: RemixDataListItemAlignment.end,
+                  child: SizedBox(key: probeKey, width: 40, height: 10),
+                ),
+              ],
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(
+          tester.getBottomRight(find.text('E')).dx,
+          equals(tester.getBottomRight(find.byKey(probeKey)).dx),
+        );
+      });
+
+      testWidgets('stretch fills the bounded cross axis', (tester) async {
+        const probeKey = ValueKey('stretched');
+        await tester.pumpRemixApp(
+          SizedBox(
+            width: 300,
+            child: RemixDataList(
+              orientation: Axis.vertical,
+              style: _metricStyle(),
+              items: const [
+                RemixDataListItem(
+                  label: 'S',
+                  alignment: RemixDataListItemAlignment.stretch,
+                  child: SizedBox(key: probeKey, width: 40, height: 10),
+                ),
+              ],
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(tester.getSize(find.text('S')).width, equals(300.0));
+        expect(tester.getSize(find.byKey(probeKey)).width, equals(300.0));
+      });
+    });
+
+    group('Text Scale and Width Bounds', () {
+      const longValue =
+          'Uma descrição razoavelmente longa que quebra em várias linhas';
+
+      testWidgets('soft-wrappable values wrap at 200% and 300% scale', (
+        tester,
+      ) async {
+        for (final scale in [2.0, 3.0]) {
+          await tester.pumpRemixApp(
+            MediaQuery(
+              data: MediaQueryData(textScaler: TextScaler.linear(scale)),
+              child: SizedBox(
+                width: 360,
+                child: RemixDataList(
+                  style: _metricStyle().columnSpacing(12.0),
+                  items: const [
+                    RemixDataListItem(label: 'Info', value: longValue),
+                  ],
+                ),
+              ),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          expect(tester.takeException(), isNull);
+          final valueHeight = tester.getSize(find.text(longValue)).height;
+          expect(
+            valueHeight,
+            greaterThan(10.0 * scale),
+            reason: 'value should wrap to multiple lines at ${scale}x',
+          );
+        }
+      });
+
+      testWidgets(
+        'below the horizontal minimum the renderer keeps the explicit '
+        'orientation and the pinned label column',
+        (tester) async {
+          await tester.pumpRemixApp(
+            SizedBox(
+              width: 80,
+              child: RemixDataList(
+                style: _metricStyle().minLabelWidth(120.0).columnSpacing(12.0),
+                items: const [RemixDataListItem(label: 'A', value: 'v')],
+              ),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          // No hidden orientation switch and no relaxation of the pinned
+          // label column: the caller owns the responsive fallback.
+          expect(tester.takeException(), isNull);
+          expect(_table, findsOneWidget);
+          expect(tester.getSize(_table).width, equals(80.0));
+          expect(tester.getSize(find.text('A')).width, equals(120.0));
+        },
+      );
+
+      testWidgets('the same data renders vertically below the minimum', (
+        tester,
+      ) async {
+        await tester.pumpRemixApp(
+          SizedBox(
+            width: 80,
+            child: RemixDataList(
+              orientation: Axis.vertical,
+              style: _metricStyle().minLabelWidth(120.0).columnSpacing(12.0),
+              items: const [RemixDataListItem(label: 'A', value: 'v')],
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(tester.takeException(), isNull);
+        expect(_table, findsNothing);
+        expect(find.text('A'), findsOneWidget);
+        expect(find.text('v'), findsOneWidget);
+      });
+    });
+  });
+}

--- a/packages/remix/test/components/data_list/data_list_widget_test.dart
+++ b/packages/remix/test/components/data_list/data_list_widget_test.dart
@@ -12,12 +12,17 @@ import '../../helpers/test_helpers.dart';
 final Finder _table = find.byWidgetPredicate((widget) => widget is Table);
 
 /// Deterministic typography for geometry assertions: the FlutterTest font has
-/// a 0.75em ascent and 0.25em descent, and `height: 1.0` pins the line height
-/// to the font size.
+/// a 0.75em ascent and 0.25em descent, `height: 1.0` pins the line height to
+/// the font size, and `letterSpacing: 0` suppresses the inherited Material
+/// bodyMedium letter spacing so glyph advances are exactly 1em.
 DataListStyler _metricStyle({double labelSize = 10, double valueSize = 10}) {
   return DataListStyler()
-      .labelTextStyle(TextStyleMix(fontSize: labelSize, height: 1.0))
-      .valueTextStyle(TextStyleMix(fontSize: valueSize, height: 1.0));
+      .labelTextStyle(
+        TextStyleMix(fontSize: labelSize, height: 1.0, letterSpacing: 0),
+      )
+      .valueTextStyle(
+        TextStyleMix(fontSize: valueSize, height: 1.0, letterSpacing: 0),
+      );
 }
 
 SemanticsNode? _findNode(
@@ -47,6 +52,29 @@ List<SemanticsNode> _rowNodes(WidgetTester tester) {
     return true;
   });
   return rows;
+}
+
+/// Maps a semantics node's rect through its ancestor transforms into global
+/// coordinates, then divides out the root view's device-pixel-ratio scale so
+/// the result is comparable with [WidgetTester.getRect].
+Rect _globalSemanticsRect(WidgetTester tester, SemanticsNode node) {
+  var rect = node.rect;
+  SemanticsNode? current = node;
+  while (current != null) {
+    final transform = current.transform;
+    if (transform != null) {
+      rect = MatrixUtils.transformRect(transform, rect);
+    }
+    current = current.parent;
+  }
+  final scale = tester.view.devicePixelRatio;
+
+  return Rect.fromLTRB(
+    rect.left / scale,
+    rect.top / scale,
+    rect.right / scale,
+    rect.bottom / scale,
+  );
 }
 
 int _countNodesWithLabel(WidgetTester tester, String label) {
@@ -180,13 +208,21 @@ void main() {
         handle.dispose();
       });
 
-      testWidgets('renders with raw styleSpec parameter', (tester) async {
-        await tester.pumpRemixApp(
-          const RemixDataList(
-            styleSpec: DataListSpec(),
-            items: [RemixDataListItem(label: 'Name', value: 'Leo')],
-          ),
+      testWidgets('direct StyleSpec is const and bypasses style resolution', (
+        tester,
+      ) async {
+        const widget = RemixDataList(
+          style: _FailIfResolvedDataListStyler(),
+          styleSpec: StyleSpec(spec: DataListSpec()),
+          items: [RemixDataListItem(label: 'Name', value: 'Leo')],
         );
+        final Style<DataListSpec> style = widget.style;
+        final StyleSpec<DataListSpec>? styleSpec = widget.styleSpec;
+
+        expect(style, isA<_FailIfResolvedDataListStyler>());
+        expect(styleSpec?.spec, equals(const DataListSpec()));
+
+        await tester.pumpRemixApp(widget);
         await tester.pumpAndSettle();
 
         expect(find.byType(RemixDataList), findsOneWidget);
@@ -230,6 +266,91 @@ void main() {
 
         expect(find.text('Name'), findsOneWidget);
         expect(find.text('Email'), findsOneWidget);
+      });
+
+      testWidgets('rejects a blank label at build time', (tester) async {
+        await tester.pumpRemixApp(
+          const RemixDataList(
+            items: [RemixDataListItem(label: '   ', value: 'Leo')],
+          ),
+        );
+
+        expect(tester.takeException(), isAssertionError);
+      });
+
+      testWidgets('rejects a blank label at build time (vertical)', (
+        tester,
+      ) async {
+        await tester.pumpRemixApp(
+          const RemixDataList(
+            orientation: Axis.vertical,
+            items: [RemixDataListItem(label: '\n', value: 'Leo')],
+          ),
+        );
+
+        expect(tester.takeException(), isAssertionError);
+      });
+
+      testWidgets('rejects a blank value at build time', (tester) async {
+        await tester.pumpRemixApp(
+          const RemixDataList(
+            items: [RemixDataListItem(label: 'Name', value: '   ')],
+          ),
+        );
+
+        expect(tester.takeException(), isAssertionError);
+      });
+
+      testWidgets('rejects a blank semanticValue at build time', (
+        tester,
+      ) async {
+        await tester.pumpRemixApp(
+          const RemixDataList(
+            items: [
+              RemixDataListItem(
+                label: 'Name',
+                semanticValue: ' \t ',
+                child: SizedBox(width: 10, height: 10),
+              ),
+            ],
+          ),
+        );
+
+        expect(tester.takeException(), isAssertionError);
+      });
+
+      testWidgets('rejects a blank semanticLabel at build time', (
+        tester,
+      ) async {
+        await tester.pumpRemixApp(
+          const RemixDataList(
+            semanticLabel: '  ',
+            items: [RemixDataListItem(label: 'Name', value: 'Leo')],
+          ),
+        );
+
+        expect(tester.takeException(), isAssertionError);
+      });
+
+      testWidgets('padded caller text is displayed and announced verbatim', (
+        tester,
+      ) async {
+        final handle = tester.ensureSemantics();
+        await tester.pumpRemixApp(
+          const RemixDataList(
+            items: [RemixDataListItem(label: ' Name ', value: ' Leo ')],
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // Blank rejection is validation only — the renderer never trims or
+        // rewrites what the caller displays and announces.
+        expect(tester.takeException(), isNull);
+        expect(find.text(' Name '), findsOneWidget);
+        final row = _rowNodes(tester).single.getSemanticsData();
+        expect(row.label, equals(' Name '));
+        expect(row.value, equals(' Leo '));
+        handle.dispose();
       });
 
       testWidgets('rejects negative resolved rowSpacing', (tester) async {
@@ -279,7 +400,7 @@ void main() {
       ) async {
         final handle = tester.ensureSemantics();
         await tester.pumpRemixApp(
-          const RemixDataList(
+          RemixDataList(
             items: [
               RemixDataListItem(label: 'Name', value: 'Leo'),
               RemixDataListItem(label: 'Email', value: 'leo@example.com'),
@@ -311,7 +432,7 @@ void main() {
       ) async {
         final handle = tester.ensureSemantics();
         await tester.pumpRemixApp(
-          const RemixDataList(
+          RemixDataList(
             orientation: Axis.vertical,
             items: [RemixDataListItem(label: 'Name', value: 'Leo')],
           ),
@@ -328,49 +449,47 @@ void main() {
         handle.dispose();
       });
 
-      testWidgets(
-        'custom interactive child keeps its action and label once',
-        (tester) async {
-          final handle = tester.ensureSemantics();
-          var pressed = 0;
-          await tester.pumpRemixApp(
-            RemixDataList(
-              items: [
-                RemixDataListItem(
-                  label: 'Status',
-                  child: RemixButton(
-                    label: 'Copy',
-                    onPressed: () => pressed += 1,
-                  ),
+      testWidgets('custom interactive child keeps its action and label once', (
+        tester,
+      ) async {
+        final handle = tester.ensureSemantics();
+        var pressed = 0;
+        await tester.pumpRemixApp(
+          RemixDataList(
+            items: [
+              RemixDataListItem(
+                label: 'Status',
+                child: RemixButton(
+                  label: 'Copy',
+                  onPressed: () => pressed += 1,
                 ),
-              ],
-            ),
-          );
-          await tester.pumpAndSettle();
+              ),
+            ],
+          ),
+        );
+        await tester.pumpAndSettle();
 
-          final rows = _rowNodes(tester);
-          expect(rows, hasLength(1));
-          final row = rows.single.getSemanticsData();
-          expect(row.role, equals(SemanticsRole.listItem));
-          expect(row.label, equals('Status'));
+        final rows = _rowNodes(tester);
+        expect(rows, hasLength(1));
+        final row = rows.single.getSemanticsData();
+        expect(row.role, equals(SemanticsRole.listItem));
+        expect(row.label, equals('Status'));
 
-          // The button survives as its own actionable node under the row.
-          final button = _findNode(
-            rows.single,
-            (data) =>
-                data.label == 'Copy' && data.hasAction(SemanticsAction.tap),
-          );
-          expect(button, isNotNull);
+        // The button survives as its own actionable node under the row.
+        final button = _findNode(
+          rows.single,
+          (data) => data.label == 'Copy' && data.hasAction(SemanticsAction.tap),
+        );
+        expect(button, isNotNull);
 
-          // The visual label is not announced a second time.
-          expect(_countNodesWithLabel(tester, 'Status'), equals(1));
+        // The visual label is not announced a second time.
+        expect(_countNodesWithLabel(tester, 'Status'), equals(1));
 
-          await tester.tap(find.text('Copy'));
-          await tester.pumpAndSettle();
-          expect(pressed, equals(1));
-          handle.dispose();
-        },
-      );
+        await tester.tap(find.text('Copy'));
+        await tester.pumpAndSettle();
+        expect(pressed, equals(1));
+        handle.dispose();
+      });
 
       testWidgets(
         'semanticValue summarizes a noninteractive child into one node',
@@ -398,6 +517,176 @@ void main() {
 
           // The child's own semantics are excluded by the summary.
           expect(_countNodesWithLabel(tester, 'Complex Widget'), isZero);
+          handle.dispose();
+        },
+      );
+
+      testWidgets(
+        'horizontal row node covers the full visible row including the label',
+        (tester) async {
+          final handle = tester.ensureSemantics();
+          await tester.pumpRemixApp(
+            SizedBox(
+              width: 400,
+              child: RemixDataList(
+                style: _metricStyle()
+                    .minLabelWidth(140.0)
+                    .columnSpacing(24.0)
+                    .rowSpacing(12.0),
+                items: const [
+                  RemixDataListItem(label: 'Name', value: 'Leo'),
+                  RemixDataListItem(label: 'Email', value: 'leo@example.com'),
+                ],
+              ),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          final rows = _rowNodes(tester);
+          expect(rows, hasLength(2));
+
+          final tableRect = tester.getRect(_table);
+          final firstRowRect = _globalSemanticsRect(tester, rows[0]);
+          final secondRowRect = _globalSemanticsRect(tester, rows[1]);
+
+          // Touch exploration over the excluded visible label must land
+          // inside the row's semantic bounds.
+          expect(firstRowRect.left, equals(tableRect.left));
+          expect(firstRowRect.width, equals(tableRect.width));
+          expect(
+            firstRowRect.contains(tester.getRect(find.text('Name')).center),
+            isTrue,
+          );
+          expect(
+            secondRowRect.contains(tester.getRect(find.text('Email')).center),
+            isTrue,
+          );
+
+          // Rows tile the table without overlapping hit regions.
+          expect(
+            secondRowRect.top,
+            greaterThanOrEqualTo(firstRowRect.bottom - 0.01),
+          );
+          handle.dispose();
+        },
+      );
+
+      testWidgets('expanded row bounds leave nested control geometry intact', (
+        tester,
+      ) async {
+        final handle = tester.ensureSemantics();
+        await tester.pumpRemixApp(
+          SizedBox(
+            width: 400,
+            child: RemixDataList(
+              style: _metricStyle().minLabelWidth(140.0).columnSpacing(24.0),
+              items: [
+                RemixDataListItem(
+                  label: 'Status',
+                  child: RemixButton(label: 'Copy', onPressed: () {}),
+                ),
+              ],
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final rows = _rowNodes(tester);
+        final rowRect = _globalSemanticsRect(tester, rows.single);
+        final tableRect = tester.getRect(_table);
+        expect(rowRect.left, equals(tableRect.left));
+        expect(rowRect.width, equals(tableRect.width));
+
+        // The nested button's node keeps its own true geometry — the row
+        // expansion must not swallow or displace it.
+        final buttonNode = _findNode(
+          rows.single,
+          (data) => data.label == 'Copy' && data.hasAction(SemanticsAction.tap),
+        );
+        expect(buttonNode, isNotNull);
+        final buttonNodeRect = _globalSemanticsRect(tester, buttonNode!);
+        final buttonRect = tester.getRect(find.byType(RemixButton));
+        expect(buttonNodeRect.width, lessThan(rowRect.width));
+        expect(
+          (buttonNodeRect.center - buttonRect.center).distance,
+          lessThan(0.1),
+        );
+        expect(rowRect.contains(buttonRect.center), isTrue);
+        handle.dispose();
+      });
+
+      testWidgets(
+        'RTL row nodes cover the full row and keep nested action geometry',
+        (tester) async {
+          final handle = tester.ensureSemantics();
+          var pressed = 0;
+          await tester.pumpRemixApp(
+            SizedBox(
+              width: 400,
+              child: RemixDataList(
+                style: _metricStyle()
+                    .minLabelWidth(140.0)
+                    .columnSpacing(24.0)
+                    .rowSpacing(12.0),
+                items: [
+                  const RemixDataListItem(label: 'Name', value: 'Leo'),
+                  RemixDataListItem(
+                    label: 'Status',
+                    child: RemixButton(
+                      label: 'Copy',
+                      onPressed: () => pressed += 1,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            textDirection: TextDirection.rtl,
+          );
+          await tester.pumpAndSettle();
+
+          final rows = _rowNodes(tester);
+          expect(rows, hasLength(2));
+
+          final tableRect = tester.getRect(_table);
+          final firstRowRect = _globalSemanticsRect(tester, rows[0]);
+          final secondRowRect = _globalSemanticsRect(tester, rows[1]);
+
+          // The trailing (right-side) label column is inside each row's
+          // expanded semantic rect, and rows span the full table width.
+          for (final rowRect in [firstRowRect, secondRowRect]) {
+            expect(rowRect.left, equals(tableRect.left));
+            expect(rowRect.width, equals(tableRect.width));
+          }
+          final nameCenter = tester.getRect(find.text('Name')).center;
+          expect(nameCenter.dx, greaterThan(tableRect.center.dx));
+          expect(firstRowRect.contains(nameCenter), isTrue);
+          expect(
+            secondRowRect.contains(tester.getRect(find.text('Status')).center),
+            isTrue,
+          );
+
+          // The nested action keeps its true rect and stays actionable. In
+          // RTL a start-aligned custom child abuts the gap before the
+          // trailing label column: its right edge sits exactly at
+          // tableRight - minLabelWidth - columnSpacing.
+          final buttonNode = _findNode(
+            rows[1],
+            (data) =>
+                data.label == 'Copy' && data.hasAction(SemanticsAction.tap),
+          );
+          expect(buttonNode, isNotNull);
+          final buttonNodeRect = _globalSemanticsRect(tester, buttonNode!);
+          final buttonRect = tester.getRect(find.byType(RemixButton));
+          expect(buttonRect.right, equals(tableRect.right - 140.0 - 24.0));
+          expect(
+            (buttonNodeRect.center - buttonRect.center).distance,
+            lessThan(0.1),
+          );
+          expect(buttonNodeRect.width, lessThan(secondRowRect.width));
+
+          await tester.tap(find.text('Copy'));
+          await tester.pumpAndSettle();
+          expect(pressed, equals(1));
           handle.dispose();
         },
       );
@@ -465,15 +754,19 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        final labelWidths = ['A', 'BBBB', 'CCCCCCCC']
-            .map((label) => tester.getSize(find.text(label)).width)
-            .toList();
+        final labelWidths = [
+          'A',
+          'BBBB',
+          'CCCCCCCC',
+        ].map((label) => tester.getSize(find.text(label)).width).toList();
         expect(labelWidths[0], equals(labelWidths[1]));
         expect(labelWidths[1], equals(labelWidths[2]));
 
-        final valueLefts = ['first', 'second', 'third']
-            .map((value) => tester.getTopLeft(find.text(value)).dx)
-            .toList();
+        final valueLefts = [
+          'first',
+          'second',
+          'third',
+        ].map((value) => tester.getTopLeft(find.text(value)).dx).toList();
         expect(valueLefts[0], equals(valueLefts[1]));
         expect(valueLefts[1], equals(valueLefts[2]));
 
@@ -510,9 +803,7 @@ void main() {
             width: 400,
             child: RemixDataList(
               style: _metricStyle().minLabelWidth(10.0).columnSpacing(12.0),
-              items: const [
-                RemixDataListItem(label: 'CCCCCCCC', value: 'v'),
-              ],
+              items: const [RemixDataListItem(label: 'CCCCCCCC', value: 'v')],
             ),
           ),
         );
@@ -566,9 +857,7 @@ void main() {
         );
       });
 
-      testWidgets('rowSpacing separates consecutive rows only', (
-        tester,
-      ) async {
+      testWidgets('rowSpacing separates consecutive rows only', (tester) async {
         await tester.pumpRemixApp(
           SizedBox(
             width: 400,
@@ -592,6 +881,77 @@ void main() {
         // No trailing gap after the last row: two lines plus one gap.
         expect(tableHeight, equals(32.0));
       });
+
+      testWidgets(
+        'long label keeps a min-intrinsic value column and wraps at ~240px',
+        (tester) async {
+          // FlutterTest font: 10px/char. Label ideal 260px would eat the
+          // whole 240px bound; the value column must keep its min intrinsic
+          // width (longest word, 40px) while the label wraps.
+          await tester.pumpRemixApp(
+            SizedBox(
+              width: 240,
+              child: RemixDataList(
+                style: _metricStyle(),
+                items: const [
+                  RemixDataListItem(
+                    label: 'Aaaaaaaa Bbbbbbbb Cccccccc',
+                    value: 'Dddd Eeee',
+                  ),
+                ],
+              ),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          expect(tester.takeException(), isNull);
+          expect(tester.getSize(_table).width, equals(240.0));
+
+          final valueSize = tester.getSize(find.text('Dddd Eeee'));
+          expect(valueSize.width, equals(40.0));
+          expect(valueSize.height, greaterThanOrEqualTo(20.0));
+
+          final labelSize = tester.getSize(
+            find.text('Aaaaaaaa Bbbbbbbb Cccccccc'),
+          );
+          expect(labelSize.width, equals(200.0));
+          expect(labelSize.height, greaterThanOrEqualTo(20.0));
+        },
+      );
+
+      testWidgets(
+        'long label and long value keep both columns at 200% text scale',
+        (tester) async {
+          await tester.pumpRemixApp(
+            MediaQuery(
+              data: const MediaQueryData(textScaler: TextScaler.linear(2.0)),
+              child: SizedBox(
+                width: 240,
+                child: RemixDataList(
+                  style: _metricStyle(),
+                  items: const [
+                    RemixDataListItem(
+                      label: 'Aaaaaaaa Bbbbbbbb Cccccccc',
+                      value: 'Dddd Eeee',
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          expect(tester.takeException(), isNull);
+          // At 2x both columns land exactly on their min intrinsic widths:
+          // label 2 * 80 = 160, value 2 * 40 = 80.
+          expect(tester.getSize(_table).width, equals(240.0));
+          expect(tester.getSize(find.text('Dddd Eeee')).width, equals(80.0));
+          expect(
+            tester.getSize(find.text('Aaaaaaaa Bbbbbbbb Cccccccc')).width,
+            equals(160.0),
+          );
+        },
+      );
 
       testWidgets(
         'custom child keeps its natural width at the value column start',
@@ -887,6 +1247,73 @@ void main() {
       });
     });
 
+    group('Row Identity', () {
+      const itemA = RemixDataListItem(
+        key: ValueKey('a'),
+        label: 'Alpha',
+        child: _StatefulValue(id: 'A'),
+      );
+      const itemB = RemixDataListItem(
+        key: ValueKey('b'),
+        label: 'Beta',
+        child: _StatefulValue(id: 'B'),
+      );
+      const itemC = RemixDataListItem(
+        key: ValueKey('c'),
+        label: 'Gamma',
+        child: _StatefulValue(id: 'C'),
+      );
+
+      Future<void> pumpItems(
+        WidgetTester tester,
+        Axis orientation,
+        List<RemixDataListItem> items,
+      ) {
+        return tester.pumpRemixApp(
+          SizedBox(
+            width: 400,
+            child: RemixDataList(orientation: orientation, items: items),
+          ),
+        );
+      }
+
+      for (final orientation in Axis.values) {
+        testWidgets(
+          'keyed rows keep custom-value state across reorder, insertion, '
+          'and removal (${orientation.name})',
+          (tester) async {
+            await pumpItems(tester, orientation, const [itemA, itemB]);
+            await tester.pumpAndSettle();
+            await tester.tap(find.text('A:0'));
+            await tester.pump();
+            expect(find.text('A:1'), findsOneWidget);
+
+            // Reorder: state must follow the keyed row, not the position.
+            await pumpItems(tester, orientation, const [itemB, itemA]);
+            await tester.pumpAndSettle();
+            expect(find.text('A:1'), findsOneWidget);
+            expect(find.text('B:0'), findsOneWidget);
+            expect(
+              tester.getTopLeft(find.text('A:1')).dy,
+              greaterThan(tester.getTopLeft(find.text('B:0')).dy),
+            );
+
+            // Insertion above keeps existing state.
+            await pumpItems(tester, orientation, const [itemC, itemB, itemA]);
+            await tester.pumpAndSettle();
+            expect(find.text('A:1'), findsOneWidget);
+            expect(find.text('C:0'), findsOneWidget);
+
+            // Removal of a sibling keeps state.
+            await pumpItems(tester, orientation, const [itemC, itemA]);
+            await tester.pumpAndSettle();
+            expect(find.text('A:1'), findsOneWidget);
+            expect(find.text('B:0'), findsNothing);
+          },
+        );
+      }
+    });
+
     group('Text Scale and Width Bounds', () {
       const longValue =
           'Uma descrição razoavelmente longa que quebra em várias linhas';
@@ -967,4 +1394,36 @@ void main() {
       });
     });
   });
+}
+
+/// Position-independent stateful probe: taps increment a counter that must
+/// stay attached to this widget's row identity across list mutations.
+class _StatefulValue extends StatefulWidget {
+  const _StatefulValue({required this.id});
+
+  final String id;
+
+  @override
+  State<_StatefulValue> createState() => _StatefulValueState();
+}
+
+class _StatefulValueState extends State<_StatefulValue> {
+  var _count = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: () => setState(() => _count += 1),
+      child: Text('${widget.id}:$_count'),
+    );
+  }
+}
+
+final class _FailIfResolvedDataListStyler extends DataListStyler {
+  const _FailIfResolvedDataListStyler() : super.create();
+
+  @override
+  StyleSpec<DataListSpec> resolve(BuildContext context) {
+    throw StateError('Direct styleSpec must bypass style resolution.');
+  }
 }

--- a/packages/remix/test/public_api_compatibility_test.dart
+++ b/packages/remix/test/public_api_compatibility_test.dart
@@ -18,6 +18,9 @@ void main() {
     const progress = RemixProgress(value: 0.5);
     const tabBar = RemixTabBar(child: Text('Tabs'));
     const spinner = RemixSpinner();
+    const dataList = RemixDataList(
+      items: [RemixDataListItem(label: 'Status', value: 'Active')],
+    );
 
     expect(button.label, 'Save');
     expect(card.child, isA<Text>());
@@ -28,6 +31,16 @@ void main() {
     expect(progress.value, 0.5);
     expect(tabBar.child, isA<Text>());
     expect(spinner, isA<RemixSpinner>());
+    expect(dataList.items.single, isA<RemixDataListItem>());
+    expect(dataList.items.single.label, 'Status');
+    expect(dataList.items.single.value, 'Active');
+    expect(
+      dataList.items.single.alignment,
+      RemixDataListItemAlignment.baseline,
+    );
+    expect(dataList.orientation, Axis.horizontal);
+    expect(dataList.style, isA<DataListStyler>());
+    expect(dataList.styleSpec, isNull);
   });
 
   test('generated wrappers preserve generic and named constructors', () {

--- a/packages/remix/test/public_api_test.dart
+++ b/packages/remix/test/public_api_test.dart
@@ -1,7 +1,65 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:remix/remix.dart';
 
 void main() {
+  test('the data list family is constructible from the public API', () {
+    const item = RemixDataListItem(
+      key: ValueKey<String>('status'),
+      label: 'Status',
+      value: 'Active',
+      alignment: RemixDataListItemAlignment.center,
+    );
+    const rawStyleSpec = StyleSpec<DataListSpec>(
+      spec: DataListSpec(
+        rowSpacing: 8,
+        columnSpacing: 16,
+        labelValueSpacing: 4,
+        minLabelWidth: 120,
+      ),
+    );
+    const raw = RemixDataList(
+      key: ValueKey<String>('raw'),
+      items: [item],
+      orientation: Axis.vertical,
+      semanticLabel: 'Account details',
+      excludeSemantics: true,
+      styleSpec: rawStyleSpec,
+    );
+    final Style<DataListSpec> style = raw.style;
+    final StyleSpec<DataListSpec>? styleSpec = raw.styleSpec;
+
+    final DataListStyler styler = RemixDataList.styleFrom(
+      rowSpacing: 12,
+      columnSpacing: 20,
+      labelValueSpacing: 6,
+      minLabelWidth: 144,
+    );
+    final items = <RemixDataListItem>[item];
+    const forwardedKey = ValueKey<String>('forwarded');
+    final called = styler(
+      key: forwardedKey,
+      items: items,
+      orientation: Axis.vertical,
+      semanticLabel: 'Forwarded account details',
+      excludeSemantics: true,
+    );
+
+    expect(raw, isA<RemixDataList>());
+    expect(raw.items.single, same(item));
+    expect(style, isA<DataListStyler>());
+    expect(styleSpec, same(rawStyleSpec));
+    expect(styleSpec?.spec, isA<DataListSpec>());
+    expect(styler, isA<DataListStyler>());
+    expect(called, isA<RemixDataList>());
+    expect(called.key, forwardedKey);
+    expect(called.style, same(styler));
+    expect(called.items, same(items));
+    expect(called.orientation, Axis.vertical);
+    expect(called.semanticLabel, 'Forwarded account details');
+    expect(called.excludeSemantics, isTrue);
+  });
+
   test('mode-aware Fortal filters are constructible from the public API', () {
     final modifier = fortalModeAwareFilter(
       light: const [RemixCssColorFilterOperation.brightness(1.1)],


### PR DESCRIPTION
## Description

Adds `RemixDataList` and `RemixDataListItem` to the public Remix API for semantic label/value metadata. Horizontal mode negotiates one shared label column, supports intrinsic-width parents such as dialogs, and lets textual values wrap unbroken identifiers at Unicode grapheme boundaries. Custom value widgets retain their normal intrinsic minimum. Vertical mode stacks labels and values. Stable row keys and direct `StyleSpec<DataListSpec>` construction are supported.

`DataListSpec` uses the current Mix 2.2 prerelease code-generation surface with `RemixDataList.new` as its target. The generated `DataListStyler` provides the canonical fluent and widget-call APIs without a handwritten forwarding extension. There is no Naked primitive because DataList owns no interaction contract, and a Fortal visual recipe remains an explicit follow-up rather than an invented default.

Rows expose one list node and one full-row list-item node per entry. String values announce exactly the caller-supplied string, interactive children retain their actions, and `semanticValue` explicitly summarizes display-only children. The horizontal table is semantics-neutral and preserves row bounds, baselines, RTL order, text scaling, and custom-child geometry.

The final adversarial review found two real blockers in the original layout: `LayoutBuilder` could not answer intrinsic dimensions inside `IntrinsicWidth`/`AlertDialog`, and long unbroken identifiers could overflow even though Radix supports break-anywhere behavior. The fix removes the intrinsic-incompatible builder and changes only textual minimum-intrinsic reporting to the widest grapheme cluster; layout, painting, baselines, and semantics still come from the original `StyledText`.

## Visual Evidence

Captured and visually verified locally; the PNGs are ignored and are not part of the package diff:

- `.context/screenshots/data_list_light.png` — 1360×800, SHA-256 `9d2bd0d3c40636d907eb28930334598d5fdb7f8201a72cd90de7272326d95365`
- `.context/screenshots/data_list_dark.png` — 1360×800, SHA-256 `7eaff63d995d7df18af03c3a974b1327b254b033b78c73d434b6a81de6e46ad1`

The horizontal/vertical layouts, shared label column, wrapping bio, display-only status badge, and interactive Reveal button were inspected at full resolution in both themes. No clipping, overflow, tofu glyphs, or cropped content was observed. Hosted GitHub attachment upload remains pending because the connector and CLI do not expose the issue-attachment endpoint.

## Validation

- Test-first regressions reproduce the original `IntrinsicWidth`/`AlertDialog` exception and bounded unbroken-value overflow before the fix.
- Independent pinned Flutter 3.44 DataList plus public-API run — 115/115 passed on the exact post-review worktree.
- Full Remix package suite — 2300/2300 passed on the exact post-review worktree.
- `fvm flutter analyze --fatal-infos` — no issues.
- `fvm dart run tool/check_generated.dart` — 24 committed artifacts reproduced byte-for-byte.
- `fvm dart run tool/validate_docs.dart` — 26 MDX files, 87 analyzable examples, 79 app/example sources, and 5 consumer Markdown files passed.
- `fvm dart doc --dry-run .` — zero warnings and errors.
- Formatting and `git diff --check` — clean; exact five-file fix scope.
- Fix commit: `82f442e0b`.
- GitHub CI on the fix commit — full all-packages workflow and PR-title validation passed.

## Related Issues

- Publish prerequisite: #102

---

## Readiness gates

- [x] Code/API/semantics and final adversarial review complete.
- [x] Focused, full-package, analyzer, docs, Dartdoc, generation-parity, and GitHub CI gates green.
- [x] Light/dark captures retained and visually inspected.
- [ ] Manual VoiceOver/TalkBack smoke check is a release follow-up; automated semantics and activation tests pass.

## Breaking Change

Does this PR require users of the package to manually update their code?

- [ ] Yes, this is a breaking change.
- [x] No, this is not a breaking change.
