### PR TITLE
fix(remix): center segmented control segment content

### DIFF
--- a/docs/components/segmented_control.mdx
+++ b/docs/components/segmented_control.mdx
@@ -180,10 +180,12 @@ nearest `Directionality`. Track styling cannot override that direction; use
 ## Sizing and wrapping
 
 The default track is intrinsic width (or intrinsic height vertically). Every
-item receives the largest item's main-axis extent. Explicit track constraints
-divide the requested extent equally. In narrow parents, labels wrap inside
-equal segments; keep labels short and use a visible output label when the
-selection needs more explanation.
+item receives the largest item's main-axis extent, and each segment centers
+its icon and label inside that extent; set an `alignment` on the item
+container style to override. Explicit track constraints divide the requested
+extent equally. In narrow parents, labels wrap inside equal segments; keep
+labels short and use a visible output label when the selection needs more
+explanation.
 
 ## Styling anatomy
 

--- a/packages/remix/CHANGELOG.md
+++ b/packages/remix/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+- **FIX**: Center `RemixSegmentedControl` segment content along the main axis,
+  matching the Radix segmented control item anatomy. Equal segments make most
+  surfaces wider than their content, which previously start-aligned the
+  icon/label cluster. An explicit item container `alignment` still overrides
+  the centered default.
 - **FEAT**: Add `RemixSegmentedControl`, an equal-segment single-select control
   mapped from Radix Segmented Control. A custom render object sizes every
   segment to the largest one and divides an explicit track extent equally,

--- a/packages/remix/lib/src/components/segmented_control/segmented_control_widget.dart
+++ b/packages/remix/lib/src/components/segmented_control/segmented_control_widget.dart
@@ -296,8 +296,17 @@ class _RemixSegmentedControlItemWidget<T extends Object>
                       return RemixBoxWithEffects(
                         styleSpec: spec.container,
                         containerEffects: spec.containerEffects,
+                        // Equal segments make most surfaces wider than their
+                        // content, so center the main-axis free space the way
+                        // Radix's segmented control item label does. This must
+                        // stay on the Row: a default container alignment would
+                        // make the Box expand into bounded loose constraints
+                        // during the layout's cross-axis measurement pass. An
+                        // explicit item container alignment still overrides by
+                        // shrink-wrapping the Row.
                         child: Row(
                           mainAxisSize: MainAxisSize.min,
+                          mainAxisAlignment: MainAxisAlignment.center,
                           spacing: spec.spacing ?? 0,
                           children: [
                             if (data.icon != null)

--- a/packages/remix/test/components/segmented_control/segmented_control_widget_test.dart
+++ b/packages/remix/test/components/segmented_control/segmented_control_widget_test.dart
@@ -1822,6 +1822,49 @@ void main() {
       }
     });
 
+    testWidgets('segment content centers inside a wider segment', (
+      tester,
+    ) async {
+      Widget control({SegmentedControlItemStyler? item}) {
+        return RemixSegmentedControl<String>(
+          items: const [
+            RemixSegmentedControlItem(value: 'day', label: 'Day'),
+            RemixSegmentedControlItem(value: 'week', label: 'A long week'),
+          ],
+          selectedValue: 'day',
+          onChanged: (_) {},
+          style: SegmentedControlStyler(
+            item: (item ?? SegmentedControlItemStyler()).paddingX(12),
+          ),
+        );
+      }
+
+      await tester.pumpRemixApp(control());
+      await tester.pumpAndSettle();
+
+      final options = find.byType(NakedToggleOption<String>);
+      var segment = tester.getRect(options.at(0));
+      var label = tester.getRect(find.text('Day'));
+      final leadingGap = label.left - segment.left;
+      final trailingGap = segment.right - label.right;
+      expect(leadingGap, closeTo(trailingGap, 0.01));
+      expect(leadingGap, greaterThan(12));
+
+      // An explicit item container alignment overrides the centered default.
+      await tester.pumpRemixApp(
+        control(
+          item: SegmentedControlItemStyler().alignment(
+            AlignmentDirectional.centerStart,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      segment = tester.getRect(options.at(0));
+      label = tester.getRect(find.text('Day'));
+      expect(label.left - segment.left, closeTo(12, 0.01));
+    });
+
     testWidgets('horizontal segments fill the shared cross axis', (
       tester,
     ) async {


### PR DESCRIPTION
## Description

Follow-up to #108, from an adversarial review of the merged component: segment content start-aligned instead of centering whenever a segment is wider than its content — which is the normal case, since equal segments size every surface to the largest item. Radix (`.rt-SegmentedControlItemLabel`, flex `justify-content: center`), iOS, and Material segmented controls all center.

### Root cause and fix

- The equal-segment layout hands each segment tight constraints, so the item `Row` stretched to the full segment extent and `MainAxisAlignment.start` left all free space trailing.
- Fix is one line of anatomy: `mainAxisAlignment: MainAxisAlignment.center` on the item Row — the same mechanism Radix uses.
- A defaulted item container `alignment` was considered and rejected: a Box alignment makes the surface expand into bounded loose constraints during the equal-segment layout's cross-axis measurement pass, ballooning the track. `mainAxisAlignment` only distributes free space and never changes the Row's size, so layout, intrinsics, and dry layout are untouched. Rationale is recorded as a code comment.
- An explicit item container `alignment` still overrides the centered default by shrink-wrapping the Row (covered by the new test).
- Cross-axis centering already worked (`crossAxisAlignment.center` plus the layout's stretch pass); no change there.

### Measured evidence

Docs-style padding with items `Day` / `This is a week`, gaps around the `Day` label inside its segment:

| | leading gap | trailing gap |
| --- | --- | --- |
| before | 12.0 | 168.75 |
| after | centered | centered (test asserts leading == trailing) |

### Scope

- No new style knob: container `alignment` already covers custom placement, so a spec field would be redundant surface.
- No playground/docs example changes needed — they now render centered by default; the docs sizing section documents the default and its override.
- Tests: new `segment content centers inside a wider segment` case (default + override); all 94 segmented-control tests pass; `flutter analyze` clean.