### PR TITLE
chore(release): remix 1.0.0-beta.2, remix_fortal 0.1.0-beta.1

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "packages/remix": "1.0.0-beta.1",
+  "packages/remix": "1.0.0-beta.2",
   "packages/remix_fortal": "0.1.0-beta.1"
 }

--- a/packages/remix/CHANGELOG.md
+++ b/packages/remix/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 1.0.0-beta.2
 
 - **FEAT**: Lower the supported floor to Dart 3.11 / Flutter 3.41, matching
   `mix` and `naked_ui`, so the whole family installs together. Only one call

--- a/packages/remix/pubspec.yaml
+++ b/packages/remix/pubspec.yaml
@@ -12,7 +12,7 @@ topics:
   - styling
   - mix
 
-version: 1.0.0-beta.1
+version: 1.0.0-beta.2
 
 # Consumer floor, matching `mix` and `naked_ui`. Intentionally lower than the
 # workspace's own toolchain floor: dev tooling needs a newer SDK than the

--- a/packages/remix_fortal/pubspec.yaml
+++ b/packages/remix_fortal/pubspec.yaml
@@ -36,7 +36,7 @@ dependencies:
   # — otherwise pub could resolve a `remix` whose symbols collide with this
   # package. `tool/fortal_parity/check.dart` (_checkRemixHostedPin) fails if the
   # two ever fall out of sync.
-  remix: ^1.0.0-beta.1 # x-release-please-version
+  remix: ^1.0.0-beta.2 # x-release-please-version
   mix: ^2.2.0-beta.1
   mix_annotations: ^2.2.0-beta.1
   naked_ui: ^1.0.0-beta.8


### PR DESCRIPTION
Release prep for the first `remix_fortal` publish and the `remix` release that drops Fortal.

| Package | From | To |
|---|---|---|
| `remix` | 1.0.0-beta.1 | **1.0.0-beta.2** |
| `remix_fortal` | — (unpublished) | **0.1.0-beta.1** |

Also moves `remix_fortal`'s `remix` floor to `^1.0.0-beta.2`.

## Why this is hand-rolled

`release-please` cannot produce this release. Run [31284764884](https://github.com/conceptadev/remix/actions/runs/31284764884) failed, and the branch it wrote shows two independent defects:

1. **Malformed versions.** Its `dart` strategy misparsed `1.0.0-beta.1` as `1.0.0+-beta.1` — prerelease read as build metadata — and proposed `version: 2.0.0-beta.1+-beta.1` for `remix` and `1.0.0-beta.1+-beta.1` for `remix_fortal`.
2. **Wrong bumps.** The squashed `feat(remix)!` touches both package directories, so the breaking change was attributed to both: `remix` → 2.0.0 (should stay on the 1.0.0 beta line) and `remix_fortal` → 1.0.0 (it has never been published; every artifact in the repo declares 0.1.0-beta.1).

Separately, the run failed outright with `GitHub Actions is not permitted to create or approve pull requests`. `repos/conceptadev/remix/actions/permissions/workflow` reports `can_approve_pull_request_reviews: false`, so release-please has never been able to open its PR. That needs **Settings → Actions → General → Workflow permissions**.

## Publish order matters

`remix` 1.0.0-beta.1 is published and still exports `FortalScope` / `FortalTokens` / `Fortal*`. `remix_fortal` must not resolve it, which is what the `^1.0.0-beta.2` floor and `_checkRemixHostedPin` enforce. Tags must go one at a time:

```
git push origin v1.0.0-beta.2            # wait for pub.dev to serve it
git push origin remix_fortal-v0.1.0-beta.1
```

pub.dev does not verify that a dependency version exists at publish time, so the wrong order ships an uninstallable `remix_fortal` rather than failing the job.

## Verification

`fortal:parity:check`, `toolchain:check` pass · workspace resolves · `flutter analyze` clean · both `pub publish --dry-run` runs reported 0 warnings on this content.