### PR TITLE
chore(skills): vendor Mix skill for Codex and Claude

### DIFF
--- a/.agents/skills/mix/SKILL.md
+++ b/.agents/skills/mix/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: mix
+description: >-
+  Use when building or maintaining Flutter UI with the Mix styling framework:
+  Mix specs and stylers, BoxStyler, TextStyler, Pressable, FlexBox, WrapBox,
+  GridBox, StackBox, responsive layouts, fluent chaining, Prop values, Mix
+  annotations and mix_generator code generation, dot shorthand, variants,
+  animations, design tokens and MixScope, widget modifiers, directives, style
+  mixins, or the Mix monorepo packages (mix, mix_annotations, mix_generator,
+  mix_lint, mix_protocol, mix_winds, and mix_chart). Also trigger for UI work in
+  a project that already depends on `mix`. Do not trigger for generic Flutter
+  work when Mix is neither present nor requested.
+---
+
+# Mix Framework
+
+Type-safe styling system for Flutter that separates style semantics from widgets.
+
+## Set Up Mix
+
+Inspect the consuming project's `pubspec.yaml` or lockfile before assuming Mix
+is available or applying version-specific APIs.
+
+```bash
+flutter pub add mix
+```
+
+```dart
+import 'package:mix/mix.dart';
+```
+
+In the Mix repository, read `packages/mix/pubspec.yaml` for the current SDK,
+Flutter, and package versions. In a consumer repository, follow its resolved
+version; older releases may not expose newer primitives such as `WrapBox` and
+`GridBox`.
+
+## Source of Truth
+
+When working on Mix code, resolve ambiguity in this order:
+
+1. **Local source code** — always highest priority when the repo is present
+2. **Dart MCP tools** (`hover`, `signature_help`, `resolve_workspace_symbol`) — if connected and dependencies resolved
+3. **Version-pinned docs** — [Mix website](https://www.fluttermix.com), [pub.dev/packages/mix](https://pub.dev/packages/mix)
+4. **This skill** — patterns, invariants, and workflows documented here
+5. **If still unclear** — state uncertainty and ask the user to confirm
+
+## Core Mental Model
+
+```
+Spec (immutable resolved data) ← Styler (fluent builder with Prop<V>) → Widget (renders Spec)
+```
+
+Resolution pipeline: `StyleWidget` → `StyleBuilder` → merge active variants → resolve `Prop<V>` fields (tokens, Mix types, directives) → produce `StyleSpec<S>` → animate → `widget.build(context, spec)` → provide `StyleSpec` → apply widget modifiers.
+
+## Widget Reference
+
+| Styler | Spec | Widget | Flutter Equivalent |
+|--------|------|--------|--------------------|
+| `BoxStyler` | `BoxSpec` | `Box` | `Container` |
+| `TextStyler` | `TextSpec` | `StyledText` | `Text` |
+| `FlexStyler` | `FlexSpec` | — (layout) | `Flex`/`Row`/`Column` |
+| `FlexBoxStyler` | `FlexBoxSpec` | `FlexBox`/`RowBox`/`ColumnBox` | `Column`/`Row` + `Container` |
+| `WrapStyler` | `WrapSpec` | — (layout) | `Wrap` |
+| `WrapBoxStyler` | `WrapBoxSpec` | `WrapBox` | `Wrap` + `Container` |
+| `GridBoxStyler` | `GridBoxSpec` | `GridBox` | Fixed/`fr` track grid |
+| `StackStyler` | `StackSpec` | — (layout) | `Stack` |
+| `StackBoxStyler` | `StackBoxSpec` | `StackBox` | `Stack` + `Container` |
+| `IconStyler` | `IconSpec` | `StyledIcon` | `Icon` |
+| `ImageStyler` | `ImageSpec` | `StyledImage` | `Image` |
+
+Interactive: `Pressable` (gesture + focus + mouse), `PressableBox` (Pressable + Box).
+
+`GridBox` is a Mix-owned layout primitive, but unlike `FlexBox`, `WrapBox`, and `StackBox`, it does not include outer `Box` decoration or padding. Compose it inside `Box` when the grid itself needs chrome.
+
+## Key Patterns
+
+### Write Mix, Not Raw Flutter
+
+When styling a Mix surface, keep visual semantics in Stylers instead of nesting raw Flutter widgets for styling concerns.
+
+| Instead of | Write |
+|------------|-------|
+| `Container(color: ..., padding: ..., child: ...)` | `Box(style: BoxStyler().color(...).paddingAll(...), child: ...)` |
+| `Text('Label', style: TextStyle(...))` | `StyledText('Label', style: TextStyler().fontSize(...).color(...))` |
+| `Icon(Icons.star, color: ..., size: ...)` | `StyledIcon(icon: Icons.star, style: IconStyler().color(...).size(...))` |
+| `Theme.of(context).colorScheme.primary` in styles | `ColorToken` values from `MixScope`, then `BoxStyler().color($primary())` |
+| `Theme.of(context).textTheme.bodyMedium` in styles | `TextStyleToken` values from `MixScope`, then `TextStyler().style($body.mix())` |
+| Nested `Padding` / `Align` for a styled widget | Styler methods such as `.paddingAll(16)` and `.alignment(Alignment.center)` |
+
+### Choose the Layout Primitive
+
+| Need | Use |
+|------|-----|
+| One child with size, padding, or decoration | `Box` |
+| One non-wrapping row or column | `RowBox`, `ColumnBox`, or `FlexBox` |
+| Chips, tags, or intrinsic items that flow onto new runs | `WrapBox` |
+| Dashboards, card catalogs, and galleries with explicit two-dimensional tracks | `GridBox` |
+| Overlays or positioned layers | `StackBox` |
+
+Use `GridBoxStyler.onConstraints` when grid geometry should react to the space offered by its parent. Use `onBreakpoint` when a style should react to viewport size through `MediaQuery`. See `references/layout.md` for the complete layout decision guide, responsive Grid patterns, constraints, animation rules, and current limitations.
+
+### Top-Level Rule
+
+Start ordinary top-level declarations with the relevant concrete Styler constructor (`BoxStyler()`, `TextStyler()`, `IconStyler()`, etc.), then chain. Static factories are valid API but usually discouraged as top-level entry points. Grid declarations are the deliberate exception: use an explicit `GridBoxStyler` type with `.equalColumns(...)` or `.columns(...)` so the required track topology is visible. In typed nested contexts (variants, state callbacks, constraint patches), use bare shorthand `.method()`. See `references/styler-api-policy.md` for the complete policy.
+
+### Fluent Chaining (recommended)
+
+```dart
+final style = BoxStyler()
+    .color(Colors.blue)
+    .size(100, 100)
+    .padding(.all(16))
+    .borderRadius(.circular(8));
+
+Box(style: style, child: child)
+```
+
+### Variants (context-aware styling)
+
+```dart
+// Bare shorthand in nested typed contexts
+final style = BoxStyler()
+    .color(Colors.white)
+    .onDark(.color(Colors.black))
+    .onHovered(.color(Colors.blue));
+```
+
+### Implicit Animation
+
+```dart
+final style = BoxStyler()
+    .color(Colors.black)
+    .onHovered(.color(Colors.blue).scale(1.2))
+    .animate(.easeInOut(300.ms));
+```
+
+### Composition via Merge
+
+```dart
+final base = BoxStyler().padding(.all(16)).borderRadius(.circular(8));
+final elevated = BoxStyler().elevation(ElevationShadow(4));
+final combined = base.merge(elevated);
+```
+
+## Critical Rules
+
+- **Specs are immutable** — always `@immutable final class`, use `copyWith()` for changes
+- **Styler value fields generally use `$` prefix** — `$padding`, `$alignment`, etc. with `Prop<V>?`; exceptions include directives, variants, modifier, and animation metadata
+- **Generated Stylers have `.create()` and default constructors** — many also expose generated factory constructors
+- **Prefer `@MixableSpec(target: Widget.new)`** — `@MixableStyler` is legacy/deprecated
+- **Use `@MixWidget` for generated widgets from style factories** — it wraps top-level `Style<S>` variables or functions
+- **`@MixWidget(target:)` supports plain Widgets** — the target needs a compatible named `style` parameter; it does not need to extend `StyleWidget`
+- **Use `@MixableModifier` for generated modifiers** — it emits the modifier contract mixin and `ModifierMix` class
+- **`mix.dart` is generated** — never edit directly; run `melos run exports`
+- **Run codegen after spec changes** — `melos run gen:build`
+- **Grid constraint branches are geometry-only** — columns, rows, `autoRows`, and gaps; keep clipping, modifiers, animations, and ordinary variants on the base styler
+- **Prop merge semantics** — regular values: last wins (replacement); Mix values: accumulated merge
+- **Variant priority** — ContextVariant/NamedVariant first → StyleVariation second → WidgetStateVariant last (highest)
+
+## Commands
+
+```bash
+melos bootstrap           # Install dependencies
+melos run gen:build       # Clean + regenerate all *.g.dart files
+melos run ci              # Run all tests (flutter + dart)
+melos run analyze         # Dart + DCM analysis
+melos run fix             # Auto-fix lint issues
+melos run exports         # Regenerate mix.dart barrel file
+```
+
+**Pre-commit verification:**
+```bash
+melos run gen:build && melos run ci && melos run analyze
+```
+
+## Monorepo Packages
+
+| Package | Purpose |
+|---------|---------|
+| `mix` | Core framework |
+| `mix_annotations` | `@MixableSpec`, `@MixWidget`, `@MixableModifier`, `@MixableStyler`, `@Mixable`, `@MixableField` |
+| `mix_generator` | `build_runner` generator producing `*.g.dart` mixins |
+| `mix_lint` | Analysis server plugin with Mix-specific lint rules |
+| `mix_protocol` | Versioned JSON wire contract, codecs, schemas, inspection, and token walking for Mix styles |
+| `mix_winds` | Tailwind-style utility layer (experimental) |
+| `mix_chart` | Mix-owned line, bar, and pie chart APIs |
+
+## References
+
+Consult these for detailed guidance:
+
+- **[`references/architecture.md`](references/architecture.md)** — Spec, Styler, Prop<V>, resolution pipeline, StyleWidget
+- **[`references/styler-api-policy.md`](references/styler-api-policy.md)** — Top-level rule, dot-shorthand policy, factory constructor table, chain-only methods
+- **[`references/layout.md`](references/layout.md)** — Box/Flex/Wrap/Grid/Stack selection, responsive Grid use cases, constraints, and layout composition
+- **[`references/fluent-api.md`](references/fluent-api.md)** — Chaining, style mixins, sizing decision tree, composition
+- **[`references/code-generation.md`](references/code-generation.md)** — Annotations, generated output, BoxSpec reference impl
+- **[`references/examples.md`](references/examples.md)** — Worked end-to-end examples
+- **[`references/variants.md`](references/variants.md)** — NamedVariant, ContextVariant, WidgetStateVariant, built-in methods
+- **[`references/animations.md`](references/animations.md)** — Implicit, Phase, Keyframe animations
+- **[`references/design-tokens.md`](references/design-tokens.md)** — MixScope, token types, theming
+- **[`references/widget-modifiers-directives.md`](references/widget-modifiers-directives.md)** — .wrap(), modifiers, directives
+- **[`references/development-workflow.md`](references/development-workflow.md)** — Creating specs, codegen workflow, monorepo
+- **[`references/testing.md`](references/testing.md)** — resolvesTo matcher, MockBuildContext, merge testing

--- a/.agents/skills/mix/agents/openai.yaml
+++ b/.agents/skills/mix/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Mix"
+  short_description: "Build Flutter UI with Mix styles and codegen"
+  brand_color: "#13B9FD"
+  default_prompt: "Use $mix to build this Flutter interface with composable Mix stylers, variants, and tokens."

--- a/.agents/skills/mix/evals/evals.json
+++ b/.agents/skills/mix/evals/evals.json
@@ -1,0 +1,53 @@
+{
+  "skill_name": "mix",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "This Flutter app depends on mix. Build a reusable profile card with padding, rounded corners, a background color, an avatar, and styled title/subtitle text.",
+      "expected_output": "Imports package:mix/mix.dart, keeps visual semantics in Mix widgets and stylers (such as Box/BoxStyler and StyledText/TextStyler), starts top-level styles from concrete styler constructors, and avoids replacing the requested Mix styling with nested Container/Padding/TextStyle boilerplate.",
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "Create a dashboard that uses one column when its parent is narrow and three explicit fractional columns when wide. The dashboard can appear inside a side panel, so viewport width is not reliable.",
+      "expected_output": "Chooses GridBox with an explicitly typed GridBoxStyler and uses onConstraints for parent-offered width rather than onBreakpoint/MediaQuery; keeps grid geometry in constraint branches and explains that GridBox needs an outer Box when decoration or padding is required.",
+      "files": []
+    },
+    {
+      "id": 3,
+      "prompt": "Set up brand color, spacing, and body typography tokens with a light/dark theme, then consume them from a Mix-styled card.",
+      "expected_output": "Defines the appropriate ColorToken, SpaceToken, and TextStyleToken values, provides them through MixScope, consumes token references inside stylers (including textToken.mix() for typography), and uses context variants or scope replacement for theme changes instead of resolving raw Theme values inside reusable style declarations.",
+      "files": []
+    },
+    {
+      "id": 4,
+      "prompt": "Make a PressableBox darken on hover, shrink while pressed, show a keyboard-only focus ring, and animate between those states.",
+      "expected_output": "Uses PressableBox with BoxStyler widget-state variants onHovered/onPressed/onFocusVisible and an AnimationConfig via animate; uses bare dot shorthand in typed nested variant and animation contexts and does not manually manage hover/press booleans.",
+      "files": []
+    },
+    {
+      "id": 5,
+      "prompt": "Inside the Mix monorepo, add a new widget-backed BannerSpec with generated styling APIs. Which annotations, files, and commands should I use?",
+      "expected_output": "Uses an immutable spec with @MixableSpec(target: Banner.new), a compatible widget style parameter, generated part files and exports, runs melos run gen:build and melos run exports, and treats @MixableStyler as legacy rather than the default implementation path.",
+      "files": []
+    },
+    {
+      "id": 6,
+      "prompt": "I need opacity, clipping, and uppercase text to remain composable when several Mix styles merge. Should these be raw wrapper widgets and pre-transformed strings?",
+      "expected_output": "Keeps wrapper behavior in widget modifiers via wrap() and value transformations in directives, explains modifier ordering and merge-safe resolution, and avoids hard-coding wrapper widgets or eagerly transforming the source string outside the style.",
+      "files": []
+    },
+    {
+      "id": 7,
+      "prompt": "I changed a generated Mix spec and the public mix.dart barrel in this monorepo. Give me the repository verification sequence before I commit.",
+      "expected_output": "Regenerates with melos run gen:build, regenerates the barrel with melos run exports when needed, then runs melos run ci and melos run analyze; it does not edit generated mix.dart or generated .g.dart files by hand.",
+      "files": []
+    },
+    {
+      "id": 8,
+      "prompt": "In a plain Flutter project with no Mix dependency, write a CustomPainter that draws a waveform.",
+      "expected_output": "Does not trigger or invoke the Mix skill, does not add the mix package, and answers with ordinary Flutter CustomPainter guidance.",
+      "files": []
+    }
+  ]
+}

--- a/.agents/skills/mix/references/animations.md
+++ b/.agents/skills/mix/references/animations.md
@@ -1,0 +1,184 @@
+# Animations
+
+Three animation systems in Mix, from simple to full control.
+
+## Table of Contents
+
+- [Implicit animations](#implicit-animations)
+- [Phase animations](#phase-animations)
+- [Keyframe animations](#keyframe-animations)
+- [Comparison](#comparison)
+
+## Implicit Animations
+
+Simplest approach. Call `.animate()` on any Styler — Mix interpolates between old and new values automatically when state or variants change.
+
+**When to use:** Simple hover/press effects, state transitions, variant-driven changes.
+
+### State-Triggered
+
+```dart
+class ScaleAnimation extends StatefulWidget {
+  @override
+  State<ScaleAnimation> createState() => _ScaleAnimationState();
+}
+
+class _ScaleAnimationState extends State<ScaleAnimation> {
+  bool appear = false;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      setState(() => appear = true);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final style = BoxStyler()
+        .color(Colors.black)
+        .height(100)
+        .width(100)
+        .borderRounded(10)
+        .scale(appear ? 1 : 0.1)
+        .animate(.easeInOut(1.s));
+
+    return Box(style: style);
+  }
+}
+```
+
+### Variant-Triggered
+
+```dart
+final style = BoxStyler()
+    .color(Colors.black)
+    .height(100)
+    .width(100)
+    .borderRounded(10)
+    .scale(1)
+    .onHovered(
+      BoxStyler()
+        .color(Colors.blue)
+        .scale(1.5),
+    )
+    .animate(.spring(800.ms));
+```
+
+### AnimationConfig Options
+
+`AnimationConfig` is a sealed class with curve-based factories and spring helpers:
+
+| Constructor / helper | Signature Notes |
+|---------|-----------------|
+| `.curve(duration:, curve:, delay:, onEnd:)` | Custom `CurveAnimationConfig` factory |
+| `.linear(duration)` | Linear curve factory |
+| `.ease(duration)` / `.easeIn(duration)` / `.easeOut(duration)` / `.easeInOut(duration)` | Common Flutter curve factories |
+| `.decelerate(duration)` | Decelerate curve factory |
+| `.spring(duration, bounce:, onEnd:)` | Duration-based spring physics (static helper) |
+| `.springWithDampingRatio(mass:, stiffness:, dampingRatio:, onEnd:)` | Physics spring without an explicit duration (static helper) |
+
+For phase animations, `configBuilder` must return `CurveAnimationConfig`; use `CurveAnimationConfig.springWithDampingRatio(duration, ratio: ...)` when a duration is required.
+
+Duration extensions: `.ms` (milliseconds), `.s` (seconds). Example: `300.ms`, `1.s`.
+
+## Phase Animations
+
+Multi-step sequences that progress through defined phases, then return to initial.
+
+**When to use:** State machines, progress indicators, sequential micro-interactions.
+
+```dart
+enum AnimationPhases { initial, compress, expanded }
+
+final style = BoxStyler()
+    .color(Colors.deepPurple)
+    .height(100)
+    .width(100)
+    .borderRounded(40)
+    .phaseAnimation(
+      trigger: _isExpanded,  // Listenable; each notification starts one run
+      phases: AnimationPhases.values,
+      styleBuilder: (phase, style) => switch (phase) {
+        .initial => style.scale(1),
+        .compress => style.scale(0.75).color(Colors.red.shade800),
+        .expanded => style.scale(1.25).borderRounded(20).color(Colors.yellow.shade300),
+      },
+      configBuilder: (phase) => switch (phase) {
+        .initial => CurveAnimationConfig.springWithDampingRatio(800.ms, ratio: 0.3),
+        .compress => .decelerate(200.ms),
+        .expanded => .decelerate(100.ms),
+      },
+    );
+```
+
+Parameters:
+- `trigger` — optional `Listenable`; each notification starts one run. Omit it for looping.
+- `phases` — list of phase values (usually an enum)
+- `styleBuilder` — returns style for each phase (receives base style)
+- `configBuilder` — returns `CurveAnimationConfig` for each phase transition
+
+## Keyframe Animations
+
+Timeline-based with precise control over multiple properties and easing (like CSS keyframes).
+
+**When to use:** Choreographed sequences, multi-property transitions.
+
+```dart
+final style = BoxStyler()
+    .color(Colors.red)
+    .size(80, 80)
+    .keyframeAnimation(
+      trigger: _trigger,  // Listenable; omit for looping
+      timeline: [
+        KeyframeTrack<Color>(
+          'color',
+          [
+            .linear(Colors.blue.shade100, 100.ms),
+            .elasticOut(Colors.blue.shade400, 800.ms),
+            .elasticOut(Colors.green.shade100, 800.ms),
+          ],
+          initial: Colors.red.shade100,
+          tweenBuilder: ColorTween.new,
+        ),
+        KeyframeTrack<double>('scale', [
+          .linear(1.0, 360.ms),
+          .elasticOut(1.5, 800.ms),
+          .elasticOut(1.0, 800.ms),
+        ], initial: 1.0),
+      ],
+      styleBuilder: (values, style) {
+        final color = values.get<Color>('color');
+        final scale = values.get<double>('scale');
+        return style
+            .color(color)
+            .transform(Matrix4.identity()..scale(scale, scale, scale));
+      },
+    );
+```
+
+Parameters:
+- `trigger` — optional `Listenable`; each notification starts one run. Omit it for looping.
+- `timeline` — `List<KeyframeTrack>`, each runs in parallel
+- `styleBuilder` — receives `KeyframeAnimationResult` and base style, returns modified style
+
+### KeyframeTrack
+
+Each track represents one animatable property:
+- `id` — positional identifier for `values.get<T>(key)`
+- `segments` — positional list of keyframe values with duration and easing
+- `initial` — required starting value
+- `tweenBuilder` — optional custom tween (e.g., `ColorTween.new`)
+
+`values.get<T>(key)` reads by the track `id`.
+
+Keyframes within a track run in sequence; tracks run in parallel.
+
+## Comparison
+
+| Type | Use Case | Complexity | Control |
+|------|----------|------------|---------|
+| **Implicit** | Simple state/variant transitions | Low | Basic |
+| **Phase** | Multi-step / state machine | Medium | Moderate |
+| **Keyframe** | Choreographed, multi-track | High | Full |

--- a/.agents/skills/mix/references/architecture.md
+++ b/.agents/skills/mix/references/architecture.md
@@ -1,0 +1,213 @@
+# Architecture
+
+Core abstractions of the Mix styling system.
+
+## Table of Contents
+
+- [Spec](#spec--immutable-resolved-data)
+- [Style and Styler](#style--styler--immutable-fluent-builder)
+- [Prop](#propv--unified-property-system)
+- [StyleWidget](#stylewidget--base-widget)
+- [Resolution pipeline](#resolution-pipeline)
+- [WidgetModifier](#widgetmodifier--widget-wrapper)
+- [Mix values](#mixv--resolvable-dto)
+
+## Spec — Immutable Resolved Data
+
+**File:** `packages/mix/lib/src/core/spec.dart`
+
+```dart
+@immutable
+abstract class Spec<T extends Spec<T>> with Equatable {
+  const Spec();
+  T copyWith();
+  T lerp(covariant T? other, double t);
+}
+```
+
+All Specs are `@immutable final class` with nullable fields representing resolved values. Generated `_$FooSpec` mixin provides `copyWith()`, `lerp()`, equality/props, and diagnostics. `_$FooSpecMethods` is only a deprecated compatibility typedef.
+
+**Example — BoxSpec:**
+
+```dart
+@MixableSpec(target: Box.new)
+@immutable
+final class BoxSpec with _$BoxSpec {
+  final AlignmentGeometry? alignment;
+  final EdgeInsetsGeometry? padding;
+  final EdgeInsetsGeometry? margin;
+  final BoxConstraints? constraints;
+  final Decoration? decoration;
+  final Decoration? foregroundDecoration;
+  final Matrix4? transform;
+  final AlignmentGeometry? transformAlignment;
+  final Clip? clipBehavior;
+
+  const BoxSpec({this.alignment, this.padding, this.margin, ...});
+}
+```
+
+Requires `part 'box_spec.g.dart'` for the generated Spec mixin and, when `target:` is provided, the generated Styler.
+
+## Style / Styler — Immutable Fluent Builder
+
+**Files:** `packages/mix/lib/src/core/style.dart`, `packages/mix/lib/src/style/abstracts/styler.dart`
+
+```dart
+abstract class Style<S extends Spec<S>> extends Mix<StyleSpec<S>> {
+  final List<VariantStyle<S>>? $variants;
+  final WidgetModifierConfig? $modifier;
+  final AnimationConfig? $animation;
+
+  Style<S> mergeActiveVariants(BuildContext context, {required Set<NamedVariant> namedVariants});
+  StyleSpec<S> resolve(BuildContext context);
+  Style<S> merge(covariant Style<S>? other);
+  StyleSpec<S> build(BuildContext context, {Set<NamedVariant> namedVariants = const {}});
+}
+```
+
+Generated Stylers extend `MixStyler<ST, SP>` and return new merged instances from fluent methods:
+- `VariantStyleMixin` — `onDark()`, `onLight()`, breakpoint/platform variants
+- `WidgetStateVariantMixin` — `onHovered()`, `onPressed()`, `onFocused()`, etc.
+- `AnimationStyleMixin` — `animate()`, `phaseAnimation()`, `keyframeAnimation()`
+- `WidgetModifierStyleMixin` — `wrap()`
+- Plus domain mixins: `SpacingStyleMixin`, `DecorationStyleMixin`, `BorderStyleMixin`, etc.
+
+**Example — BoxStyler:**
+
+```dart
+class BoxStyler extends MixStyler<BoxStyler, BoxSpec>
+    with
+        BorderStyleMixin<BoxStyler>,
+        BorderRadiusStyleMixin<BoxStyler>,
+        ShadowStyleMixin<BoxStyler>,
+        DecorationStyleMixin<BoxStyler>,
+        SpacingStyleMixin<BoxStyler>,
+        TransformStyleMixin<BoxStyler>,
+        ConstraintStyleMixin<BoxStyler>,
+        TransformStyleMixin<BoxStyler> {
+
+  final Prop<AlignmentGeometry>? $alignment;
+  final Prop<EdgeInsetsGeometry>? $padding;
+  final Prop<BoxConstraints>? $constraints;
+  final Prop<Decoration>? $decoration;
+  // ...
+
+  // Internal constructor (const-capable, takes raw Prop<V>)
+  const BoxStyler.create({
+    Prop<AlignmentGeometry>? alignment,
+    Prop<EdgeInsetsGeometry>? padding,
+    // ...
+    super.variants, super.modifier, super.animation,
+  }) : $alignment = alignment, $padding = padding, ...;
+
+  // Public constructor (takes Flutter/Mix types, wraps with Prop)
+  BoxStyler({
+    AlignmentGeometry? alignment,
+    EdgeInsetsGeometryMix? padding,
+    // ...
+  }) : this.create(
+    alignment: Prop.maybe(alignment),
+    padding: Prop.maybeMix(padding),
+    // ...
+  );
+}
+```
+
+## Prop<V> — Unified Property System
+
+**File:** `packages/mix/lib/src/core/prop.dart`
+
+The central value wrapper enabling tokens, Mix types, merging, and directives.
+
+### Sources
+
+Each Prop holds `List<PropSource<V>>`:
+
+| Source | Created By | Resolution |
+|--------|-----------|------------|
+| `ValueSource<V>` | `Prop.value(v)` | Returns value directly |
+| `TokenSource<V>` | `Prop.token(t)` | Resolves from `MixScope` via `BuildContext` |
+| `MixSource<V>` | `Prop.mix(m)` | Holds a `Mix<V>` DTO for accumulation |
+
+### Factory Methods
+
+```dart
+Prop.value(v)       // Direct value (no auto-conversion to Mix)
+Prop.mix(m)         // Explicit Mix value for accumulation merge
+Prop.token(t)       // Token reference resolved from MixScope
+Prop.maybe(v)       // Nullable — returns null if v is null
+Prop.maybeMix(m)    // Nullable — returns null if m is null
+Prop.directives(ds) // Directives only, no value source
+```
+
+### Merge Behavior
+
+`mergeProp()` always accumulates all sources. During resolution:
+
+- **Regular values (ValueSource)**: last value wins (replacement)
+- **Mix values (MixSource)**: all Mix values merged via accumulation, then resolved
+- **Directives**: merged from both Prop instances, applied after resolution
+
+### Resolution Process
+
+```
+1. Resolve all sources (tokens → values, Mix types stay as Mix)
+2. If Mix values present → try to convert regular values through `MixConverterRegistry`, merge convertible Mix values, resolve
+3. If only regular values → use last value (replacement)
+4. Apply directives to final value
+```
+
+## StyleWidget — Base Widget
+
+**File:** `packages/mix/lib/src/core/style_widget.dart`
+
+```dart
+abstract class StyleWidget<S extends Spec<S>> extends StatefulWidget {
+  final Style<S> style;
+  final StyleSpec<S>? styleSpec;
+
+  Widget build(BuildContext context, S spec);
+}
+```
+
+Accepts either `style` (goes through full resolution) or `styleSpec` (pre-resolved, bypasses resolution). `StyleBuilder` merges variants and resolves the style; `StyleSpecBuilder` runs animation, provides the `StyleSpec`, and applies modifiers.
+
+## Resolution Pipeline
+
+```
+StyleWidget.build(context)
+  → StyleBuilder<S>
+    → style.build(context, namedVariants)
+      → mergeActiveVariants(context)     // evaluate variants, sort by priority
+      → resolve(context)                 // Prop.resolveProp() for each field
+      → StyleSpec<S>                     // wraps Spec + AnimationConfig + resolved WidgetModifier list
+    → StyleAnimationBuilder              // implicit animation via SpecTween
+    → widget.build(context, spec)        // map Spec fields to Flutter widgets
+    → StyleSpecProvider                  // expose active StyleSpec
+    → RenderModifiers                    // wrap with ordered widget modifiers
+```
+
+## WidgetModifier — Widget Wrapper
+
+**File:** `packages/mix/lib/src/core/widget_modifier.dart`
+
+```dart
+abstract class WidgetModifier<Self extends WidgetModifier<Self>> extends Spec<Self> {
+  Widget build(Widget child);
+}
+```
+
+Modifiers wrap the rendered widget with additional Flutter widgets (Padding, Opacity, Transform, etc.). Defined at the style level via `ModifierMix<S>` and resolved during the pipeline.
+
+## Mix<V> — Resolvable DTO
+
+```dart
+abstract class Mix<V> extends Mixable<V> with Resolvable<V>, Equatable {
+  V resolve(BuildContext context);
+}
+```
+
+Mix types are intermediate representations (DTOs) between user-facing API and resolved Flutter types. Examples: `EdgeInsetsGeometryMix`, `DecorationMix`, `BoxConstraintsMix`, `BorderRadiusMix`.
+
+They support field-wise merging — setting `padding: EdgeInsetsGeometryMix.only(left: 8)` then merging with `padding: EdgeInsetsGeometryMix.only(right: 16)` produces `EdgeInsets.only(left: 8, right: 16)`.

--- a/.agents/skills/mix/references/code-generation.md
+++ b/.agents/skills/mix/references/code-generation.md
@@ -1,0 +1,289 @@
+# Code Generation
+
+Annotations, generators, and the codegen workflow in Mix.
+
+## Table of Contents
+
+- [Spec-driven generation](#current-default-spec-driven-styler-generation)
+- [Annotations](#annotations)
+- [File structure](#file-structure-per-widget-spec)
+- [Type metadata](#type-metadata-registry)
+- [Run code generation](#running-code-generation)
+- [Box reference implementation](#reference-implementation-box)
+- [Generator flags](#generator-flags)
+
+## Current Default: Spec-Driven Styler Generation
+
+For widget-backed specs, prefer `@MixableSpec(target: Widget.new)`. The generator emits both:
+
+- `_$FooSpec` — Spec contract mixin for `FooSpec`
+- `FooStyler` — generated fluent Styler in the same `<name>_spec.g.dart` part
+
+```dart
+part 'box_spec.g.dart';
+
+@MixableSpec(target: Box.new)
+@immutable
+final class BoxSpec with _$BoxSpec {
+  @override
+  final AlignmentGeometry? alignment;
+  @override
+  final EdgeInsetsGeometry? padding;
+
+  const BoxSpec({this.alignment, this.padding});
+}
+```
+
+Generated stylers include value fields (`Prop<V>?`), `.create()` and default constructors, field factories, fluent setters, `merge()`, `resolve()`, diagnostics, props, and `call()` when a widget target supports it.
+
+`_$FooSpecMethods` is only a deprecated compatibility typedef for older `extends Spec<FooSpec> with _$FooSpecMethods` declarations. Do not use it for new specs.
+
+## Annotations
+
+### `@MixableSpec()`
+
+Applied to Spec classes. Generates `_$FooSpec` with:
+
+- `copyWith()` — replaces fields when non-null replacement arguments are provided
+- `lerp()` — interpolation for supported fields
+- `props`, `==`, `hashCode` — value equality support
+- `debugFillProperties()` — Flutter diagnostics
+
+Optional method flags:
+
+- `GeneratedSpecMethods.all` — copyWith | equals | lerp
+- `GeneratedSpecMethods.skipCopyWith`
+- `GeneratedSpecMethods.skipEquals` — suppresses generated `props`; the user must supply props for equality
+- `GeneratedSpecMethods.skipLerp`
+
+With `target: Widget.new`, it also drives generated Styler and `call()` support from the target widget constructor.
+
+### `@MixableStyler()` Legacy
+
+`@MixableStyler()` still exists for handwritten Styler classes, but it is deprecated. Prefer `@MixableSpec(target: Widget.new)` for new widget-backed APIs.
+
+Use legacy `@MixableStyler()` only when maintaining an existing handwritten Styler whose fields are already `$`-prefixed `Prop<V>?` values.
+
+### `@MixWidget()`
+
+Apply to a top-level variable or function returning a `Style<S>`. It generates a
+`StatelessWidget` wrapper whose `build()` delegates to the styler's `call()` or
+to an explicitly configured plain Widget target.
+
+```dart
+@MixWidget()
+final cardStyle = BoxStyler().paddingAll(16).borderRounded(12);
+// Generates `class Card extends StatelessWidget { ... }`.
+```
+
+By default, the widget name is derived from a lowerCamelCase element name ending in `Style`: `cardStyle` becomes `Card`, and leading underscores are preserved. Override the name with `@MixWidget(name: 'X')`.
+
+For a plain Widget with a compatible named `style` parameter, pass its
+constructor tear-off through `target`. The Widget does not need to extend
+`StyleWidget` or expose a Styler extension `call()` method. This direct-target
+path ships in `mix_generator 2.2.0-beta.2` with
+`mix_annotations 2.2.0-beta.1`:
+
+```dart
+@MixWidget(
+  name: 'AppButton',
+  target: PlainButton.new,
+  widgetParameters: .only({'label', 'onPressed'}),
+  factoryParameters: .only({'variant', 'size'}),
+)
+ButtonStyler appButtonStyle({
+  ButtonVariant variant = .solid,
+  ButtonSize size = .medium,
+  bool highContrast = false,
+}) => switch (variant) {
+  .solid => solidButtonStyle(size, highContrast: highContrast),
+  .soft => softButtonStyle(size, highContrast: highContrast),
+};
+```
+
+Use `widgetParameters` to curate parameters read from the Styler `call()` or
+plain target constructor. Use `factoryParameters` to curate the recipe
+function's own parameters. Required parameters must remain selected; omitted
+optional parameters use their original defaults. The target's `style` and
+`styleSpec` parameters never become generated wrapper fields.
+
+When a recipe function has a named, non-nullable enum parameter named exactly
+`variant` and that parameter remains selected by `factoryParameters`, generate
+one named constructor per accessible enum value while retaining the unnamed
+constructor:
+
+```dart
+AppButton.solid(label: 'Save')
+AppButton.soft(label: 'Save')
+AppButton(variant: selectedVariant, label: 'Save')
+```
+
+Do not add an `EnumVariant` mixin solely for this feature. The enum is a recipe
+switch key and does not enter Mix's runtime variant system. Nullable,
+positional, non-enum, or differently named parameters retain the unnamed-only
+constructor shape. Preserve the unnamed constructor because runtime-selected
+variants cannot choose a named constructor at compile time.
+
+`@MixWidget` complements `@MixableSpec(target:)`; it wraps a style recipe after
+a Styler exists, while `@MixableSpec(target:)` generates the Styler and its
+`call()` support. Mix's own specs use `@MixableSpec(target:)`; `@MixWidget` is
+mainly a downstream-author convenience. When changing this contract inside the
+Mix repository, also consult its `guides/mix-widget-variant-constructors.md`
+decision record if present; do not treat a proposed curation rename as shipped
+API unless the current source exposes it.
+
+### `@MixableModifier()`
+
+Applied to `WidgetModifier` classes. The modifier class mixes in the generated `_$FooModifier` mixin, and the generator emits both the modifier contract implementation and the matching `FooModifierMix` class.
+
+```dart
+part 'opacity_modifier.g.dart';
+
+@MixableModifier()
+final class OpacityModifier with _$OpacityModifier {
+  @override
+  final double opacity;
+
+  const OpacityModifier([double? opacity]) : opacity = opacity ?? 1.0;
+
+  @override
+  Widget build(Widget child) => Opacity(opacity: opacity, child: child);
+}
+```
+
+Use `@MixableModifier(lerp: false)` when interpolation needs custom behavior and the modifier class implements `lerp()` manually. Current built-in generated modifiers live under `packages/mix/lib/src/modifiers/`.
+
+### `@Mixable()`
+
+Applied to Mix/DTO classes. Generates `_$FooMixin` with:
+
+- `merge()`
+- `resolve()`
+- `props`
+- `debugFillProperties()`
+
+```dart
+@Mixable()
+final class BoxConstraintsMix extends ConstraintsMix<BoxConstraints>
+    with DefaultValue<BoxConstraints>, Diagnosticable, _$BoxConstraintsMixMixin {
+  final Prop<double>? $minWidth;
+  final Prop<double>? $maxWidth;
+}
+```
+
+### `@MixableField()`
+
+Applied to fields for per-field generation control.
+
+For spec-driven stylers:
+
+```dart
+@MixableField(skipFactory: true)
+final Color? internalColor;
+
+@MixableField(factoryName: 'visibility')
+final bool? visible;
+
+@MixableField(mixin: SpacingStyleMixin)
+final EdgeInsetsGeometry? padding;
+
+@MixableField(skipMixin: true)
+final Matrix4? transform;
+
+@MixableField(forwardStyler: true)
+final StyleSpec<LabelSpec>? label;
+```
+
+Nested `StyleSpec<XSpec>` fields derive `XStyler` by convention for generated
+constructors and setters. Use `setterType` only to override that convention.
+Use `forwardStyler: true` to project a nested Styler's canonical factories and
+fluent anchors onto the parent Styler; add `stylerSurface` only when generation
+needs an explicit compatible surface during a same-package clean build.
+
+For legacy handwritten stylers:
+
+```dart
+@MixableField(ignoreSetter: true)
+final Prop<Matrix4>? $transform;
+
+@MixableField(setterType: List<Shadow>)
+final Prop<List<Shadow>>? $shadows;
+```
+
+## File Structure Per Widget Spec
+
+Current spec-driven shape:
+
+```text
+specs/box/
+├── box_spec.dart     # Hand-written: @MixableSpec(target: Box.new), fields
+├── box_spec.g.dart   # Generated: _$BoxSpec + BoxStyler
+└── box_widget.dart   # Hand-written: Box extends StyleWidget<BoxSpec>
+```
+
+There is no handwritten `box_style.dart` for the current `Box` implementation; `BoxStyler` is generated from `box_spec.dart`.
+
+Current generated modifier shape:
+
+```text
+modifiers/
+├── opacity_modifier.dart     # Hand-written: @MixableModifier(), fields, build()
+└── opacity_modifier.g.dart   # Generated: _$OpacityModifier + OpacityModifierMix
+```
+
+## Type Metadata Registry
+
+**File:** `packages/mix_generator/lib/src/core/curated/type_metadata.dart`
+
+The generator uses `typeMetadata` and helpers from the curated registry to determine:
+
+- Mix counterpart type (`TypeMetadata.mixType`, exposed through helpers such as `mixTypeFor`)
+- Owner mixins for generated Styler methods
+- Lerp behavior (`TypeCategory.lerpable`, `.snappable`, `.enumType`)
+- Diagnostic property behavior
+
+When generating `lerp()`, the generator selects:
+
+- Lerpable → `MixOps.lerp(field, other?.field, t)`
+- Snappable/enum → `MixOps.lerpSnap(field, other?.field, t)`
+- Nested `StyleSpec<T>` → delegate to the nested spec lerp path
+
+## Running Code Generation
+
+```bash
+# Full clean + rebuild
+melos run gen:build
+
+# Watch mode during development
+melos run gen:watch
+
+# Clean generated files
+melos run gen:clean
+```
+
+`gen:build` runs:
+
+1. `gen:clean`
+2. `gen:build:flutter`
+3. `gen:build:dart`
+
+The build commands pass `--delete-conflicting-outputs`; the clean scripts remove generated outputs separately.
+
+## Reference Implementation: Box
+
+Use `packages/mix/lib/src/specs/box/` as the canonical current pattern:
+
+1. `box_spec.dart` — `BoxSpec` with `@MixableSpec(target: Box.new)` and nullable final fields
+2. `box_spec.g.dart` — generated `_$BoxSpec` and `BoxStyler`
+3. `box_widget.dart` — `Box extends StyleWidget<BoxSpec>`, defaults to `IdentityStyle(BoxSpec())`, maps `BoxSpec` fields to `Container`
+
+## Generator Flags
+
+Fine-grained control uses bitflags in annotation parameters:
+
+```dart
+@MixableSpec(methods: GeneratedSpecMethods.skipLerp)
+@Mixable(methods: GeneratedMixMethods.skipResolve)
+```
+
+`GeneratedStylerMethods.call` / `skipCall` are deprecated compatibility flags. `call()` for widget-backed generated stylers comes from `@MixableSpec(target: Widget.new)`, not from the legacy styler flag.

--- a/.agents/skills/mix/references/design-tokens.md
+++ b/.agents/skills/mix/references/design-tokens.md
@@ -1,0 +1,146 @@
+# Design Tokens
+
+Centralized visual properties via `MixToken` and `MixScope`.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Token workflow](#token-workflow)
+- [Built-in token types](#built-in-token-types)
+- [MixScope](#mixscope)
+- [Theme switching](#theme-switching)
+- [Custom token types](#custom-token-types)
+- [Programmatic resolution](#programmatic-resolution)
+- [Material integration](#mixscopewithmaterial)
+
+## Overview
+
+Design tokens define visual properties (colors, typography, spacing) in a centralized, swappable way. Mix provides token types and `MixScope` (an `InheritedModel`) to provide values to the widget tree.
+
+## Token Workflow
+
+```dart
+// 1. Declare tokens
+final $primary = ColorToken('primary');
+final $spacingMd = SpaceToken('spacingMd');
+
+// 2. Provide values via MixScope
+MixScope(
+  colors: { $primary: Colors.blue },
+  spaces: { $spacingMd: 16.0 },
+  child: MyApp(),
+);
+
+// 3. Use in styles — call() creates a token reference
+final style = BoxStyler()
+    .color($primary())
+    .paddingAll($spacingMd());
+```
+
+The `()` call syntax on tokens creates a type-specific reference (`ColorRef`, `DoubleRef`, `RadiusRef`, etc.) that the `Prop` system recognizes as a token source and resolves from `MixScope` during style resolution.
+
+## Built-in Token Types
+
+| Token Type | Value Type | MixScope Parameter |
+|------------|-----------|-------------------|
+| `ColorToken` | `Color` | `colors:` |
+| `SpaceToken` | `double` | `spaces:` |
+| `DoubleToken` | `double` | `doubles:` |
+| `RadiusToken` | `Radius` | `radii:` |
+| `TextStyleToken` | `TextStyle` | `textStyles:` |
+| `BorderSideToken` | `BorderSide` | `borders:` |
+| `ShadowToken` | `List<Shadow>` | `shadows:` |
+| `BoxShadowToken` | `List<BoxShadow>` | `boxShadows:` |
+| `FontWeightToken` | `FontWeight` | `fontWeights:` |
+| `DurationToken` | `Duration` | generic `tokens:` |
+| `BreakpointToken` | `Breakpoint` | `breakpoints:` |
+
+## MixScope
+
+**File:** `packages/mix/lib/src/theme/mix_theme.dart`
+
+```dart
+MixScope(
+  colors: { $primary: Colors.blue, $secondary: Colors.green },
+  spaces: { $spacingSm: 8.0, $spacingMd: 16.0, $spacingLg: 24.0 },
+  radii: { $radiusSm: Radius.circular(4), $radiusMd: Radius.circular(8) },
+  textStyles: { $heading: TextStyle(fontSize: 24, fontWeight: FontWeight.bold) },
+  child: MaterialApp(home: MyHomePage()),
+)
+```
+
+### Key API
+
+| Method | Description |
+|--------|-------------|
+| `MixScope(colors:, spaces:, radii:, ...)` | Constructor with typed token maps |
+| `MixScope.withMaterial(...)` | Pre-configured with Material Design tokens |
+| `MixScope.combine(scopes: [...], child: ...)` | Merge multiple scopes |
+| `MixScope.of(context)` | Get nearest scope (throws if not found) |
+| `MixScope.maybeOf(context)` | Get nearest scope or null |
+| `MixScope.tokenOf<T>(token, context)` | Resolve a single token value |
+
+### Token Resolution
+
+During `Prop.resolveProp()`, `TokenSource` resolves via:
+```dart
+MixScope.tokenOf(token, context)
+```
+
+If no `MixScope` is found, `MixScope.of` throws a `FlutterError`. If a scope exists but a token is missing or has the wrong value type, token resolution throws `StateError`.
+
+## Theme Switching
+
+```dart
+class MyApp extends StatefulWidget {
+  @override
+  State<MyApp> createState() => _MyAppState();
+}
+
+class _MyAppState extends State<MyApp> {
+  bool isDark = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return MixScope(
+      colors: isDark
+          ? { $primary: Colors.blue.shade200, $background: Colors.grey.shade900 }
+          : { $primary: Colors.blue, $background: Colors.white },
+      child: MaterialApp(home: MyHomePage()),
+    );
+  }
+}
+```
+
+## Custom Token Types
+
+Extend `MixToken<T>` for custom value types:
+
+```dart
+class CustomToken extends MixToken<MyCustomType> {
+  const CustomToken(super.name);
+}
+```
+
+Arbitrary custom tokens can be supplied through the generic `tokens:` map and resolved with `MixScope.tokenOf` or `token.resolve(context)`. The convenient `token()` call syntax returns a supported reference type when Mix has one; otherwise it falls back to a `Prop<T>` reference.
+
+## Programmatic Resolution
+
+Resolve tokens outside of style context:
+
+```dart
+final color = MixScope.tokenOf($primary, context);
+```
+
+## MixScope.withMaterial
+
+Pre-configures tokens that map to Material Design's `ThemeData`:
+
+```dart
+MixScope.withMaterial(
+  colors: { $primary: Colors.blue },  // Override specific tokens
+  child: MyApp(),
+)
+```
+
+Material tokens are extracted from `Theme.of(context)` and merged with any explicit overrides.

--- a/.agents/skills/mix/references/development-workflow.md
+++ b/.agents/skills/mix/references/development-workflow.md
@@ -1,0 +1,167 @@
+# Development Workflow
+
+Creating, modifying, and maintaining specs in the Mix monorepo.
+
+## Table of Contents
+
+- [Monorepo structure](#monorepo-structure)
+- [Create a widget-backed spec](#creating-a-new-widget-backed-spec)
+- [Modify a spec](#modifying-an-existing-spec)
+- [Commands](#commands-reference)
+- [Pre-commit verification](#pre-commit-verification)
+- [Type metadata](#adding-type-metadata)
+
+## Monorepo Structure
+
+```text
+packages/
+  mix/                    # Core framework
+  mix_annotations/        # Annotations for codegen
+  mix_generator/          # build_runner generator
+  mix_lint/               # Analysis server plugin
+  mix_protocol/           # Versioned JSON wire contract and codecs
+  mix_winds/              # Tailwind utility layer
+  mix_winds/example/      # Tailwind example app
+  mix_chart/              # Mix-owned chart API
+  mix_chart/example/      # Chart example app
+```
+
+**SDK constraints:** Dart >=3.11.0, Flutter >=3.41.0
+
+## Creating a New Widget-Backed Spec
+
+Follow `packages/mix/lib/src/specs/box/` as the canonical reference.
+
+### Step 1: Create the Spec Class
+
+**File:** `packages/mix/lib/src/specs/<name>/<name>_spec.dart`
+
+```dart
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:mix_annotations/mix_annotations.dart';
+
+import '../../generated_styler_support.dart';
+import '<name>_widget.dart';
+
+part '<name>_spec.g.dart';
+
+@MixableSpec(target: Foo.new)
+@immutable
+final class FooSpec with _$FooSpec {
+  @override
+  final Color? color;
+  @override
+  final double? size;
+
+  const FooSpec({this.color, this.size});
+}
+```
+
+Key rules:
+
+- Use `@MixableSpec(target: Foo.new)` when the spec has a widget target.
+- Use `final class FooSpec with _$FooSpec`.
+- Fields are nullable, final, resolved spec values; most are Flutter value types, but some specs include Mix runtime values such as directives.
+- Include `part '<name>_spec.g.dart'`.
+- Add `@MixableField(...)` only when the generated Styler needs field-specific behavior.
+
+### Step 2: Create the Widget
+
+**File:** `packages/mix/lib/src/specs/<name>/<name>_widget.dart`
+
+```dart
+import 'package:flutter/widgets.dart';
+
+import '../../core/style.dart';
+import '../../core/style_widget.dart';
+import '<name>_spec.dart';
+
+class Foo extends StyleWidget<FooSpec> {
+  const Foo({
+    super.style = const IdentityStyle(FooSpec()),
+    super.styleSpec,
+    super.key,
+    this.child,
+  });
+
+  final Widget? child;
+
+  @override
+  Widget build(BuildContext context, FooSpec spec) {
+    return SomeFlutterWidget(
+      color: spec.color,
+      child: child,
+    );
+  }
+}
+```
+
+The generated `FooStyler` will live in `<name>_spec.g.dart`; do not create a separate `<name>_style.dart` unless intentionally maintaining a legacy handwritten Styler.
+
+### Step 3: Run Code Generation
+
+```bash
+melos run gen:build
+```
+
+This generates `<name>_spec.g.dart`, including `_$FooSpec` and, for `target: Foo.new`, `FooStyler`.
+
+### Step 4: Update Exports
+
+```bash
+melos run exports
+```
+
+Regenerates `packages/mix/lib/mix.dart`.
+
+## Modifying an Existing Spec
+
+1. Add/remove/change fields in the spec file.
+2. Update the widget's `build()` method if the resolved spec changes rendering.
+3. Add or adjust `@MixableField(...)` metadata if the generated Styler surface needs custom factory/mixin behavior.
+4. Run `melos run gen:build`.
+5. Run `melos run ci && melos run analyze`.
+
+Generated Stylers are not edited directly. Edit the spec annotation, fields, widget target, or generator inputs instead.
+
+## Commands Reference
+
+| Command | Purpose |
+|---------|---------|
+| `melos bootstrap` | Install all dependencies |
+| `melos run gen:build` | Clean + regenerate all `*.g.dart` files |
+| `melos run gen:watch` | Watch mode for codegen |
+| `melos run gen:clean` | Clean generated outputs |
+| `melos run gen:winds-registry` | Regenerate the deterministic mix_winds parser registry |
+| `melos run ci` | Run all tests (flutter + dart) |
+| `melos run test:flutter` | Flutter tests only |
+| `melos run test:dart` | Dart tests only |
+| `melos run test:coverage` | Tests with coverage report |
+| `melos run analyze` | Dart + DCM analysis |
+| `melos run schema:inventory` | Verify `mix_protocol` schema inventory coverage |
+| `melos run format:check` | Verify Dart formatting without changing files |
+| `melos run fix` | Auto-fix lint issues |
+| `melos run exports` | Regenerate `mix.dart` barrel file |
+| `melos run api-check` | API compatibility checking |
+
+## Pre-Commit Verification
+
+```bash
+melos run gen:build && melos run ci && melos run analyze
+```
+
+Always run this before committing changes that touch specs, stylers, generated code, runtime behavior, or shared APIs.
+
+## Adding Type Metadata
+
+When creating Mix types for new Flutter types, update the generator's curated metadata:
+
+**File:** `packages/mix_generator/lib/src/core/curated/type_metadata.dart`
+
+Add or update:
+
+- `typeMetadata` entry keyed by analyzer display name
+- `TypeMetadata.mixType` when the Flutter type has a Mix counterpart
+- `TypeMetadata.ownerMixins` for generated fluent method ownership
+- `TypeCategory` for lerp/snapping behavior

--- a/.agents/skills/mix/references/examples.md
+++ b/.agents/skills/mix/references/examples.md
@@ -1,0 +1,225 @@
+# Examples
+
+Worked examples that show current Mix APIs in complete Flutter snippets.
+
+## Table of Contents
+
+- [Themed profile page](#themed-profile-page)
+- [Dark and light toggle](#darklight-toggle)
+- [Pressable button](#pressable-button)
+
+## Themed Profile Page
+
+Tokens define the visual vocabulary, `MixScope` provides concrete values, and Stylers consume token refs with `$token()` or `$token.mix()`.
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:mix/mix.dart';
+
+final $primary = ColorToken('primary');
+final $background = ColorToken('background');
+final $surface = ColorToken('surface');
+final $onPrimary = ColorToken('on.primary');
+final $onSurface = ColorToken('on.surface');
+final $heading = TextStyleToken('heading');
+final $body = TextStyleToken('body');
+final $spaceSm = SpaceToken('space.sm');
+final $spaceMd = SpaceToken('space.md');
+final $spaceLg = SpaceToken('space.lg');
+final $radiusMd = RadiusToken('radius.md');
+
+final lightColors = <ColorToken, Color>{
+  $primary: Colors.blue,
+  $background: Color(0xFFF5F7FA),
+  $surface: Colors.white,
+  $onPrimary: Colors.white,
+  $onSurface: Color(0xFF1D1F24),
+};
+
+final lightTextStyles = <TextStyleToken, TextStyle>{
+  $heading: TextStyle(fontSize: 22, fontWeight: FontWeight.w700),
+  $body: TextStyle(fontSize: 16),
+};
+
+final lightSpaces = <SpaceToken, double>{
+  $spaceSm: 8,
+  $spaceMd: 16,
+  $spaceLg: 24,
+};
+
+final lightRadii = <RadiusToken, Radius>{
+  $radiusMd: Radius.circular(12),
+};
+
+class ThemedProfilePage extends StatelessWidget {
+  const ThemedProfilePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final pageStyle = FlexBoxStyler()
+        .color($background())
+        .paddingAll($spaceLg())
+        .spacing($spaceMd());
+
+    final cardStyle = BoxStyler()
+        .color($surface())
+        .paddingAll($spaceMd())
+        .borderRadiusAll($radiusMd())
+        .shadowOnly(
+          color: Colors.black.withValues(alpha: 0.08),
+          offset: Offset(0, 6),
+          blurRadius: 18,
+        );
+
+    final avatarStyle = BoxStyler()
+        .color($primary())
+        .size(56, 56)
+        .borderRadiusAll($radiusMd())
+        .alignment(Alignment.center);
+
+    final avatarTextStyle = TextStyler()
+        .style($heading.mix())
+        .color($onPrimary());
+
+    final titleStyle = TextStyler()
+        .style($heading.mix())
+        .color($onSurface());
+
+    final bodyStyle = TextStyler().style($body.mix()).color($onSurface());
+
+    return MixScope(
+      colors: lightColors,
+      textStyles: lightTextStyles,
+      spaces: lightSpaces,
+      radii: lightRadii,
+      child: ColumnBox(
+        style: pageStyle,
+        children: [
+          Box(
+            style: cardStyle,
+            child: RowBox(
+              style: FlexBoxStyler()
+                  .spacing($spaceMd())
+                  .crossAxisAlignment(CrossAxisAlignment.center),
+              children: [
+                Box(
+                  style: avatarStyle,
+                  child: StyledText('LF', style: avatarTextStyle),
+                ),
+                ColumnBox(
+                  style: FlexBoxStyler()
+                      .spacing($spaceSm())
+                      .crossAxisAlignment(CrossAxisAlignment.start),
+                  children: [
+                    StyledText('Profile', style: titleStyle),
+                    StyledText('Welcome back!', style: bodyStyle),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+```
+
+## Dark/Light Toggle
+
+`onDark` responds to the platform brightness in `MediaQuery`, so this example keeps the toggle local by overriding `platformBrightness`.
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:mix/mix.dart';
+
+class ThemeToggle extends StatefulWidget {
+  const ThemeToggle({super.key});
+
+  @override
+  State<ThemeToggle> createState() => _ThemeToggleState();
+}
+
+class _ThemeToggleState extends State<ThemeToggle> {
+  bool isDark = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final buttonStyle = BoxStyler()
+        .height(60)
+        .width(60)
+        .borderRounded(30)
+        .color(Colors.grey.shade200)
+        .alignment(Alignment.center)
+        .shadowOnly(
+          color: Colors.black.withValues(alpha: 0.1),
+          offset: Offset(0, 4),
+          blurRadius: 10,
+        )
+        .onDark(BoxStyler().color(Colors.grey.shade800))
+        .animate(AnimationConfig.easeInOut(600.ms));
+
+    final iconStyle = IconStyler()
+        .color(Colors.grey.shade800)
+        .size(28)
+        .icon(Icons.dark_mode)
+        .onDark(IconStyler().icon(Icons.light_mode).color(Colors.yellow))
+        .animate(AnimationConfig.easeInOut(200.ms));
+
+    return MediaQuery(
+      data: MediaQuery.of(context).copyWith(
+        platformBrightness: isDark ? Brightness.dark : Brightness.light,
+      ),
+      child: PressableBox(
+        style: buttonStyle,
+        onPress: () => setState(() => isDark = !isDark),
+        child: StyledIcon(style: iconStyle),
+      ),
+    );
+  }
+}
+```
+
+## Pressable Button
+
+`PressableBox` combines gesture/focus state handling with a `BoxStyler`, so widget-state variants such as `onHovered` and `onPressed` can live in the style.
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:mix/mix.dart';
+
+class PrimaryActionButton extends StatelessWidget {
+  const PrimaryActionButton({
+    super.key,
+    required this.label,
+    required this.onPressed,
+  });
+
+  final String label;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final buttonStyle = BoxStyler()
+        .color(Colors.blue)
+        .paddingX(24)
+        .paddingY(12)
+        .borderRounded(8)
+        .alignment(Alignment.center)
+        .onHovered(BoxStyler().color(Colors.blue.shade700).translate(0, -1))
+        .onPressed(BoxStyler().color(Colors.blue.shade900).scale(0.98))
+        .animate(AnimationConfig.easeInOut(150.ms));
+
+    final labelStyle = TextStyler()
+        .color(Colors.white)
+        .fontSize(16)
+        .fontWeight(FontWeight.w700);
+
+    return PressableBox(
+      style: buttonStyle,
+      onPress: onPressed,
+      child: StyledText(label, style: labelStyle),
+    );
+  }
+}
+```

--- a/.agents/skills/mix/references/fluent-api.md
+++ b/.agents/skills/mix/references/fluent-api.md
@@ -1,0 +1,283 @@
+# Fluent API
+
+Chaining patterns, style mixins, and composition in Mix.
+
+## Table of Contents
+
+- [Core principle](#core-principle)
+- [Style mixins](#style-mixins)
+- [Interaction widgets](#interaction-widgets)
+- [Sizing](#sizing-decision-tree)
+- [Composition](#composition-via-merge)
+- [Callable stylers](#callable-stylers)
+
+## Core Principle
+
+Prefer fluent chaining on Styler types. Each setter returns a new merged instance:
+
+```dart
+final style = BoxStyler()
+    .color(Colors.blue)
+    .paddingAll(16)
+    .borderRounded(8)
+    .width(200);
+```
+
+Generated primitive setters merge a new Styler with the changed field. Convenience methods may delegate to lower-level setters or add widget modifiers.
+
+## Style Mixins
+
+Stylers mix in convenience methods. All methods are available on the corresponding Styler.
+
+### SpacingStyleMixin
+
+Padding and margin shortcuts:
+
+| Method | Description |
+|--------|-------------|
+| `paddingAll(v)` | All sides |
+| `paddingX(v)` / `paddingY(v)` | Horizontal / vertical |
+| `paddingTop(v)`, `paddingBottom(v)`, `paddingLeft(v)`, `paddingRight(v)` | Individual sides |
+| `paddingStart(v)` / `paddingEnd(v)` | RTL-aware |
+| `paddingOnly(...)` | Named parameters for any combination |
+| `marginAll(v)` | All margin sides |
+| `marginTop(v)`, etc. | Individual margin sides |
+| `marginOnly(...)` | Named margin parameters |
+
+### DecorationStyleMixin
+
+Decoration, color, gradient, border, shadow, shape, background image:
+
+| Method | Description |
+|--------|-------------|
+| `color(v)` | Background color |
+| `gradient(v)` | Gradient fill |
+| `border(v)` | Border (BoxBorderMix) |
+| `borderRadius(v)` | Border radius (BorderRadiusGeometryMix) |
+| `shadow(v)` / `shadows(v)` | Box shadow(s) |
+| `elevation(v)` | Elevation shadow preset |
+| `image(v)` | Decoration image |
+| `shape(v)` | Shape border |
+| `shapeCircle()`, `shapeStadium()`, `shapeRoundedRectangle()`, etc. | Shape shortcuts |
+| `backgroundImage(image)`, `backgroundImageUrl(url)`, `backgroundImageAsset(path)` | Background image utilities |
+| `linearGradient(...)`, `radialGradient(...)`, `sweepGradient(...)` | Gradient shortcuts |
+| `foregroundLinearGradient(...)`, etc. | Foreground gradient shortcuts |
+
+### BorderStyleMixin
+
+| Method | Description |
+|--------|-------------|
+| `borderAll(...)` | All sides: `color`, `width`, `style`, `strokeAlign` |
+| `borderTop(...)`, `borderBottom(...)`, `borderLeft(...)`, `borderRight(...)` | Individual sides |
+| `borderStart(...)` / `borderEnd(...)` | RTL-aware |
+| `borderVertical(...)` / `borderHorizontal(...)` | Grouped sides |
+
+### BorderRadiusStyleMixin
+
+| Method | Description |
+|--------|-------------|
+| `borderRounded(radius)` | Uniform circular radius (most common) |
+| `borderRadiusAll(radius)` | All corners with `Radius` |
+| `borderRadiusTop(r)`, `borderRadiusBottom(r)` | Top/bottom grouped |
+| `borderRadiusLeft(r)`, `borderRadiusRight(r)` | Left/right grouped |
+| `borderRadiusTopLeft(r)`, `borderRadiusTopRight(r)`, etc. | Individual corners |
+| `borderRadiusTopStart(r)`, `borderRadiusTopEnd(r)`, etc. | RTL-aware corners |
+| `borderRoundedTop(r)`, `borderRoundedBottom(r)`, etc. | Circular grouped |
+
+### ConstraintStyleMixin
+
+| Method | Description |
+|--------|-------------|
+| `width(v)` / `height(v)` | Fixed dimension |
+| `size(w, h)` | Both dimensions |
+| `minWidth(v)` / `maxWidth(v)` | Width constraints |
+| `minHeight(v)` / `maxHeight(v)` | Height constraints |
+| `constraintsOnly(...)` | Named parameters for any combination |
+
+### ShadowStyleMixin
+
+| Method | Description |
+|--------|-------------|
+| `shadowOnly(...)` | Single shadow with `color`, `offset`, `blurRadius`, `spreadRadius` |
+| `boxShadows(v)` | List of BoxShadowMix |
+| `boxElevation(v)` | ElevationShadow preset |
+
+### TransformStyleMixin
+
+| Method | Description |
+|--------|-------------|
+| `transform(matrix, {alignment})` | Raw Matrix4 |
+| `rotate(angle, {alignment})` | Rotation in radians |
+| `scale(factor, {alignment})` | Uniform scale |
+| `translate(x, y, [z])` | Translation |
+| `skew(skewX, skewY)` | Skew |
+| `transformReset()` | Reset to identity |
+
+### FlexStyleMixin (on FlexStyler/FlexBoxStyler)
+
+`RowBox` and `ColumnBox` are widgets backed by `FlexBoxStyler`; there are no separate `RowBoxStyler` or `ColumnBoxStyler` classes.
+
+| Method | Description |
+|--------|-------------|
+| `direction(axis)` | Flex direction |
+| `mainAxisAlignment(v)` | Main axis alignment |
+| `crossAxisAlignment(v)` | Cross axis alignment |
+| `mainAxisSize(v)` | Main axis sizing |
+| `spacing(v)` | Gap between children |
+| `row()` / `column()` | Direction shortcuts |
+
+### WrapStyleMixin (on WrapStyler/WrapBoxStyler)
+
+`WrapBoxStyler` flattens the common Wrap fields while keeping Box collisions
+explicit:
+
+| Method | Description |
+|--------|-------------|
+| `direction(axis)` | Wrap main-axis direction |
+| `spacing(v)` | Space between children within a run |
+| `runSpacing(v)` | Space between runs |
+| `wrapAlignment(v)` | Child alignment within each run |
+| `runAlignment(v)` | Run alignment on the cross axis |
+| `crossAxisAlignment(v)` | Child alignment within a run's cross axis |
+| `wrapClipBehavior(v)` | Inner Wrap clipping |
+| `flow(WrapStyler(...))` | Direct nested Wrap-style composition |
+
+On `WrapBoxStyler`, `alignment()` and `clipBehavior()` belong to the outer Box.
+Use `wrapAlignment()` and `wrapClipBehavior()` for the inner Wrap.
+
+### GridBoxStyler
+
+`GridBoxStyler` is handwritten because Grid adds render-time local constraint
+selection. Prefer an explicitly typed factory initializer:
+
+```dart
+final GridBoxStyler grid = .equalColumns(3)
+    .gap(16)
+    .autoRows(.fixed(220));
+```
+
+Use `columns`, `equalColumns`, `rows`, `autoRows`, `gap`, `columnGap`,
+`rowGap`, `clipBehavior`, and `onConstraints`. See [`layout.md`](layout.md) for
+the Grid track model, use cases, constraints, and animation compatibility.
+
+### TextStyleMixin (on TextStyler)
+
+| Method | Description |
+|--------|-------------|
+| `color(v)`, `fontSize(v)`, `fontWeight(v)`, `fontStyle(v)` | Basic text styling |
+| `letterSpacing(v)`, `wordSpacing(v)`, `height(v)` | Spacing |
+| `decoration(v)`, `decorationColor(v)`, `decorationStyle(v)` | Text decoration |
+| `fontFamily(v)`, `fontFamilyFallback(v)` | Font selection |
+| `shadows(v)`, `fontFeatures(v)`, `fontVariations(v)` | Advanced |
+
+### IconStyler
+
+Generated fluent setters from `IconSpec`:
+
+| Method | Description |
+|--------|-------------|
+| `icon(v)` | Icon glyph data |
+| `color(v)` | Icon color |
+| `size(v)` | Icon size |
+| `weight(v)` | Variable-font weight axis |
+| `grade(v)` | Variable-font grade axis |
+| `opticalSize(v)` | Variable-font optical size axis |
+| `fill(v)` | Variable-font fill axis |
+| `opacity(v)` | Icon opacity |
+| `shadow(v)` / `shadows(v)` | One shadow or a shadow list |
+| `blendMode(v)` | Color blend mode |
+| `applyTextScaling(v)` | Whether text scaling affects the icon |
+| `textDirection(v)` | Text direction for directional icons |
+| `semanticsLabel(v)` | Accessibility label |
+
+### ImageStyler
+
+Generated fluent setters from `ImageSpec`:
+
+| Method | Description |
+|--------|-------------|
+| `image(v)` | Image provider |
+| `width(v)` / `height(v)` | Display dimensions |
+| `color(v)` | Color filter color |
+| `fit(v)` | Box fit |
+| `alignment(v)` | Image alignment |
+| `repeat(v)` | Image repeat mode |
+| `centerSlice(v)` | Nine-patch center slice |
+| `filterQuality(v)` | Sampling quality |
+| `colorBlendMode(v)` | Color filter blend mode |
+| `semanticLabel(v)` | Accessibility label |
+| `gaplessPlayback(v)` | Keep old image while new image loads |
+| `isAntiAlias(v)` | Anti-alias image edges |
+| `matchTextDirection(v)` | Flip in RTL contexts |
+
+See also [`styler-api-policy.md`](styler-api-policy.md) for top-level factory and dot-shorthand guidance.
+
+## Interaction Widgets
+
+Use `Pressable` for interaction state around any child, and `PressableBox` when the interactive surface is also a `Box`.
+
+### Pressable
+
+| Parameter | Description |
+|-----------|-------------|
+| `child` | Required child widget |
+| `onPress` / `onLongPress` | Tap and long-press callbacks |
+| `enabled` | Enables interaction; defaults to `true` |
+| `enableFeedback` | Enables haptic/audio feedback; defaults to `false` |
+| `onFocusChange` | Focus change callback |
+| `autofocus` | Requests focus automatically; defaults to `false` |
+| `focusNode` | Optional focus node |
+| `mouseCursor` | Cursor override |
+| `hitTestBehavior` | Gesture hit-test behavior; defaults to `HitTestBehavior.opaque` |
+| `canRequestFocus` | Whether focus can be requested; defaults to `true` |
+| `controller` | Optional `WidgetStatesController` |
+| `actions` | Additional focus actions |
+| `onKeyEvent` | Custom key handling while enabled; runs before built-in activation |
+| `semanticsLabel` | Accessibility label |
+| `semanticsRole` | `PressableSemanticsRole.button` (default), `link`, or `none` |
+| `excludeFromSemantics` | Suppresses Pressable's semantic annotations while preserving descendant semantics; defaults to `false` |
+
+While focused, `Pressable` handles unmodified Space, Enter, numpad Enter,
+select, and game button A itself: pressed on key down, activated once on key up.
+It leaves those keys alone when a descendant holds focus, so a nested
+`TextField` still receives them, and leaves modified chords to application
+shortcuts. Those direct key bindings are handled before Flutter can dispatch an
+`ActivateIntent`; use `onKeyEvent` to override them. `ActivateIntent` remains
+bound so remapped shortcuts and programmatic invocation activate `onPress`, and
+a custom action can override that binding. With `semanticsRole: .link`, Enter
+activates but Space does not. Custom actions are not installed while the
+Pressable is disabled.
+
+### PressableBox
+
+| Parameter | Description |
+|-----------|-------------|
+| `style` | Optional `BoxStyler` for the surface |
+| `child` | Required child widget |
+| `onPress` / `onLongPress` | Tap and long-press callbacks |
+| `enabled` | Enables interaction; defaults to `true` |
+| `focusNode` | Optional focus node |
+| `onFocusChange` | Focus change callback |
+| `autofocus` | Requests focus automatically; defaults to `false` |
+| `enableFeedback` | Enables haptic/audio feedback; defaults to `false` |
+| `hitTestBehavior` | Gesture hit-test behavior; defaults to `HitTestBehavior.opaque` |
+
+`PressableBox` forwards the full `Pressable` surface — including `mouseCursor`, `canRequestFocus`, `onKeyEvent`, `controller`, `actions`, `semanticsLabel`, `semanticsRole`, and `excludeFromSemantics` — and renders the child through `Box(style: style, child: child)`.
+
+## Sizing Decision Tree
+
+See [`styler-api-policy.md`](styler-api-policy.md) for the canonical sizing and composition decision tree.
+See [`layout.md`](layout.md) when choosing among Box, Flex, Wrap, Grid, and Stack.
+
+## Composition via Merge
+
+Use `merge()` for combining reusable style fragments; see [`styler-api-policy.md`](styler-api-policy.md) for the reference example. Later replacement values override earlier ones, while Mix values merge field-by-field before resolving.
+
+## Callable Stylers
+
+Widget-backed generated Stylers support `call()` for inline widget creation. This includes `BoxStyler`, `TextStyler`, `IconStyler`, `ImageStyler`, `FlexBoxStyler`, `WrapBoxStyler`, and `StackBoxStyler`; layout-only stylers such as `FlexStyler`, `WrapStyler`, and `StackStyler` do not create widgets directly. `GridBoxStyler` is handwritten and is not callable; construct `GridBox(style: ..., children: ...)` explicitly.
+
+```dart
+BoxStyler().color(Colors.blue).paddingAll(16)(child: Text('Hello'))
+// Equivalent to: Box(style: BoxStyler()..., child: Text('Hello'))
+```

--- a/.agents/skills/mix/references/layout.md
+++ b/.agents/skills/mix/references/layout.md
@@ -1,0 +1,283 @@
+# Layout with Mix
+
+Choose and compose Mix-owned layout primitives without falling back to raw
+Flutter layout widgets for styling concerns.
+
+## Table of Contents
+
+- [Verify API availability](#verify-api-availability)
+- [Select a primitive](#select-the-primitive)
+- [Understand composites](#understand-composite-layouts)
+- [One-dimensional layouts](#build-one-dimensional-layouts)
+- [Wrapping layouts](#build-wrapping-layouts)
+- [Grid layouts](#build-two-dimensional-grid-layouts)
+- [Overlays](#build-overlays)
+- [Verification](#verify-layout-work)
+
+## Verify API Availability
+
+Check the consuming package's `pubspec.yaml` and resolved dependency before
+using a layout API. This repository's `main` branch includes `WrapBox` and
+`GridBox`, both first shipped in the `mix 2.2.0-beta.2` release. When working in
+the Mix repository, prefer local source. When working downstream, confirm the
+installed version exposes the referenced classes.
+
+## Select the Primitive
+
+| Layout need | Mix primitive | Why |
+|---|---|---|
+| One child with size, padding, constraints, or decoration | `Box` + `BoxStyler` | Owns single-child box styling |
+| One non-wrapping horizontal or vertical sequence | `RowBox`, `ColumnBox`, or `FlexBox` + `FlexBoxStyler` | Combines Flex geometry with outer Box styling |
+| Intrinsic items that should flow onto additional runs | `WrapBox` + `WrapBoxStyler` | Models tags, chips, and button groups without fixed tracks |
+| Explicit two-dimensional rows and columns | `GridBox` + `GridBoxStyler` | Models dashboards, card catalogs, and galleries with fixed/`fr` tracks |
+| Overlapping or positioned children | `StackBox` + `StackBoxStyler` | Combines Stack geometry with outer Box styling |
+
+Prefer the simplest primitive that represents the layout semantics. Do not use
+Grid merely to place a single row, and do not use Wrap when columns must align
+across runs.
+
+## Understand Composite Layouts
+
+`FlexBox`, `WrapBox`, and `StackBox` resolve a layout sub-spec and optionally an
+outer `BoxSpec`. Their Stylers therefore expose both layout and Box methods.
+Keep decoration, padding, margin, transforms, and constraints on the composite
+Styler instead of nesting a raw `Container`.
+
+`GridBox` is different: it owns Grid geometry, clipping, Mix variants,
+modifiers, and animation, but it does not contain an outer `BoxSpec`. Wrap it
+in `Box` when the grid itself needs padding or decoration:
+
+```dart
+Box(
+  style: BoxStyler().paddingAll(16).color(Colors.white),
+  child: GridBox(style: gridStyle, children: cards),
+);
+```
+
+Use the layout-only `FlexStyler`, `WrapStyler`, and `StackStyler` when composing
+the nested sub-style directly. For ordinary widget code, start from the
+corresponding `*BoxStyler`.
+
+## Build One-Dimensional Layouts
+
+Use `RowBox` or `ColumnBox` when direction is fixed by the widget:
+
+```dart
+final toolbarStyle = FlexBoxStyler()
+    .mainAxisAlignment(.spaceBetween)
+    .crossAxisAlignment(.center)
+    .spacing(12)
+    .paddingAll(16);
+
+RowBox(style: toolbarStyle, children: actions);
+```
+
+Do not set a conflicting direction on a `RowBox` or `ColumnBox` style. Use
+`FlexBox` when direction itself is dynamic:
+
+```dart
+final contentStyle = FlexBoxStyler()
+    .direction(isCompact ? .vertical : .horizontal)
+    .spacing(16);
+
+FlexBox(style: contentStyle, children: sections);
+```
+
+Use `.wrap(WidgetModifierConfig.flexible(...))` on a child Styler when that
+child needs Flutter `Flexible` behavior inside a Flex layout. Keep parent
+alignment and spacing on `FlexBoxStyler`.
+
+## Build Wrapping Layouts
+
+Use `WrapBox` for items whose intrinsic widths determine where runs break:
+
+```dart
+final tagCloudStyle = WrapBoxStyler()
+    .paddingAll(16)
+    .spacing(8)
+    .runSpacing(10)
+    .wrapAlignment(.center);
+
+WrapBox(style: tagCloudStyle, children: tags);
+```
+
+Distinguish the collision-safe composite names:
+
+- `.alignment(...)` and `.clipBehavior(...)` configure the outer Box.
+- `.wrapAlignment(...)` and `.wrapClipBehavior(...)` configure the inner Wrap.
+- `.flow(WrapStyler(...))` replaces or merges the nested Wrap style directly.
+- `.wrap(...)` remains Mix's widget-modifier API, so the nested Wrap field is
+  intentionally named `flow`.
+
+Choose Wrap over Grid for tags, filters, and button groups that have varying
+intrinsic widths. Choose Grid when cells need shared column boundaries or
+explicit row heights.
+
+## Build Two-Dimensional Grid Layouts
+
+### Start with explicit tracks
+
+Give a Grid declaration an explicit `GridBoxStyler` type, then use factory
+shorthand to make its topology visible:
+
+```dart
+final GridBoxStyler cardGridStyle = .equalColumns(3)
+    .gap(16)
+    .autoRows(.fixed(220));
+
+GridBox(style: cardGridStyle, children: cards);
+```
+
+Use `.equalColumns(count)` for equal `fr(1)` columns. Use `.columns([...])` for
+mixed geometry:
+
+```dart
+final GridBoxStyler reportGridStyle = .columns([
+  .fixed(240),
+  .fr(2),
+  .fr(1),
+]).columnGap(16).autoRows(.fixed(280));
+```
+
+Interpret tracks as follows:
+
+- `.fixed(240)` consumes 240 logical pixels and does not shrink.
+- `.fr(2)` receives twice the remaining space of `.fr(1)` after fixed tracks
+  and gaps.
+- Fractional columns require bounded width.
+- Fractional rows and fractional `autoRows` require bounded height.
+
+### Provide row geometry
+
+Children fill columns left to right, then advance row by row. Provide enough
+explicit `.rows([...])` tracks for every required row or set `.autoRows(...)`
+for the remaining rows. A non-empty Grid with no applicable row track reports
+an error instead of guessing content-sized geometry.
+
+```dart
+final GridBoxStyler galleryStyle = .equalColumns(2)
+    .rows([.fixed(180)])
+    .autoRows(.fixed(180))
+    .columnGap(12)
+    .rowGap(12);
+```
+
+With five children and two columns, this Grid needs three rows. The first uses
+the explicit track and the next two repeat `autoRows`. In a vertical
+`SingleChildScrollView`, use fixed row tracks because height is unbounded.
+
+### Respond to the offered container
+
+Use `.onConstraints(...)` when a Grid should adapt to the maximum size offered
+by its own parent:
+
+```dart
+final GridBoxStyler responsiveCards = .equalColumns(3)
+    .gap(16)
+    .autoRows(.fixed(220))
+    .onConstraints(
+      .maxWidth(760),
+      .equalColumns(2).gap(12),
+    )
+    .onConstraints(
+      .maxWidth(520),
+      .equalColumns(1).gap(10),
+    );
+```
+
+Apply matching branches in declaration order. In the example, both maximum
+width branches match below 520, so the later one-column patch refines the
+earlier two-column patch.
+
+Keep `onConstraints` patches geometry-only. They may set columns, rows,
+`autoRows`, `columnGap`, and `rowGap`. They may not set clipping, modifiers,
+animations, ordinary variants, or nested constraint branches. Put those values
+on the base `GridBoxStyler`.
+
+Use `.onBreakpoint(...)` instead when the decision should observe viewport
+size through `MediaQuery`. Two Grids in the same viewport can select different
+`onConstraints` branches because their parents offer different widths.
+
+### Pick Grid for concrete use cases
+
+Use responsive `GridBox` for:
+
+- metric dashboards whose panels collapse from four to two to one column;
+- product catalogs with equal card widths and repeated fixed row heights;
+- media galleries with aligned tracks and controlled clipping;
+- asymmetric report layouts using fixed sidebar tracks plus fractional content;
+- nested components that should respond to their container rather than the
+  whole device viewport.
+
+Avoid the current Grid API when the design requires content-sized tracks,
+spans, named areas, masonry packing, direction-aware placement, or baseline
+alignment. Those features are intentionally outside the current contract. Use
+a more suitable Flutter layout or redesign the track model rather than
+pretending the API supports them.
+
+### Animate compatible geometry
+
+Use the standard Mix `.animate(...)` API when state changes Grid geometry:
+
+```dart
+final GridBoxStyler animatedGrid = .columns([
+  .fr(focused ? 2 : 1),
+  .fr(1),
+])
+    .autoRows(.fixed(focused ? 148 : 112))
+    .gap(focused ? 20 : 12)
+    .animate(.easeInOut(const Duration(milliseconds: 400)));
+```
+
+Keep track lists the same length and keep each positional track kind compatible
+(`fixed` with `fixed`, `fr` with `fr`) for continuous interpolation. Compatible
+rows, `autoRows`, and gaps interpolate too. Track-count or track-kind changes,
+clipping, and constraint-patch lists switch at the midpoint. A live
+`onConstraints` branch change remains immediate because selection happens
+during layout rather than creating a new animation target.
+
+### Handle overflow deliberately
+
+Expect fixed tracks to preserve their requested size even when they exceed the
+available extent. Leave `clipBehavior` at `.none` when overflow should remain
+visible with diagnostics, or set it on the base style when painting must be
+contained:
+
+```dart
+final GridBoxStyler clippedGallery = .equalColumns(4)
+    .autoRows(.fixed(160))
+    .gap(12)
+    .clipBehavior(.hardEdge);
+```
+
+## Build Overlays
+
+Use `StackBox` for badges, overlays, and positioned content:
+
+```dart
+final overlayStyle = StackBoxStyler()
+    .paddingAll(12)
+    .borderRounded(16)
+    .stackAlignment(.bottomCenter)
+    .stackClipBehavior(.none);
+
+StackBox(style: overlayStyle, children: layers);
+```
+
+Distinguish `.alignment(...)` and `.clipBehavior(...)` for the outer Box from
+`.stackAlignment(...)` and `.stackClipBehavior(...)` for the inner Stack. Use
+`.stack(StackStyler(...))` for direct nested-style composition.
+
+## Verify Layout Work
+
+Check the smallest source and test surface that owns the behavior:
+
+- Grid guide: `packages/mix/doc/grid-layout.md`
+- Grid runnable use cases: `packages/mix/example/lib/grid_example.dart`
+- Grid contract tests: `packages/mix/test/src/layout/`
+- Wrap runnable use case: `packages/mix/example/lib/main.dart`
+- Flex, Wrap, and Stack composites: `packages/mix/lib/src/specs/`
+
+Run focused widget tests while iterating. Before handing off changes to Mix
+layout internals, run the repository-required generation, test, and analysis
+commands from the main skill.

--- a/.agents/skills/mix/references/styler-api-policy.md
+++ b/.agents/skills/mix/references/styler-api-policy.md
@@ -1,0 +1,143 @@
+# Styler API Policy
+
+Rules for static factory constructors on Styler classes and Dart 3.11+ dot-shorthand usage.
+
+## Table of Contents
+
+- [Top-level rule](#the-top-level-rule)
+- [Nested shorthand](#nested-shorthand-rule)
+- [Enum shorthand](#dot-shorthand-for-enumconstant-arguments)
+- [Factory constructors](#factory-constructors-by-styler)
+- [Chain-only methods](#methods-without-factories-chain-only)
+- [Composition](#composition-decision-tree)
+
+Requires Dart SDK >=3.11.0 and Flutter >=3.41.0.
+
+## The Top-Level Rule
+
+Start ordinary top-level style declarations with an instance constructor, then chain:
+
+```dart
+// CORRECT — instance constructor at top-level
+BoxStyler().color(Colors.blue).padding(.all(16))
+TextStyler().fontSize(18).color(Colors.white)
+IconStyler().size(24).color(Colors.red)
+FlexBoxStyler().direction(.horizontal).spacing(8).padding(.all(16))
+```
+
+```dart
+// Discouraged by policy at top-level, though valid API
+BoxStyler.color(Colors.blue)
+
+// WRONG — bare dot-shorthand at top-level
+.color(Colors.blue)
+```
+
+Use an explicitly typed factory initializer when the factory communicates
+required topology better than an empty constructor. Grid is the deliberate
+case in the current API:
+
+```dart
+// CORRECT — the declared type supplies shorthand context
+final GridBoxStyler cards = .equalColumns(3)
+    .gap(16)
+    .autoRows(.fixed(220));
+
+// WRONG — no contextual type for the leading shorthand
+final cards = .equalColumns(3);
+```
+
+## Nested Shorthand Rule
+
+In typed contexts (variants, state callbacks, typed params), use bare shorthand without the type prefix:
+
+```dart
+// CORRECT — bare shorthand in nested contexts
+style.onHovered(.color(Colors.blue))
+style.onDark(.color(Colors.white))
+style.onDisabled(.color(Colors.grey))
+BoxStyler().color(Colors.blue)
+  .onHovered(.shadow(.color(Colors.black12).blurRadius(10)))
+```
+
+```dart
+// WRONG — explicit constructor in nested context
+style.onHovered(BoxStyler().color(Colors.blue))
+```
+
+Common typed contexts:
+- explicitly typed initializers such as `final GridBoxStyler grid = .columns(...)`
+- `.container(.shadow(...))`
+- `.onHovered(.color(...))`
+- `.onDisabled(.color(...))`
+- `.onConstraints(.maxWidth(600), .equalColumns(1))`
+
+## Dot-Shorthand for Enum/Constant Arguments
+
+Within chains, use Dart 3.11+ inferred shorthand for enum and constant values:
+
+```dart
+BoxStyler().alignment(.center)
+FlexBoxStyler().mainAxisAlignment(.center)
+StackBoxStyler().fit(.expand)
+```
+
+## Factory Constructors by Styler
+
+Generated Styler factories are valid API, but this skill intentionally discourages top-level factory entry points in favor of `Styler().chain()` declarations. The factory surface is generated and can drift, so confirm against the local `*_spec.g.dart` file when exact coverage matters.
+
+Common generated factories include:
+
+| Styler | Common factory groups |
+|---|---|
+| `BoxStyler` | layout (`alignment`, `padding`, `margin`, constraints), decoration (`color`, `gradient`, `border`, `borderRadius`, `shadow`, `image`, `shape`), transforms (`transform`, `scale`, `rotate`, `translate`, `skew`), gradients/background images, `textStyle`, `animate` |
+| `FlexStyler` | `direction`, `mainAxisAlignment`, `crossAxisAlignment`, `mainAxisSize`, `spacing`, row/column presets |
+| `FlexBoxStyler` | generated flexbox spec fields plus many box-style factories; verify clip/flex naming in `flexbox_spec.g.dart` |
+| `WrapStyler` | `direction`, `alignment`, `spacing`, `runAlignment`, `runSpacing`, `crossAxisAlignment`, `clipBehavior` |
+| `WrapBoxStyler` | generated wrapbox fields plus Box factories; use collision-safe `wrapAlignment` and `wrapClipBehavior` for the inner Wrap |
+| `GridBoxStyler` | handwritten `columns`, `equalColumns`, `rows`, `autoRows`, gaps, `clipBehavior`, `onConstraints`, `animate` |
+| `StackStyler` | `alignment`, `fit`, `clipBehavior` |
+| `StackBoxStyler` | generated stackbox fields plus Box factories; use `stackAlignment` and `stackClipBehavior` for the inner Stack |
+| `TextStyler` | layout (`overflow`, `textAlign`, `maxLines`, `softWrap`, direction), typography (`style`, color/font/decoration/spacing), paint/shadow/font-feature fields, text directives (`uppercase`, `lowercase`, `capitalize`, `titlecase`, `sentencecase`) |
+| `IconStyler` | `icon`, `color`, `size`, `weight`, `grade`, `opticalSize`, `fill`, `opacity`, `shadows`, `shadow`, `textDirection`, `applyTextScaling`, `blendMode` |
+| `ImageStyler` | `image`, dimensions, `color`, `repeat`, `fit`, `alignment`, `centerSlice`, `filterQuality`, `colorBlendMode`, `gaplessPlayback`, `isAntiAlias`, `matchTextDirection` |
+
+## Methods WITHOUT Factories (Chain-Only)
+
+These are mid-chain or end-of-chain policy choices. Some may also have generated factories; still prefer chained usage in top-level declarations:
+
+| Category | Methods |
+|---|---|
+| Compound spacing | `padding(.all(8))`, `padding(.horizontal(8))`, `padding(.vertical(8))`, `margin(.all(8))`, `margin(.horizontal(8))`, `margin(.vertical(8))`, `padding(.only(left: 8, right: 8))` |
+| Compound border | `border(.all())`, `border(.top())`, `borderRadius(.circular())` |
+| Compound box | `shadow(.color(...).blurRadius(...))`, `backgroundImageUrl` |
+| Text directives | `uppercase`, `lowercase`, `capitalize`, `titlecase`, `sentencecase` |
+| Variants and local constraints | `onHovered`, `onPressed`, `onDark`, `onLight`, `onDisabled`, `onFocused`, `variant`, `onBreakpoint`, Grid `onConstraints` |
+| Advanced modifiers | `wrap`, `phaseAnimation`, `keyframeAnimation` |
+
+**Rationale:** Factory constructors are reserved for primitives that map to stable style concepts. Compound convenience methods remain as instance methods to keep the static API focused.
+
+## Composition Decision Tree
+
+- Fixed size? → `BoxStyler().size(w, h)`
+- Square? → `BoxStyler().size(s, s)` or `BoxStyler(constraints: BoxConstraintsMix.square(s))`
+- Min/max bounds? → `BoxStyler().minWidth(100).maxWidth(300)`
+- Pre-built Size/constraints? → Pass via constructor
+- Combining fragments? → `merge()`
+- Choosing a multi-child layout? → Use the decision guide in [`layout.md`](layout.md)
+- Otherwise → Chain on the Styler instance
+
+## Composition Examples
+
+```dart
+// Chaining (preferred for everyday use)
+final style = BoxStyler().color(Colors.blue).padding(.all(16)).borderRadius(.circular(8));
+
+// merge() for combining reusable fragments
+final base = BoxStyler().padding(.all(16));
+final elevated = BoxStyler().borderRadius(.circular(12));
+final card = base.merge(elevated);
+
+// Constructor for passing pre-built objects
+final box = BoxStyler(constraints: BoxConstraintsMix.square(200));
+```

--- a/.agents/skills/mix/references/testing.md
+++ b/.agents/skills/mix/references/testing.md
@@ -1,0 +1,251 @@
+# Testing
+
+Testing patterns for Mix, adapted from `packages/mix/test/helpers/testing_utils.dart`.
+
+## Table of Contents
+
+- [Philosophy](#core-philosophy)
+- [Utilities](#utilities)
+- [Testing patterns](#testing-patterns)
+- [MockBuildContext](#mockbuildcontext)
+- [Widget testing](#widget-testing)
+- [Common mistakes](#common-mistakes)
+- [Best practices](#best-practices)
+
+## Core Philosophy
+
+Testing in Mix focuses on **resolution testing**: verify what `Resolvable` types, `Prop` values, Mix value objects, Stylers, and modifier Mix classes resolve to in a `BuildContext`.
+
+## Utilities
+
+Core resolution utilities live in `packages/mix/test/helpers/testing_utils.dart`; widget-state helpers live in `packages/mix/test/helpers/widget_state_test_helper.dart`.
+
+| Utility | Purpose |
+|---------|---------|
+| `resolvesTo<T>(expected, {context})` | Core matcher for `Resolvable` and `Prop` values |
+| `MockBuildContext` | BuildContext with `MixScope` token and modifier-order support |
+| `MockStyle<T>` | Universal test style wrapping any type |
+| `MockSpec<T>` | Simple spec for test resolution |
+| `pumpWithMixScope()` | Widget tester extension: pump a widget inside `MixScope` |
+| `pumpMaterialApp()` | Widget tester extension: pump in `MaterialApp` |
+| `TestToken<T>` | Test-only concrete `MixToken<T>` implementation |
+
+## Testing Patterns
+
+### Basic Prop Resolution
+
+```dart
+test('Props resolve to their values', () {
+  final colorProp = Prop.value(Colors.red);
+
+  expect(colorProp, resolvesTo(Colors.red));
+});
+```
+
+### Mix Type Resolution
+
+```dart
+test('Mix types resolve to Flutter types', () {
+  final radiusMix = BorderRadiusMix.all(Radius.circular(8.0));
+  expect(radiusMix, resolvesTo(BorderRadius.circular(8.0)));
+
+  final edgeInsetsMix = EdgeInsetsGeometryMix.all(16.0);
+  expect(edgeInsetsMix, resolvesTo(const EdgeInsets.all(16.0)));
+});
+```
+
+### Token Resolution
+
+```dart
+test('Tokens resolve with custom context', () {
+  const primary = ColorToken('primary');
+  final tokenProp = Prop.token(primary);
+
+  final context = MockBuildContext(
+    tokens: {primary: const Color(0xFF2196F3)},
+  );
+
+  expect(tokenProp, resolvesTo(const Color(0xFF2196F3), context: context));
+});
+```
+
+Use `TestToken<T>` when no concrete token subtype exists for the value under test:
+
+```dart
+const custom = TestToken<MyValue>('custom');
+final context = MockBuildContext(tokens: {custom: myValue});
+```
+
+### Merge Behavior: Replacement
+
+Regular `Prop<T>` sources use last-value-wins merge behavior:
+
+```dart
+test('Prop<T> merge - replacement strategy', () {
+  final prop1 = Prop.value(100.0);
+  final prop2 = Prop.value(200.0);
+  final prop3 = Prop.value(300.0);
+
+  final merged = prop1.mergeProp(prop2).mergeProp(prop3);
+
+  expect(merged, resolvesTo(300.0));
+});
+```
+
+### Merge Behavior: Accumulation
+
+`Prop.mix(...)` values accumulate by merging Mix value objects field-by-field:
+
+```dart
+test('Prop<V> with Mix values - accumulation strategy', () {
+  final prop1 = Prop.mix(EdgeInsetsGeometryMix.only(left: 8.0));
+  final prop2 = Prop.mix(EdgeInsetsGeometryMix.only(right: 16.0));
+
+  final merged = prop1.mergeProp(prop2);
+
+  expect(
+    merged,
+    resolvesTo(const EdgeInsets.only(left: 8.0, right: 16.0)),
+  );
+});
+```
+
+### Generated Styler Resolution
+
+Generated Stylers expose raw resolved fields with `$` prefixes and resolve to `StyleSpec<TSpec>`:
+
+```dart
+test('BoxStyler resolves props and spec values', () {
+  final style = BoxStyler()
+      .width(100)
+      .padding(EdgeInsetsGeometryMix.all(16));
+
+  expect(style.$constraints, resolvesTo(BoxConstraints.tightFor(width: 100)));
+  expect(style.$padding, resolvesTo(const EdgeInsets.all(16)));
+
+  final resolved = style.resolve(MockBuildContext());
+  expect(resolved.spec.constraints, BoxConstraints.tightFor(width: 100));
+  expect(resolved.spec.padding, const EdgeInsets.all(16));
+});
+```
+
+### Styler Merge
+
+```dart
+test('BoxStyler merging combines replacement and accumulation fields', () {
+  final base = BoxStyler()
+      .width(100)
+      .padding(EdgeInsetsGeometryMix.only(left: 8.0));
+
+  final override = BoxStyler()
+      .width(200)
+      .padding(EdgeInsetsGeometryMix.only(right: 16.0));
+
+  final merged = base.merge(override);
+
+  expect(merged.$constraints, resolvesTo(BoxConstraints.tightFor(width: 200)));
+  expect(
+    merged.$padding,
+    resolvesTo(const EdgeInsets.only(left: 8.0, right: 16.0)),
+  );
+});
+```
+
+### Modifier Mix Testing
+
+```dart
+test('modifier mix resolves to modifier', () {
+  final modifier = OpacityModifierMix(opacity: 0.8);
+
+  expect(modifier, resolvesTo(const OpacityModifier(0.8)));
+});
+
+test('modifier mix merging uses replacement for scalar props', () {
+  final base = AspectRatioModifierMix(aspectRatio: 1.0);
+  final override = AspectRatioModifierMix(aspectRatio: 2.0);
+
+  final merged = base.merge(override);
+
+  expect(merged.aspectRatio, resolvesTo(2.0));
+});
+```
+
+### Utility and Fluent API Testing
+
+Test public fluent methods through the generated Styler instead of removed utility classes:
+
+```dart
+test('fluent utility method creates correct style', () {
+  final style = BoxStyler().color(Colors.orange);
+  final resolved = style.resolve(MockBuildContext());
+
+  final decoration = resolved.spec.decoration as BoxDecoration;
+  expect(decoration.color, Colors.orange);
+});
+```
+
+## MockBuildContext
+
+Use `MockBuildContext` when resolution requires a `BuildContext`:
+
+```dart
+// Basic context with an empty MixScope.
+final context = MockBuildContext();
+
+// Context with token values.
+const primary = ColorToken('primary');
+final contextWithTokens = MockBuildContext(
+  tokens: {primary: Colors.blue},
+);
+
+// Context with custom modifier order.
+final contextWithOrder = MockBuildContext(
+  orderOfModifiers: [OpacityModifier, PaddingModifier],
+);
+```
+
+## Widget Testing
+
+`pumpWithMixScope` takes the widget as its first positional argument:
+
+```dart
+testWidgets('Box renders with style', (tester) async {
+  const primary = ColorToken('primary');
+
+  await tester.pumpWithMixScope(
+    Box(
+      style: BoxStyler().color(primary()).paddingAll(16),
+      child: const Text('Hello'),
+    ),
+    tokens: {primary: Colors.blue},
+  );
+
+  expect(find.text('Hello'), findsOneWidget);
+});
+```
+
+## Common Mistakes
+
+### Tokens Need Context
+
+```dart
+// Wrong: token values require context for resolution.
+expect(tokenProp, resolvesTo(Colors.blue));
+
+// Correct: provide a context with token mappings.
+final context = MockBuildContext(tokens: {token: Colors.blue});
+expect(tokenProp, resolvesTo(Colors.blue, context: context));
+```
+
+### Use Current Generated Names
+
+Current Mix tests use generated Stylers, modifier Mix classes, direct `MockBuildContext` constructor arguments, and public fluent Styler methods. Avoid older spec-attribute classes, modifier-attribute classes, scope-data wrappers, and utility classes from pre-generated APIs.
+
+## Best Practices
+
+1. Prefer resolution tests for Props, Mix values, Stylers, and modifiers.
+2. Use `MockBuildContext(tokens: ...)` when token resolution is involved.
+3. Test generated Styler fields through `$field` access only in package tests.
+4. Test widget integration with `pumpWithMixScope(widget, tokens: ...)`.
+5. Test merge behavior through resolved values, not only object shape.
+6. Add widget-state helper tests when interaction variants are involved.

--- a/.agents/skills/mix/references/variants.md
+++ b/.agents/skills/mix/references/variants.md
@@ -1,0 +1,185 @@
+# Variants
+
+Context-aware and state-driven styling in Mix.
+
+## Table of Contents
+
+- [Variant hierarchy](#variant-hierarchy)
+- [Priority order](#priority-order)
+- [Built-in variants](#built-in-variant-methods)
+- [Usage patterns](#usage-patterns)
+- [Named variants](#pre-defined-named-variants)
+- [ContextVariant factories](#contextvariant-factory-methods)
+- [StyleVariation](#stylevariation)
+
+## Variant Hierarchy
+
+**File:** `packages/mix/lib/src/variants/variant.dart`
+
+```dart
+sealed class Variant {
+  String get key;
+}
+```
+
+| Type | Activation | Use Case |
+|------|-----------|----------|
+| `NamedVariant` | Manual — via `namedVariants` set in `build()` | Design system: `primary`, `secondary`, `small`, `large` |
+| `ContextVariant` | Auto — evaluates `bool Function(BuildContext)` | Environment: dark mode, orientation, breakpoint, platform |
+| `WidgetStateVariant` | Auto — extends `ContextVariant` for `WidgetState` | Interaction: hovered, pressed, focused, disabled |
+| `ContextVariantBuilder` | Auto — dynamically builds a Style from context | Dynamic: computed styles based on context |
+
+## Priority Order
+
+During `mergeActiveVariants()`, active variants are resolved and widget-state variants are applied last:
+
+1. Resolve active `ContextVariant` and `NamedVariant` entries.
+2. Sort matching entries so `WidgetStateVariant` entries run last.
+3. Run `StyleVariation` values when their `variantType` is active; their results skip recursive variant resolution.
+
+## Built-in Variant Methods
+
+### VariantStyleMixin (context/platform/breakpoint)
+
+Available on all Stylers via `VariantStyleMixin`:
+
+| Method | Variant Type | Triggers When |
+|--------|-------------|---------------|
+| `onDark(style)` | ContextVariant | `Brightness.dark` |
+| `onLight(style)` | ContextVariant | `Brightness.light` |
+| `onPortrait(style)` | ContextVariant | Portrait orientation |
+| `onLandscape(style)` | ContextVariant | Landscape orientation |
+| `onMobile(style)` | ContextVariant | Mobile breakpoint |
+| `onTablet(style)` | ContextVariant | Tablet breakpoint |
+| `onDesktop(style)` | ContextVariant | Desktop breakpoint |
+| `onBreakpoint(bp, style)` | ContextVariant | Custom breakpoint |
+| `onLtr(style)` | ContextVariant | Left-to-right direction |
+| `onRtl(style)` | ContextVariant | Right-to-left direction |
+| `onIos(style)` | ContextVariant | iOS platform |
+| `onAndroid(style)` | ContextVariant | Android platform |
+| `onMacos(style)` | ContextVariant | macOS platform |
+| `onWindows(style)` | ContextVariant | Windows platform |
+| `onLinux(style)` | ContextVariant | Linux platform |
+| `onFuchsia(style)` | ContextVariant | Fuchsia platform |
+| `onWeb(style)` | ContextVariant | Web platform |
+| `onNot(variant, style)` | ContextVariant | Negation of any ContextVariant |
+| `onBuilder(fn)` | ContextVariantBuilder | Dynamic style from BuildContext |
+
+### WidgetStateVariantMixin (interaction states)
+
+Available on all Stylers via `WidgetStateVariantMixin`:
+
+| Method | Widget State |
+|--------|-------------|
+| `onHovered(style)` | `WidgetState.hovered` |
+| `onPressed(style)` | `WidgetState.pressed` |
+| `onFocused(style)` | `WidgetState.focused` |
+| `onFocusVisible(style)` | `WidgetState.focused` while Flutter's focus highlight mode is `traditional` (keyboard/directional input) — use it for focus rings that should not appear on touch |
+| `onDisabled(style)` | `WidgetState.disabled` |
+| `onEnabled(style)` | Not disabled |
+
+## Usage Patterns
+
+### Basic Variant
+
+```dart
+final style = BoxStyler()
+    .color(Colors.white)
+    .onDark(BoxStyler().color(Colors.grey.shade900));
+```
+
+### Composing Variants
+
+```dart
+final style = BoxStyler()
+    .color(Colors.white)
+    .paddingAll(16)
+    .onDark(BoxStyler().color(Colors.black))
+    .onHovered(BoxStyler().color(Colors.blue.shade100))
+    .onPressed(BoxStyler().color(Colors.blue.shade300));
+```
+
+### Named Variants
+
+```dart
+// Define
+const primary = NamedVariant('primary');
+const small = NamedVariant('small');
+
+// Apply in style
+final style = BoxStyler()
+    .paddingAll(16)
+    .variant(primary, BoxStyler().color(Colors.blue))
+    .variant(small, BoxStyler().paddingAll(8));
+
+// Resolve with named variants where a BuildContext is available
+final spec = style.build(context, namedVariants: {primary, small}).spec;
+```
+
+### Programmatic Variant Application
+
+```dart
+final style = BoxStyler()
+    .paddingAll(16)
+    .variant(primary, BoxStyler().color(Colors.blue));
+
+// Apply named variants to a style
+final resolved = style.applyVariants([primary]);
+```
+
+### Dynamic Context Builder
+
+```dart
+final style = BoxStyler()
+    .onBuilder((context) {
+      final size = MediaQuery.sizeOf(context);
+      return BoxStyler().width(size.width * 0.5);
+    });
+```
+
+## Pre-defined Named Variants
+
+```dart
+const primary   = NamedVariant('primary');
+const secondary = NamedVariant('secondary');
+const outlined  = NamedVariant('outlined');
+const solid     = NamedVariant('solid');
+const danger    = NamedVariant('danger');
+const small     = NamedVariant('small');
+const large     = NamedVariant('large');
+```
+
+## ContextVariant Factory Methods
+
+Create custom context variants:
+
+```dart
+ContextVariant.brightness(Brightness.dark)
+ContextVariant.orientation(Orientation.portrait)
+ContextVariant.platform(TargetPlatform.iOS)
+ContextVariant.directionality(TextDirection.rtl)
+ContextVariant.breakpoint(myBreakpoint)
+ContextVariant.web()
+ContextVariant.mobile()
+ContextVariant.tablet()
+ContextVariant.desktop()
+ContextVariant.not(existingVariant)   // Negation
+ContextVariant.size('compact', (size) => size.width < 600)
+```
+
+## StyleVariation
+
+Interface for design system components that adapt styling based on active variants:
+
+```dart
+abstract class StyleVariation<S extends Spec<S>> {
+  NamedVariant get variantType;
+  Style<S> styleBuilder(
+    covariant Style<S> style,
+    Set<NamedVariant> activeVariants,
+    BuildContext context,
+  );
+}
+```
+
+StyleVariation results skip recursive variant resolution to prevent infinite recursion.

--- a/.agents/skills/mix/references/widget-modifiers-directives.md
+++ b/.agents/skills/mix/references/widget-modifiers-directives.md
@@ -1,0 +1,181 @@
+# Widget Modifiers & Directives
+
+## Table of Contents
+
+- [Widget modifiers](#widget-modifiers)
+- [Modifier usage](#usage)
+- [Built-in modifiers](#built-in-modifiers)
+- [Authoring modifiers](#authoring-modifiers)
+- [Modifier ordering](#modifier-ordering)
+- [Fluent chaining](#fluent-chaining)
+- [Directives](#directives)
+
+## Widget Modifiers
+
+Modifiers wrap a widget with another widget (`Transform`, `Padding`, `Opacity`, etc.) without changing the styled widget API. Apply them with `.wrap()` on a Styler, or use convenience methods such as `BoxStyler().rotate(...)` when the Styler exposes them.
+
+### Usage
+
+```dart
+final style = BoxStyler()
+    .color(Colors.blue)
+    .wrap(WidgetModifierConfig.opacity(0.5))
+    .wrap(WidgetModifierConfig.rotate(radians: 0.1));
+```
+
+### Built-in Modifiers
+
+**File:** `packages/mix/lib/src/modifiers/widget_modifier_config.dart`
+
+| Factory Method | Modifier | Effect |
+|---------------|----------|--------|
+| `.opacity(value)` | `OpacityModifier` | Widget opacity |
+| `.blur(sigma)` | `BlurModifier` | Gaussian blur |
+| `.aspectRatio(ratio)` | `AspectRatioModifier` | Aspect ratio constraint |
+| `.clipOval()` | `ClipOvalModifier` | Oval clip |
+| `.clipRect()` | `ClipRectModifier` | Rectangular clip |
+| `.clipRRect(borderRadius: value)` | `ClipRRectModifier` | Rounded rectangle clip |
+| `.clipPath(clipper: value)` | `ClipPathModifier` | Custom path clip |
+| `.clipTriangle()` | `ClipTriangleModifier` | Triangle clip |
+| `.transform(transform: matrix)` | `TransformModifier` | Matrix4 transform |
+| `.scale(x: value, y: value)` | `ScaleModifier` | Scale using transform |
+| `.rotate(radians: angle)` | `RotateModifier` | Rotation |
+| `.translate(x: x, y: y)` | `TranslateModifier` | Translation |
+| `.skew(skewX: x, skewY: y)` | `SkewModifier` | Skew |
+| `.shaderMask(...)` | `ShaderMaskModifier` | Shader mask |
+| `.visibility(visible)` | `VisibilityModifier` | Show/hide |
+| `.align(alignment: value)` | `AlignModifier` | Alignment |
+| `.padding(insets)` | `PaddingModifier` | Extra padding |
+| `.sizedBox(width: value, height: value)` | `SizedBoxModifier` | Fixed size box |
+| `.flexible(flex: value, fit: value)` | `FlexibleModifier` | Flex layout |
+| `.rotatedBox(quarterTurns)` | `RotatedBoxModifier` | 90-degree rotations |
+| `.intrinsicHeight()` / `.intrinsicWidth()` | `IntrinsicModifier` | Intrinsic sizing |
+| `.fractionallySizedBox(...)` | `FractionallySizedBoxModifier` | Fractional sizing |
+| `.defaultTextStyle(...)` | `DefaultTextStyleModifier` | Default Flutter text style |
+| `.defaultTextStyler(style)` | `DefaultTextStylerModifier` | Inherited Mix text style |
+| `.iconTheme(...)` | `IconThemeModifier` | Icon theme |
+
+### Authoring Modifiers
+
+Use `@MixableModifier()` from `mix_annotations` for new generated modifier APIs. Annotate the modifier class, include the generated `part`, and mix in `_$NameModifier`; the generator emits the `WidgetModifier` contract methods plus the matching `NameModifierMix`.
+
+```dart
+part 'opacity_modifier.g.dart';
+
+@MixableModifier()
+final class OpacityModifier with _$OpacityModifier {
+  @override
+  final double opacity;
+
+  const OpacityModifier([double? opacity]) : opacity = opacity ?? 1.0;
+
+  @override
+  Widget build(Widget child) => Opacity(opacity: opacity, child: child);
+}
+```
+
+Set `@MixableModifier(lerp: false)` when the modifier needs a custom `lerp()` implementation.
+
+### Modifier Ordering
+
+`WidgetModifierConfig` resolves modifiers in an outermost-to-innermost order. `RenderModifiers` reverses that list while building wrappers so the first configured type becomes the outside wrapper.
+
+1. Context and behavior: `Flexible`, `Visibility`, `IconTheme`, `DefaultTextStyle`, `DefaultTextStyler`
+2. Size establishment: `SizedBox`, `FractionallySizedBox`, `Intrinsic`, `AspectRatio`
+3. Layout: `RotatedBox`, `Align`
+4. Spacing: `Padding`
+5. Visual effects: `Transform`/`Scale`/`Rotate`/`Translate`/`Skew`, clip modifiers, `Blur`/`Opacity`, `ShaderMask`
+
+Set custom style-local ordering with `WidgetModifierConfig.orderOfModifiers([...])`:
+
+```dart
+final style = BoxStyler().wrap(
+  WidgetModifierConfig.orderOfModifiers([OpacityModifier, PaddingModifier])
+      .opacity(0.8)
+      .padding(EdgeInsetsGeometryMix.all(16)),
+);
+```
+
+`MixScope(orderOfModifiers: ...)` stores an inherited default for callers that explicitly read it, but modifier rendering uses the order in the resolved `WidgetModifierConfig`.
+
+### Fluent Chaining
+
+`WidgetModifierConfig` also supports fluent chaining:
+
+```dart
+final modifier = WidgetModifierConfig.opacity(0.8)
+    .padding(EdgeInsetsGeometryMix.all(16))
+    .rotate(radians: 0.1);
+```
+
+## Directives
+
+Directives transform resolved values. Text directives are stored on `TextSpec.textDirectives`; Prop-based number and color directives are stored in `Prop.$directives`.
+
+### TextStyler Directives
+
+Applied to the `String` rendered by `StyledText`:
+
+| Method | Effect |
+|--------|--------|
+| `.uppercase()` | HELLO WORLD |
+| `.lowercase()` | hello world |
+| `.capitalize()` | Hello world |
+| `.titlecase()` | Hello World |
+| `.sentencecase()` | Hello world (first letter) |
+
+```dart
+final style = TextStyler().uppercase();
+
+StyledText('hello world', style: style);
+// or
+TextStyler().uppercase()('hello world');
+```
+
+### Prop Number Directives
+
+Applied to `Prop<T extends num>` and returned as `Prop<num>`:
+
+| Method | Effect |
+|--------|--------|
+| `.multiply(factor)` | `value * factor` |
+| `.add(amount)` | `value + amount` |
+| `.subtract(amount)` | `value - amount` |
+| `.divide(divisor)` | `value / divisor` |
+| `.clamp(min, max)` | Clamp to range |
+| `.abs()` | Absolute value |
+| `.round()` | Round to nearest int |
+| `.floor()` | Floor |
+| `.ceil()` | Ceiling |
+| `.scale(factor)` | Alias for multiply |
+
+```dart
+final value = Prop.value(10.0).multiply(2).add(4);
+```
+
+### Color Token Directives
+
+`ColorRef` exposes channel methods that return a color token reference with directives attached:
+
+| Method | Effect |
+|--------|--------|
+| `.withValues(alpha:, red:, green:, blue:, colorSpace:)` | Override multiple channels |
+| `.withAlpha(value)` | Override alpha channel |
+| `.withRed(value)` / `.withGreen(value)` / `.withBlue(value)` | Override one RGB channel |
+| `.withOpacity(value)` | Set alpha from opacity |
+
+```dart
+final $primary = ColorToken('primary');
+final style = BoxStyler().color($primary().withOpacity(0.7));
+```
+
+### How Directives Work
+
+Prop directives are applied after value resolution:
+
+```dart
+// During resolution:
+// value -> resolve sources -> apply Prop directives -> return
+```
+
+Text directives are applied by `StyledText` to the resolved string. Directives from merged Props or Stylers are combined and applied in order.

--- a/.claude/skills/mix
+++ b/.claude/skills/mix
@@ -1,0 +1,1 @@
+../../.agents/skills/mix

--- a/.gitignore
+++ b/.gitignore
@@ -101,9 +101,15 @@ pubspec.lock
 # Do not remove or rename entries in this file, only add new ones
 # See https://github.com/flutter/flutter/issues/128635 for more context.
 
-# Agent skills are distributed from /skills. Local installations stay untracked.
-/.agents/
-/.claude/skills
+# Agent skills published by Remix live in /skills. Keep local installs ignored
+# except for the vendored Mix skill shared by Codex and Claude Code.
+/.agents/*
+!/.agents/skills/
+/.agents/skills/*
+!/.agents/skills/mix/
+!/.agents/skills/mix/**
+/.claude/skills/*
+!/.claude/skills/mix
 
 # Miscellaneous
 *.class

--- a/README.md
+++ b/README.md
@@ -45,6 +45,22 @@ npx skills ls
 npx skills update
 ```
 
+### Vendored Mix skill
+
+This repository commits the project-scoped Mix skill and its lockfile so Codex
+and Claude Code use the same reviewed instructions. Install or refresh the
+canonical copy and Claude symlink with:
+
+```bash
+npx skills add conceptadev/mix --skill mix --agent codex --agent claude-code -y
+```
+
+Update the committed installation from its locked project source with:
+
+```bash
+npx skills update mix --project -y
+```
+
 ## Why Remix?
 
 ### The Problem

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "skills": {
+    "mix": {
+      "source": "conceptadev/mix",
+      "sourceType": "github",
+      "skillPath": "skills/mix/SKILL.md",
+      "computedHash": "0bcc745ff3debef56b906016a251c6ef73ddbdb7bdbffb58711f613e78849e23"
+    }
+  }
+}


### PR DESCRIPTION
## Description

Vendor the upstream Mix agent skill as a project-scoped dependency for Codex and Claude Code. The canonical skill tree lives in `.agents/skills/mix`, Claude uses a relative symlink, and `skills-lock.json` records the `conceptadev/mix` source plus its content hash.

The narrow ignore exceptions keep other local skill installations untracked. The README documents the explicit install command and the project-scoped update command so future refreshes remain reproducible. Remix's public skill discovery continues to expose only `using-remix` and `building-remix-design-system`.

## Related Issues

No related issue.

---

## Validation

- `quick_validate.py .agents/skills/mix` — passed.
- `npx skills update mix --project -y` in a fresh clone — passed and produced no Git diff.
- `npx skills add . --list` — discovered exactly the two Remix-owned public skills.
- Verified `.claude/skills/mix` remains a relative symlink to `.agents/skills/mix` after a fresh checkout.

## Checklist

**Note**: Updating the `pubspec.yaml` and `CHANGELOG.md` is not required. These are handled automatically during the release process.

- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors.
- [x] I have updated or added relevant documentation (doc comments with `///`).
- [x] I am prepared to follow up on review comments in a timely manner.

## Breaking Change

Does this PR require users of the package to manually update their code?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.
