### PR TITLE
fix(remix): forward toggle excludeSemantics

### DIFF
--- a/packages/remix/lib/src/components/toggle/toggle_style.dart
+++ b/packages/remix/lib/src/components/toggle/toggle_style.dart
@@ -28,6 +28,7 @@ extension RemixToggleStylerRemixHelpers on ToggleStyler {
     FocusNode? focusNode,
     bool autofocus = false,
     String? semanticLabel,
+    bool excludeSemantics = false,
     MouseCursor mouseCursor = SystemMouseCursors.click,
   }) {
     return RemixToggle(
@@ -41,6 +42,7 @@ extension RemixToggleStylerRemixHelpers on ToggleStyler {
       focusNode: focusNode,
       autofocus: autofocus,
       semanticLabel: semanticLabel,
+      excludeSemantics: excludeSemantics,
       mouseCursor: mouseCursor,
       style: this,
     );

--- a/packages/remix/lib/src/components/toggle/toggle_widget.dart
+++ b/packages/remix/lib/src/components/toggle/toggle_widget.dart
@@ -33,6 +33,7 @@ class RemixToggle extends StatelessWidget {
     this.focusNode,
     this.autofocus = false,
     this.semanticLabel,
+    this.excludeSemantics = false,
     this.mouseCursor = SystemMouseCursors.click,
     this.style = const ToggleStyler.create(),
     this.styleSpec,
@@ -79,6 +80,12 @@ class RemixToggle extends StatelessWidget {
   /// The semantic label for the toggle.
   final String? semanticLabel;
 
+  /// Whether to exclude this toggle's semantics.
+  ///
+  /// Use this when an ancestor supplies a different semantics contract, such
+  /// as selected destination semantics instead of toggled on/off semantics.
+  final bool excludeSemantics;
+
   /// Cursor when hovering over the toggle.
   final MouseCursor mouseCursor;
 
@@ -95,6 +102,7 @@ class RemixToggle extends StatelessWidget {
       focusNode: focusNode,
       autofocus: autofocus,
       semanticLabel: semanticLabel,
+      excludeSemantics: excludeSemantics,
       builder: (context, state, _) {
         return RemixStyleSpecBuilder<ToggleSpec>(
           style: style,

--- a/packages/remix/test/components/toggle/toggle_style_test.dart
+++ b/packages/remix/test/components/toggle/toggle_style_test.dart
@@ -322,6 +322,7 @@ void main() {
           focusNode: focusNode,
           autofocus: true,
           semanticLabel: 'Test Toggle',
+          excludeSemantics: true,
           mouseCursor: SystemMouseCursors.forbidden,
         );
 
@@ -334,6 +335,7 @@ void main() {
         expect(toggle.focusNode, equals(focusNode));
         expect(toggle.autofocus, isTrue);
         expect(toggle.semanticLabel, equals('Test Toggle'));
+        expect(toggle.excludeSemantics, isTrue);
         expect(toggle.mouseCursor, equals(SystemMouseCursors.forbidden));
 
         focusNode.dispose();

--- a/packages/remix/test/components/toggle/toggle_widget_test.dart
+++ b/packages/remix/test/components/toggle/toggle_widget_test.dart
@@ -270,6 +270,48 @@ void main() {
         final toggle = tester.widget<RemixToggle>(find.byType(RemixToggle));
         expect(toggle.semanticLabel, equals('Toggle bold formatting'));
       });
+
+      testWidgets('excludeSemantics allows replacement destination semantics', (
+        tester,
+      ) async {
+        final semantics = tester.ensureSemantics();
+
+        await tester.pumpRemixApp(
+          Semantics(
+            button: true,
+            selected: true,
+            label: 'Overview',
+            onTap: () {},
+            child: RemixToggle(
+              selected: true,
+              onChanged: (value) {},
+              label: 'Overview',
+              excludeSemantics: true,
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final nakedToggle = tester.widget<NakedToggle>(
+          find.byType(NakedToggle),
+        );
+        final destination = find.semantics.byLabel('Overview');
+
+        expect(nakedToggle.excludeSemantics, isTrue);
+        expect(destination, findsOne);
+        expect(
+          destination.evaluate().single,
+          isSemantics(
+            label: 'Overview',
+            isButton: true,
+            isSelected: true,
+            hasSelectedState: true,
+            hasToggledState: false,
+            hasTapAction: true,
+          ),
+        );
+        semantics.dispose();
+      });
     });
 
     group('Layout and Sizing', () {

--- a/packages/remix_fortal/lib/src/recipes/toggle.g.dart
+++ b/packages/remix_fortal/lib/src/recipes/toggle.g.dart
@@ -22,6 +22,7 @@ class FortalToggle extends StatelessWidget {
     this.focusNode,
     this.autofocus = false,
     this.semanticLabel,
+    this.excludeSemantics = false,
     this.mouseCursor = SystemMouseCursors.click,
   });
 
@@ -38,6 +39,7 @@ class FortalToggle extends StatelessWidget {
     this.focusNode,
     this.autofocus = false,
     this.semanticLabel,
+    this.excludeSemantics = false,
     this.mouseCursor = SystemMouseCursors.click,
   }) : variant = FortalToggleVariant.ghost;
 
@@ -54,6 +56,7 @@ class FortalToggle extends StatelessWidget {
     this.focusNode,
     this.autofocus = false,
     this.semanticLabel,
+    this.excludeSemantics = false,
     this.mouseCursor = SystemMouseCursors.click,
   }) : variant = FortalToggleVariant.outline;
 
@@ -81,6 +84,8 @@ class FortalToggle extends StatelessWidget {
 
   final String? semanticLabel;
 
+  final bool excludeSemantics;
+
   final MouseCursor mouseCursor;
 
   @override
@@ -101,6 +106,7 @@ class FortalToggle extends StatelessWidget {
       focusNode: this.focusNode,
       autofocus: this.autofocus,
       semanticLabel: this.semanticLabel,
+      excludeSemantics: this.excludeSemantics,
       mouseCursor: this.mouseCursor,
     );
   }


### PR DESCRIPTION
## Description

`RemixToggle` now exposes `excludeSemantics` and forwards it to `NakedToggle`. Previously, consumers could not suppress the built-in toggled on/off contract, which prevented navigation destinations from supplying selected semantics and could produce duplicate accessible names.

The new parameter defaults to `false`, preserving existing behavior. `ToggleStyler.call` exposes the same option, and regression coverage verifies that an ancestor can provide a single selected destination node without a toggled state.

## Validation

- `fvm flutter test test/components/toggle` — passed (69 tests)
- `fvm flutter analyze` — passed

## Related Issues

Closes #119

---

## Checklist

- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors.
- [x] I have updated or added relevant documentation (doc comments with `///`).
- [x] I am prepared to follow up on review comments in a timely manner.

## Breaking Change

Does this PR require users of the package to manually update their code?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.
