### PR TITLE
fix(remix): make checkbox styles value-comparable

### DIFF
--- a/packages/remix/lib/src/components/checkbox/checkbox_style.dart
+++ b/packages/remix/lib/src/components/checkbox/checkbox_style.dart
@@ -1,5 +1,10 @@
 part of 'checkbox.dart';
 
+final _onIndeterminateVariant = ContextVariant(
+  'on_indeterminate',
+  (context) => NakedCheckboxState.maybeOf(context)?.isChecked == null,
+);
+
 /// Style configuration for [RemixCheckbox] container and indicator icon.
 extension RemixCheckboxStylerRemixHelpers on CheckboxStyler {
   /// Sets indicator color.
@@ -8,13 +13,7 @@ extension RemixCheckboxStylerRemixHelpers on CheckboxStyler {
   }
 
   CheckboxStyler onIndeterminate(CheckboxStyler value) {
-    return variant(
-      ContextVariant(
-        'on_indeterminate',
-        (context) => NakedCheckboxState.maybeOf(context)?.isChecked == null,
-      ),
-      value,
-    );
+    return variant(_onIndeterminateVariant, value);
   }
 
   /// Sets checkbox fill color on the container.

--- a/packages/remix_fortal/test/components/checkbox/checkbox_style_test.dart
+++ b/packages/remix_fortal/test/components/checkbox/checkbox_style_test.dart
@@ -1,0 +1,12 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:remix_fortal/remix_fortal.dart';
+
+void main() {
+  test('same arguments produce equal styles', () {
+    final first = fortalCheckboxStyle();
+    final second = fortalCheckboxStyle();
+
+    expect(first, equals(second));
+    expect(first.hashCode, equals(second.hashCode));
+  });
+}


### PR DESCRIPTION
## Description

`CheckboxStyler.onIndeterminate` allocated a new identity-based
`ContextVariant` on every call, causing equivalent `fortalCheckboxStyle()`
results to compare unequal.

Reuse one shared indeterminate variant while preserving its predicate and
resolved styling behavior. Add regression coverage for equality and matching
hash codes.

## Related Issues

Closes #121

## Validation

- `fvm dart analyze`
- `fvm dart run melos run ci`
  - Generated artifacts reproduced byte-for-byte.
  - Documentation and Fortal parity checks passed.
  - 2,553 Remix, 275 Fortal, and 25 dashboard tests passed.

---

## Checklist

- [x] My PR includes unit or integration tests for all changed behavior.
- [x] Existing documentation remains accurate; no documentation changes are required.
- [x] I am prepared to follow up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is not a breaking change.
