### PR TITLE
fix(remix): respect input modality for focus rings

### DIFF
--- a/apps/dashboard/lib/widgets/theme_panel.dart
+++ b/apps/dashboard/lib/widgets/theme_panel.dart
@@ -212,7 +212,7 @@ class _AccentSwatch extends StatelessWidget {
                 .iconColor(FortalTokens.accentContrast())
                 .merge(_ring),
           )
-          .onFocused(_ring);
+          .onFocusVisible(_ring);
 
   final FortalAccentColor accent;
   final bool selected;

--- a/docs/components/segmented_control.mdx
+++ b/docs/components/segmented_control.mdx
@@ -94,7 +94,7 @@ class _ReportingPeriodControlState extends State<ReportingPeriodControl> {
                 ),
               ),
         )
-        .onFocused(
+        .onFocusVisible(
           .containerEffects(
             RemixBoxEffectsMix(
               outline: BorderSideMix(

--- a/packages/remix/lib/remix.dart
+++ b/packages/remix/lib/remix.dart
@@ -59,7 +59,11 @@ export 'src/rendering/remix_box_effects.dart'
 
 /// STYLER CONVENIENCES
 export 'src/utilities/remix_style.dart'
-    show RemixBoxStylerAnchors, RemixBoxStylerMixin, RemixBoxStylerConvenience;
+    show
+        FocusVisibleWidgetStateVariantExtension,
+        RemixBoxStylerAnchors,
+        RemixBoxStylerMixin,
+        RemixBoxStylerConvenience;
 export 'src/utilities/selected_mixin.dart'
     show SelectedWidgetStateVariantExtension;
 

--- a/packages/remix/lib/remix.dart
+++ b/packages/remix/lib/remix.dart
@@ -59,11 +59,7 @@ export 'src/rendering/remix_box_effects.dart'
 
 /// STYLER CONVENIENCES
 export 'src/utilities/remix_style.dart'
-    show
-        FocusVisibleWidgetStateVariantExtension,
-        RemixBoxStylerAnchors,
-        RemixBoxStylerMixin,
-        RemixBoxStylerConvenience;
+    show RemixBoxStylerAnchors, RemixBoxStylerMixin, RemixBoxStylerConvenience;
 export 'src/utilities/selected_mixin.dart'
     show SelectedWidgetStateVariantExtension;
 

--- a/packages/remix/lib/src/components/segmented_control/segmented_control_widget.dart
+++ b/packages/remix/lib/src/components/segmented_control/segmented_control_widget.dart
@@ -201,6 +201,7 @@ class RemixSegmentedControl<T extends Object> extends StatelessWidget {
         child: RemixStyleSpecBuilder<SegmentedControlSpec>(
           style: style,
           styleSpec: styleSpec,
+          trackFocusHighlightMode: true,
           builder: (context, spec) {
             final textDirection = Directionality.of(context);
             return StyleSpecBuilder<BoxSpec>(

--- a/packages/remix/lib/src/components/slider/slider_spec.dart
+++ b/packages/remix/lib/src/components/slider/slider_spec.dart
@@ -59,7 +59,8 @@ class SliderSpec with _$SliderSpec {
   @MixableField(setterType: RemixBoxEffectsMix)
   final RemixBoxEffectsSpec? thumbEffects;
 
-  /// Additional overlay painted only on the focused thumb.
+  /// Additional overlay painted only when the focused thumb should show a
+  /// focus highlight for the current input modality.
   @override
   @MixableField(setterType: RemixBoxEffectsMix)
   final RemixBoxEffectsSpec? thumbFocusEffects;

--- a/packages/remix/lib/src/components/slider/slider_widget.dart
+++ b/packages/remix/lib/src/components/slider/slider_widget.dart
@@ -125,6 +125,10 @@ class RemixSlider extends StatelessWidget {
             final trackThickness = spec.trackThickness > 0
                 ? spec.trackThickness
                 : SliderSpec.defaultTrackStrokeWidth;
+            final shouldShowThumbFocusEffect =
+                state.focusedThumbIndex == 0 &&
+                RemixFocusHighlightModeProvider.of(context) ==
+                    FocusHighlightMode.traditional;
 
             // Slider height accommodates both thumb and track:
             // - thumb.height + trackThickness: ensures thumb has clearance above/below
@@ -230,10 +234,7 @@ class RemixSlider extends StatelessWidget {
                           containerEffects:
                               (spec.thumbEffects ?? const RemixBoxEffectsSpec())
                                   .merge(
-                                    state.focusedThumbIndex == 0 &&
-                                            remixShouldShowFocusHighlight(
-                                              context,
-                                            )
+                                    shouldShowThumbFocusEffect
                                         ? spec.thumbFocusEffects
                                         : null,
                                   ),

--- a/packages/remix/lib/src/components/slider/slider_widget.dart
+++ b/packages/remix/lib/src/components/slider/slider_widget.dart
@@ -118,6 +118,7 @@ class RemixSlider extends StatelessWidget {
           style: style,
           styleSpec: styleSpec,
           controller: NakedSliderState.controllerOf(context),
+          trackFocusHighlightMode: true,
           builder: (context, spec) {
             final thumbSpec = spec.thumb;
             final thumbSize = _resolveThumbSize(context, thumbSpec);

--- a/packages/remix/lib/src/components/slider/slider_widget.dart
+++ b/packages/remix/lib/src/components/slider/slider_widget.dart
@@ -229,7 +229,10 @@ class RemixSlider extends StatelessWidget {
                           containerEffects:
                               (spec.thumbEffects ?? const RemixBoxEffectsSpec())
                                   .merge(
-                                    state.focusedThumbIndex == 0
+                                    state.focusedThumbIndex == 0 &&
+                                            remixShouldShowFocusHighlight(
+                                              context,
+                                            )
                                         ? spec.thumbFocusEffects
                                         : null,
                                   ),

--- a/packages/remix/lib/src/components/toggle_group/toggle_group_widget.dart
+++ b/packages/remix/lib/src/components/toggle_group/toggle_group_widget.dart
@@ -203,6 +203,7 @@ class RemixToggleGroup<T> extends StatelessWidget {
       child: RemixStyleSpecBuilder<ToggleGroupSpec>(
         style: effectiveStyle,
         styleSpec: styleSpec,
+        trackFocusHighlightMode: true,
         builder: (context, spec) {
           return FlexBox(
             styleSpec: _withOrientation(spec.container),

--- a/packages/remix/lib/src/utilities/remix_style.dart
+++ b/packages/remix/lib/src/utilities/remix_style.dart
@@ -2,16 +2,6 @@ import 'package:flutter/foundation.dart' show internal;
 import 'package:flutter/material.dart';
 import 'package:mix/mix.dart' hide AnimationConfig;
 
-/// Whether Flutter currently allows a focus highlight to be painted.
-///
-/// This is internal Remix infrastructure shared by visuals, such as slider
-/// thumbs, that do not resolve their focus treatment through a Mix variant.
-@internal
-bool remixShouldShowFocusHighlight(BuildContext context) {
-  return _RemixFocusHighlightModeProvider.of(context) ==
-      FocusHighlightMode.traditional;
-}
-
 /// Applies resolved Remix text and icon specs as inherited defaults for
 /// arbitrary component content.
 ///
@@ -94,7 +84,7 @@ class RemixStyleSpecBuilder<S extends Spec<S>> extends StatelessWidget {
   /// Mix-managed controller scopes already make [FocusVisibleVariant]
   /// reactive. Set this for composite widgets that publish focus through a
   /// manual [WidgetStateProvider], or for visuals that read
-  /// [remixShouldShowFocusHighlight] directly.
+  /// [RemixFocusHighlightModeProvider.of] directly.
   final bool trackFocusHighlightMode;
 
   /// Builds the widget with the resolved or supplied spec.
@@ -106,7 +96,7 @@ class RemixStyleSpecBuilder<S extends Spec<S>> extends StatelessWidget {
       // resolved beneath manually mounted WidgetStateProvider instances, where
       // Mix's focus-visible variant otherwise observes modality on the next
       // unrelated rebuild.
-      remixShouldShowFocusHighlight(context);
+      RemixFocusHighlightModeProvider.of(context);
     }
     return builder(context, spec);
   }
@@ -129,17 +119,20 @@ class RemixStyleSpecBuilder<S extends Spec<S>> extends StatelessWidget {
     }
 
     if (!trackFocusHighlightMode ||
-        _RemixFocusHighlightModeProvider.hasScope(context)) {
+        RemixFocusHighlightModeProvider._hasScope(context)) {
       return result;
     }
 
-    return _RemixFocusHighlightModeProvider(child: result);
+    return RemixFocusHighlightModeProvider._(child: result);
   }
 }
 
-class _RemixFocusHighlightModeProvider extends StatefulWidget {
-  const _RemixFocusHighlightModeProvider({required this.child});
+/// Provides reactive access to Flutter's current focus-highlight mode.
+@internal
+final class RemixFocusHighlightModeProvider extends StatefulWidget {
+  const RemixFocusHighlightModeProvider._({required this.child});
 
+  /// Returns the current mode and subscribes to changes when a scope exists.
   static FocusHighlightMode of(BuildContext context) {
     return context
             .dependOnInheritedWidgetOfExactType<_RemixFocusHighlightModeScope>()
@@ -147,7 +140,7 @@ class _RemixFocusHighlightModeProvider extends StatefulWidget {
         FocusManager.instance.highlightMode;
   }
 
-  static bool hasScope(BuildContext context) {
+  static bool _hasScope(BuildContext context) {
     return context
             .getInheritedWidgetOfExactType<_RemixFocusHighlightModeScope>() !=
         null;
@@ -156,12 +149,12 @@ class _RemixFocusHighlightModeProvider extends StatefulWidget {
   final Widget child;
 
   @override
-  State<_RemixFocusHighlightModeProvider> createState() =>
+  State<RemixFocusHighlightModeProvider> createState() =>
       _RemixFocusHighlightModeProviderState();
 }
 
 class _RemixFocusHighlightModeProviderState
-    extends State<_RemixFocusHighlightModeProvider> {
+    extends State<RemixFocusHighlightModeProvider> {
   late FocusHighlightMode _mode;
 
   @override

--- a/packages/remix/lib/src/utilities/remix_style.dart
+++ b/packages/remix/lib/src/utilities/remix_style.dart
@@ -2,33 +2,6 @@ import 'package:flutter/foundation.dart' show internal;
 import 'package:flutter/material.dart';
 import 'package:mix/mix.dart' hide AnimationConfig;
 
-final _focusVisibleVariant = ContextVariant('focus_visible', (context) {
-  final override = WidgetStateStyleOverride.maybeOf(context);
-  if (override != null) {
-    return override.states.contains(WidgetState.focused);
-  }
-
-  return WidgetStateProvider.hasStateOf(context, WidgetState.focused) &&
-      remixShouldShowFocusHighlight(context);
-});
-
-/// Adds a focus-visible variant to generated Remix stylers.
-///
-/// Unlike [WidgetState.focused], this variant applies only while Flutter is in
-/// [FocusHighlightMode.traditional]. This matches CSS `:focus-visible` for
-/// focus indicators that should follow keyboard or directional navigation.
-extension FocusVisibleWidgetStateVariantExtension<
-  T extends Style<S>,
-  S extends Spec<S>
->
-    on MixStyler<T, S> {
-  /// Applies [style] while the widget is focused and focus highlights are
-  /// visible for the current input modality.
-  T onFocusVisible(T style) {
-    return variant(_focusVisibleVariant, style);
-  }
-}
-
 /// Whether Flutter currently allows a focus highlight to be painted.
 ///
 /// This is internal Remix infrastructure shared by visuals, such as slider
@@ -116,14 +89,27 @@ class RemixStyleSpecBuilder<S extends Spec<S>> extends StatelessWidget {
   /// Optional widget state controller for fluent style resolution.
   final WidgetStatesController? controller;
 
-  /// Whether descendants resolve focus visuals from manually provided states.
+  /// Whether [builder] should rebuild when the focus highlight mode changes.
   ///
-  /// Controllers enable this automatically. Set it for composite widgets that
-  /// publish each item's focus through their own [WidgetStateProvider].
+  /// Mix-managed controller scopes already make [FocusVisibleVariant]
+  /// reactive. Set this for composite widgets that publish focus through a
+  /// manual [WidgetStateProvider], or for visuals that read
+  /// [remixShouldShowFocusHighlight] directly.
   final bool trackFocusHighlightMode;
 
   /// Builds the widget with the resolved or supplied spec.
   final Widget Function(BuildContext context, S spec) builder;
+
+  Widget _buildTracked(BuildContext context, S spec) {
+    if (trackFocusHighlightMode) {
+      // Register a dependency on the Remix scope. This also rebuilds styles
+      // resolved beneath manually mounted WidgetStateProvider instances, where
+      // Mix's focus-visible variant otherwise observes modality on the next
+      // unrelated rebuild.
+      remixShouldShowFocusHighlight(context);
+    }
+    return builder(context, spec);
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -132,19 +118,17 @@ class RemixStyleSpecBuilder<S extends Spec<S>> extends StatelessWidget {
     if (spec != null) {
       result = StyleSpecBuilder<S>(
         styleSpec: StyleSpec(spec: spec),
-        builder: builder,
+        builder: _buildTracked,
       );
     } else {
       result = StyleBuilder<S>(
         style: style,
         controller: controller,
-        builder: builder,
+        builder: _buildTracked,
       );
     }
 
-    final tracksFocusHighlightMode =
-        controller != null || trackFocusHighlightMode;
-    if (!tracksFocusHighlightMode ||
+    if (!trackFocusHighlightMode ||
         _RemixFocusHighlightModeProvider.hasScope(context)) {
       return result;
     }

--- a/packages/remix/lib/src/utilities/remix_style.dart
+++ b/packages/remix/lib/src/utilities/remix_style.dart
@@ -2,6 +2,43 @@ import 'package:flutter/foundation.dart' show internal;
 import 'package:flutter/material.dart';
 import 'package:mix/mix.dart' hide AnimationConfig;
 
+final _focusVisibleVariant = ContextVariant('focus_visible', (context) {
+  final override = WidgetStateStyleOverride.maybeOf(context);
+  if (override != null) {
+    return override.states.contains(WidgetState.focused);
+  }
+
+  return WidgetStateProvider.hasStateOf(context, WidgetState.focused) &&
+      remixShouldShowFocusHighlight(context);
+});
+
+/// Adds a focus-visible variant to generated Remix stylers.
+///
+/// Unlike [WidgetState.focused], this variant applies only while Flutter is in
+/// [FocusHighlightMode.traditional]. This matches CSS `:focus-visible` for
+/// focus indicators that should follow keyboard or directional navigation.
+extension FocusVisibleWidgetStateVariantExtension<
+  T extends Style<S>,
+  S extends Spec<S>
+>
+    on MixStyler<T, S> {
+  /// Applies [style] while the widget is focused and focus highlights are
+  /// visible for the current input modality.
+  T onFocusVisible(T style) {
+    return variant(_focusVisibleVariant, style);
+  }
+}
+
+/// Whether Flutter currently allows a focus highlight to be painted.
+///
+/// This is internal Remix infrastructure shared by visuals, such as slider
+/// thumbs, that do not resolve their focus treatment through a Mix variant.
+@internal
+bool remixShouldShowFocusHighlight(BuildContext context) {
+  return _RemixFocusHighlightModeProvider.of(context) ==
+      FocusHighlightMode.traditional;
+}
+
 /// Applies resolved Remix text and icon specs as inherited defaults for
 /// arbitrary component content.
 ///
@@ -67,6 +104,7 @@ class RemixStyleSpecBuilder<S extends Spec<S>> extends StatelessWidget {
     required this.styleSpec,
     required this.builder,
     this.controller,
+    this.trackFocusHighlightMode = false,
   });
 
   /// The fluent style to resolve when [styleSpec] is null.
@@ -78,24 +116,106 @@ class RemixStyleSpecBuilder<S extends Spec<S>> extends StatelessWidget {
   /// Optional widget state controller for fluent style resolution.
   final WidgetStatesController? controller;
 
+  /// Whether descendants resolve focus visuals from manually provided states.
+  ///
+  /// Controllers enable this automatically. Set it for composite widgets that
+  /// publish each item's focus through their own [WidgetStateProvider].
+  final bool trackFocusHighlightMode;
+
   /// Builds the widget with the resolved or supplied spec.
   final Widget Function(BuildContext context, S spec) builder;
 
   @override
   Widget build(BuildContext context) {
     final spec = styleSpec;
+    late final Widget result;
     if (spec != null) {
-      return StyleSpecBuilder<S>(
+      result = StyleSpecBuilder<S>(
         styleSpec: StyleSpec(spec: spec),
+        builder: builder,
+      );
+    } else {
+      result = StyleBuilder<S>(
+        style: style,
+        controller: controller,
         builder: builder,
       );
     }
 
-    return StyleBuilder<S>(
-      style: style,
-      controller: controller,
-      builder: builder,
-    );
+    final tracksFocusHighlightMode =
+        controller != null || trackFocusHighlightMode;
+    if (!tracksFocusHighlightMode ||
+        _RemixFocusHighlightModeProvider.hasScope(context)) {
+      return result;
+    }
+
+    return _RemixFocusHighlightModeProvider(child: result);
+  }
+}
+
+class _RemixFocusHighlightModeProvider extends StatefulWidget {
+  const _RemixFocusHighlightModeProvider({required this.child});
+
+  static FocusHighlightMode of(BuildContext context) {
+    return context
+            .dependOnInheritedWidgetOfExactType<_RemixFocusHighlightModeScope>()
+            ?.mode ??
+        FocusManager.instance.highlightMode;
+  }
+
+  static bool hasScope(BuildContext context) {
+    return context
+            .getInheritedWidgetOfExactType<_RemixFocusHighlightModeScope>() !=
+        null;
+  }
+
+  final Widget child;
+
+  @override
+  State<_RemixFocusHighlightModeProvider> createState() =>
+      _RemixFocusHighlightModeProviderState();
+}
+
+class _RemixFocusHighlightModeProviderState
+    extends State<_RemixFocusHighlightModeProvider> {
+  late FocusHighlightMode _mode;
+
+  @override
+  void initState() {
+    super.initState();
+    _mode = FocusManager.instance.highlightMode;
+    FocusManager.instance.addHighlightModeListener(_handleModeChange);
+  }
+
+  void _handleModeChange(FocusHighlightMode mode) {
+    if (!mounted || mode == _mode) return;
+
+    setState(() => _mode = mode);
+  }
+
+  @override
+  void dispose() {
+    FocusManager.instance.removeHighlightModeListener(_handleModeChange);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return _RemixFocusHighlightModeScope(mode: _mode, child: widget.child);
+  }
+}
+
+class _RemixFocusHighlightModeScope extends InheritedWidget {
+  const _RemixFocusHighlightModeScope({
+    required this.mode,
+    required super.child,
+  });
+
+  final FocusHighlightMode mode;
+
+  @override
+  bool updateShouldNotify(_RemixFocusHighlightModeScope oldWidget) {
+    return mode != oldWidget.mode;
   }
 }
 

--- a/packages/remix/pubspec.yaml
+++ b/packages/remix/pubspec.yaml
@@ -25,7 +25,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  mix: ^2.2.0-beta.2
+  mix: ^2.2.0-beta.3
   mix_annotations: ^2.2.0-beta.1
   naked_ui: ^1.0.0-beta.8
 

--- a/packages/remix/test/components/segmented_control/segmented_control_widget_test.dart
+++ b/packages/remix/test/components/segmented_control/segmented_control_widget_test.dart
@@ -1418,6 +1418,55 @@ void main() {
       expect(tester.widget<Text>(find.text('List')).style?.color, Colors.grey);
     });
 
+    testWidgets('focus-visible item style tracks highlight mode', (
+      tester,
+    ) async {
+      final previousStrategy = FocusManager.instance.highlightStrategy;
+      addTearDown(() {
+        FocusManager.instance.highlightStrategy = previousStrategy;
+      });
+      FocusManager.instance.highlightStrategy =
+          FocusHighlightStrategy.alwaysTouch;
+      final node = FocusNode();
+      addTearDown(node.dispose);
+
+      await tester.pumpRemixApp(
+        RemixSegmentedControl<String>(
+          items: [
+            RemixSegmentedControlItem(
+              value: 'list',
+              label: 'List',
+              focusNode: node,
+            ),
+          ],
+          selectedValue: 'list',
+          onChanged: (_) {},
+          style: SegmentedControlStyler(
+            item: SegmentedControlItemStyler()
+                .labelColor(Colors.blue)
+                .onFocusVisible(
+                  SegmentedControlItemStyler().labelColor(Colors.green),
+                ),
+          ),
+        ),
+      );
+
+      node.requestFocus();
+      await tester.pumpAndSettle();
+      expect(node.hasFocus, isTrue);
+      expect(tester.widget<Text>(find.text('List')).style?.color, Colors.blue);
+
+      FocusManager.instance.highlightStrategy =
+          FocusHighlightStrategy.alwaysTraditional;
+      await tester.pump();
+      expect(tester.widget<Text>(find.text('List')).style?.color, Colors.green);
+
+      FocusManager.instance.highlightStrategy =
+          FocusHighlightStrategy.alwaysTouch;
+      await tester.pump();
+      expect(tester.widget<Text>(find.text('List')).style?.color, Colors.blue);
+    });
+
     testWidgets('focus style is removed when the focused item is disabled', (
       tester,
     ) async {

--- a/packages/remix/test/components/slider/slider_widget_test.dart
+++ b/packages/remix/test/components/slider/slider_widget_test.dart
@@ -506,57 +506,64 @@ void main() {
         focusNode.dispose();
       });
 
-      testWidgets('thumb focus effect follows focus highlight mode', (
-        tester,
-      ) async {
-        final previousStrategy = FocusManager.instance.highlightStrategy;
-        addTearDown(() {
-          FocusManager.instance.highlightStrategy = previousStrategy;
-        });
-        FocusManager.instance.highlightStrategy =
-            FocusHighlightStrategy.alwaysTouch;
-        final focusNode = FocusNode();
-        addTearDown(focusNode.dispose);
-
-        await tester.pumpRemixApp(
-          RemixSlider(
-            value: 0.5,
-            onChanged: (value) {},
-            focusNode: focusNode,
-            style: SliderStyler(
-              thumb: BoxStyler().size(20, 20),
-              thumbFocusEffects: RemixBoxEffectsMix(
-                outline: BorderSideMix(
-                  color: Colors.red,
-                  width: 3,
-                  strokeAlign: BorderSide.strokeAlignInside,
-                ),
+      for (final useRawSpec in [false, true]) {
+        final source = useRawSpec ? 'raw styleSpec' : 'fluent style';
+        testWidgets('thumb focus effect from $source follows highlight mode', (
+          tester,
+        ) async {
+          final previousStrategy = FocusManager.instance.highlightStrategy;
+          addTearDown(() {
+            FocusManager.instance.highlightStrategy = previousStrategy;
+          });
+          FocusManager.instance.highlightStrategy =
+              FocusHighlightStrategy.alwaysTouch;
+          final focusNode = FocusNode();
+          addTearDown(focusNode.dispose);
+          final style = SliderStyler(
+            thumb: BoxStyler().size(20, 20),
+            thumbFocusEffects: RemixBoxEffectsMix(
+              outline: BorderSideMix(
+                color: Colors.red,
+                width: 3,
+                strokeAlign: BorderSide.strokeAlignInside,
               ),
             ),
-          ),
-        );
-        await tester.pumpAndSettle();
+          );
 
-        focusNode.requestFocus();
-        await tester.pumpAndSettle();
+          await tester.pumpRemixApp(
+            Builder(
+              builder: (context) => RemixSlider(
+                value: 0.5,
+                onChanged: (value) {},
+                focusNode: focusNode,
+                style: style,
+                styleSpec: useRawSpec ? style.resolve(context).spec : null,
+              ),
+            ),
+          );
+          await tester.pumpAndSettle();
 
-        expect(focusNode.hasFocus, isTrue);
-        expect(_sliderThumb(tester).containerEffects?.outline.width, 0);
+          focusNode.requestFocus();
+          await tester.pumpAndSettle();
 
-        FocusManager.instance.highlightStrategy =
-            FocusHighlightStrategy.alwaysTraditional;
-        await tester.pump();
+          expect(focusNode.hasFocus, isTrue);
+          expect(_sliderThumb(tester).containerEffects?.outline.width, 0);
 
-        expect(focusNode.hasFocus, isTrue);
-        expect(_sliderThumb(tester).containerEffects?.outline.width, 3);
+          FocusManager.instance.highlightStrategy =
+              FocusHighlightStrategy.alwaysTraditional;
+          await tester.pump();
 
-        FocusManager.instance.highlightStrategy =
-            FocusHighlightStrategy.alwaysTouch;
-        await tester.pump();
+          expect(focusNode.hasFocus, isTrue);
+          expect(_sliderThumb(tester).containerEffects?.outline.width, 3);
 
-        expect(focusNode.hasFocus, isTrue);
-        expect(_sliderThumb(tester).containerEffects?.outline.width, 0);
-      });
+          FocusManager.instance.highlightStrategy =
+              FocusHighlightStrategy.alwaysTouch;
+          await tester.pump();
+
+          expect(focusNode.hasFocus, isTrue);
+          expect(_sliderThumb(tester).containerEffects?.outline.width, 0);
+        });
+      }
     });
 
     group('Snap Divisions', () {

--- a/packages/remix/test/components/slider/slider_widget_test.dart
+++ b/packages/remix/test/components/slider/slider_widget_test.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:remix/remix.dart';
+import 'package:remix/src/rendering/remix_box_effects.dart'
+    show RemixBoxWithEffects;
 
 import '../../helpers/test_helpers.dart';
 
@@ -503,6 +505,58 @@ void main() {
         expect(focusNode.hasFocus, isTrue);
         focusNode.dispose();
       });
+
+      testWidgets('thumb focus effect follows focus highlight mode', (
+        tester,
+      ) async {
+        final previousStrategy = FocusManager.instance.highlightStrategy;
+        addTearDown(() {
+          FocusManager.instance.highlightStrategy = previousStrategy;
+        });
+        FocusManager.instance.highlightStrategy =
+            FocusHighlightStrategy.alwaysTouch;
+        final focusNode = FocusNode();
+        addTearDown(focusNode.dispose);
+
+        await tester.pumpRemixApp(
+          RemixSlider(
+            value: 0.5,
+            onChanged: (value) {},
+            focusNode: focusNode,
+            style: SliderStyler(
+              thumb: BoxStyler().size(20, 20),
+              thumbFocusEffects: RemixBoxEffectsMix(
+                outline: BorderSideMix(
+                  color: Colors.red,
+                  width: 3,
+                  strokeAlign: BorderSide.strokeAlignInside,
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        focusNode.requestFocus();
+        await tester.pumpAndSettle();
+
+        expect(focusNode.hasFocus, isTrue);
+        expect(_sliderThumb(tester).containerEffects?.outline.width, 0);
+
+        FocusManager.instance.highlightStrategy =
+            FocusHighlightStrategy.alwaysTraditional;
+        await tester.pump();
+
+        expect(focusNode.hasFocus, isTrue);
+        expect(_sliderThumb(tester).containerEffects?.outline.width, 3);
+
+        FocusManager.instance.highlightStrategy =
+            FocusHighlightStrategy.alwaysTouch;
+        await tester.pump();
+
+        expect(focusNode.hasFocus, isTrue);
+        expect(_sliderThumb(tester).containerEffects?.outline.width, 0);
+      });
     });
 
     group('Snap Divisions', () {
@@ -791,4 +845,12 @@ void main() {
       });
     });
   });
+}
+
+RemixBoxWithEffects _sliderThumb(WidgetTester tester) {
+  return tester
+      .widgetList<RemixBoxWithEffects>(find.byType(RemixBoxWithEffects))
+      .singleWhere(
+        (widget) => widget.styleSpec.spec.constraints?.maxWidth == 20,
+      );
 }

--- a/packages/remix/test/components/toggle_group/toggle_group_widget_test.dart
+++ b/packages/remix/test/components/toggle_group/toggle_group_widget_test.dart
@@ -963,6 +963,51 @@ void main() {
       expect(tester.widget<Text>(find.text('List')).style?.color, Colors.grey);
     });
 
+    testWidgets('focus-visible item style tracks highlight mode', (
+      tester,
+    ) async {
+      final previousStrategy = FocusManager.instance.highlightStrategy;
+      addTearDown(() {
+        FocusManager.instance.highlightStrategy = previousStrategy;
+      });
+      FocusManager.instance.highlightStrategy =
+          FocusHighlightStrategy.alwaysTouch;
+      final node = FocusNode();
+      addTearDown(node.dispose);
+
+      await tester.pumpRemixApp(
+        RemixToggleGroup<String>(
+          items: [
+            RemixToggleGroupItem(value: 'list', label: 'List', focusNode: node),
+          ],
+          selectedValue: 'list',
+          onChanged: (_) {},
+          style: ToggleGroupStyler(
+            item: ToggleGroupItemStyler()
+                .foregroundColor(Colors.blue)
+                .onFocusVisible(
+                  ToggleGroupItemStyler().foregroundColor(Colors.green),
+                ),
+          ),
+        ),
+      );
+
+      node.requestFocus();
+      await tester.pumpAndSettle();
+      expect(node.hasFocus, isTrue);
+      expect(tester.widget<Text>(find.text('List')).style?.color, Colors.blue);
+
+      FocusManager.instance.highlightStrategy =
+          FocusHighlightStrategy.alwaysTraditional;
+      await tester.pump();
+      expect(tester.widget<Text>(find.text('List')).style?.color, Colors.green);
+
+      FocusManager.instance.highlightStrategy =
+          FocusHighlightStrategy.alwaysTouch;
+      await tester.pump();
+      expect(tester.widget<Text>(find.text('List')).style?.color, Colors.blue);
+    });
+
     testWidgets('focus style is removed when the focused item is disabled', (
       tester,
     ) async {

--- a/packages/remix/test/utilities/remix_style_test.dart
+++ b/packages/remix/test/utilities/remix_style_test.dart
@@ -2,10 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mix/mix.dart';
 import 'package:remix/src/utilities/remix_style.dart'
-    show
-        FocusVisibleWidgetStateVariantExtension,
-        RemixDefaultContentStyle,
-        RemixStyleSpecBuilder;
+    show RemixDefaultContentStyle, RemixStyleSpecBuilder;
 
 void main() {
   group('focus-visible styling', () {

--- a/packages/remix/test/utilities/remix_style_test.dart
+++ b/packages/remix/test/utilities/remix_style_test.dart
@@ -30,7 +30,7 @@ void main() {
           home: RemixStyleSpecBuilder<BoxSpec>(
             style: BoxStyler()
                 .color(Colors.blue)
-                .onFocusVisible(BoxStyler().color(Colors.red)),
+                .onFocusVisible(.color(Colors.red)),
             styleSpec: null,
             controller: controller,
             builder: (context, spec) {
@@ -70,7 +70,7 @@ void main() {
         final child = RemixStyleSpecBuilder<BoxSpec>(
           style: BoxStyler()
               .color(Colors.blue)
-              .onFocusVisible(BoxStyler().color(Colors.red)),
+              .onFocusVisible(.color(Colors.red)),
           styleSpec: null,
           controller: controller,
           builder: (context, spec) {

--- a/packages/remix/test/utilities/remix_style_test.dart
+++ b/packages/remix/test/utilities/remix_style_test.dart
@@ -2,9 +2,113 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mix/mix.dart';
 import 'package:remix/src/utilities/remix_style.dart'
-    show RemixDefaultContentStyle;
+    show
+        FocusVisibleWidgetStateVariantExtension,
+        RemixDefaultContentStyle,
+        RemixStyleSpecBuilder;
 
 void main() {
+  group('focus-visible styling', () {
+    late FocusHighlightStrategy previousStrategy;
+
+    setUp(() {
+      previousStrategy = FocusManager.instance.highlightStrategy;
+    });
+
+    tearDown(() {
+      FocusManager.instance.highlightStrategy = previousStrategy;
+    });
+
+    testWidgets('reacts to focus highlight mode while focus is retained', (
+      tester,
+    ) async {
+      FocusManager.instance.highlightStrategy =
+          FocusHighlightStrategy.alwaysTouch;
+      final controller = WidgetStatesController({WidgetState.focused});
+      addTearDown(controller.dispose);
+      late BoxSpec resolved;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: RemixStyleSpecBuilder<BoxSpec>(
+            style: BoxStyler()
+                .color(Colors.blue)
+                .onFocusVisible(BoxStyler().color(Colors.red)),
+            styleSpec: null,
+            controller: controller,
+            builder: (context, spec) {
+              resolved = spec;
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      expect(_boxColor(resolved), Colors.blue);
+      expect(controller.value, contains(WidgetState.focused));
+
+      FocusManager.instance.highlightStrategy =
+          FocusHighlightStrategy.alwaysTraditional;
+      await tester.pump();
+      expect(_boxColor(resolved), Colors.red);
+      expect(controller.value, contains(WidgetState.focused));
+
+      FocusManager.instance.highlightStrategy =
+          FocusHighlightStrategy.alwaysTouch;
+      await tester.pump();
+      expect(_boxColor(resolved), Colors.blue);
+      expect(controller.value, contains(WidgetState.focused));
+    });
+
+    testWidgets('requires focus unless tooling forces the visual state', (
+      tester,
+    ) async {
+      FocusManager.instance.highlightStrategy =
+          FocusHighlightStrategy.alwaysTraditional;
+      final controller = WidgetStatesController();
+      addTearDown(controller.dispose);
+      late BoxSpec resolved;
+
+      Widget build({required bool forceFocus}) {
+        final child = RemixStyleSpecBuilder<BoxSpec>(
+          style: BoxStyler()
+              .color(Colors.blue)
+              .onFocusVisible(BoxStyler().color(Colors.red)),
+          styleSpec: null,
+          controller: controller,
+          builder: (context, spec) {
+            resolved = spec;
+            return const SizedBox.shrink();
+          },
+        );
+
+        return MaterialApp(
+          home: forceFocus
+              ? WidgetStateStyleOverride(
+                  states: const {WidgetState.focused},
+                  child: child,
+                )
+              : child,
+        );
+      }
+
+      await tester.pumpWidget(build(forceFocus: false));
+      expect(_boxColor(resolved), Colors.blue);
+
+      controller.focused = true;
+      await tester.pump();
+      expect(_boxColor(resolved), Colors.red);
+
+      FocusManager.instance.highlightStrategy =
+          FocusHighlightStrategy.alwaysTouch;
+      await tester.pump();
+      expect(_boxColor(resolved), Colors.blue);
+
+      await tester.pumpWidget(build(forceFocus: true));
+      expect(_boxColor(resolved), Colors.red);
+    });
+  });
+
   testWidgets(
     'RemixDefaultContentStyle provides defaults while descendants can override',
     (tester) async {
@@ -50,4 +154,8 @@ void main() {
       expect(explicitIcon.size, 13);
     },
   );
+}
+
+Color? _boxColor(BoxSpec spec) {
+  return (spec.decoration as BoxDecoration?)?.color;
 }

--- a/packages/remix_fortal/lib/src/recipes/accordion.dart
+++ b/packages/remix_fortal/lib/src/recipes/accordion.dart
@@ -71,7 +71,7 @@ AccordionStyler _fortalAccordionSurfaceStyler([
       )
       .onHovered(.trigger(.color(FortalTokens.gray2())))
       .onPressed(.trigger(.color(FortalTokens.gray3())))
-      .onFocused(_fortalAccordionFocusStyler())
+      .onFocusVisible(_fortalAccordionFocusStyler())
       .onDisabled(_fortalAccordionDisabledStyler());
 }
 
@@ -97,7 +97,7 @@ AccordionStyler _fortalAccordionSoftStyler([
       )
       .onHovered(.trigger(.color(FortalTokens.accent3())))
       .onPressed(.trigger(.color(FortalTokens.accent4())))
-      .onFocused(_fortalAccordionFocusStyler())
+      .onFocusVisible(_fortalAccordionFocusStyler())
       .onDisabled(_fortalAccordionDisabledStyler());
 }
 

--- a/packages/remix_fortal/lib/src/recipes/button.dart
+++ b/packages/remix_fortal/lib/src/recipes/button.dart
@@ -41,7 +41,7 @@ ButtonStyler fortalButtonStyle({
         .outline => _fortalButtonOutline(base, highContrast: highContrast),
         .ghost => _fortalButtonGhost(base, highContrast: highContrast),
       }
-      .onFocused(.containerEffects(focus))
+      .onFocusVisible(.containerEffects(focus))
       .onDisabled(.containerEffects(disabledFocus));
 }
 

--- a/packages/remix_fortal/lib/src/recipes/card.dart
+++ b/packages/remix_fortal/lib/src/recipes/card.dart
@@ -23,7 +23,7 @@ CardStyler fortalCardStyle({
       .paddingAll(metrics.padding)
       .borderRadiusAll(metrics.radius)
       .clipBehavior(Clip.antiAlias)
-      .onFocused(
+      .onFocusVisible(
         .containerEffects(
           RemixBoxEffectsMix(
             outline: BorderSideMix(
@@ -95,7 +95,7 @@ CardStyler _fortalCardSurface(CardStyler base) {
           overContent: _fortalCardSurfaceStroke(FortalTokens.grayStroke6()),
         ),
       )
-      .onFocused(activeFocus)
+      .onFocusVisible(activeFocus)
       .onSelected(open);
 
   return base
@@ -146,7 +146,7 @@ CardStyler _fortalCardClassic(CardStyler base) {
           ),
         ),
       )
-      .onFocused(
+      .onFocusVisible(
         .containerEffects(
           RemixBoxEffectsMix(behindContent: _fortalCardActiveFocus()),
         ).onSelected(open),
@@ -176,10 +176,12 @@ CardStyler _fortalCardClassic(CardStyler base) {
 
 CardStyler _fortalCardGhost(CardStyler base, double ghostMargin) {
   final focused = CardStyler().color(FortalTokens.accentA2());
-  final open = CardStyler().color(FortalTokens.grayA3()).onFocused(focused);
+  final open = CardStyler()
+      .color(FortalTokens.grayA3())
+      .onFocusVisible(focused);
   final pressed = CardStyler()
       .color(FortalTokens.grayA4())
-      .onFocused(focused)
+      .onFocusVisible(focused)
       .onSelected(open);
 
   return base

--- a/packages/remix_fortal/lib/src/recipes/checkbox.dart
+++ b/packages/remix_fortal/lib/src/recipes/checkbox.dart
@@ -31,7 +31,7 @@ CheckboxStyler fortalCheckboxStyle({
           behindContent: _fortalCheckboxLayer(),
           overContent: _fortalCheckboxLayer(),
         ),
-      ).onFocused(
+      ).onFocusVisible(
         .containerEffects(
           RemixBoxEffectsMix(
             outline: BorderSideMix(

--- a/packages/remix_fortal/lib/src/recipes/icon_button.dart
+++ b/packages/remix_fortal/lib/src/recipes/icon_button.dart
@@ -41,7 +41,7 @@ IconButtonStyler fortalIconButtonStyle({
         .outline => _fortalIconButtonOutline(base, highContrast: highContrast),
         .ghost => _fortalIconButtonGhost(base, highContrast: highContrast),
       }
-      .onFocused(.containerEffects(focus))
+      .onFocusVisible(.containerEffects(focus))
       .onDisabled(.containerEffects(disabledFocus));
 }
 

--- a/packages/remix_fortal/lib/src/recipes/link.dart
+++ b/packages/remix_fortal/lib/src/recipes/link.dart
@@ -105,7 +105,7 @@ BadgeStyler _fortalInteractiveLinkStyle(
   required bool truncate,
   required bool highContrast,
 }) {
-  BadgeStyler resolve({bool hovered = false, bool focused = false}) {
+  BadgeStyler styleFor({bool hovered = false, bool focused = false}) {
     return fortalLinkStyle(
       context,
       size: size,
@@ -120,11 +120,11 @@ BadgeStyler _fortalInteractiveLinkStyle(
     );
   }
 
-  final focusVisible = resolve(
+  final focusVisible = styleFor(
     focused: true,
   ).label(.decoration(TextDecoration.none));
-  return resolve()
-      .onHovered(resolve(hovered: true).onFocusVisible(focusVisible))
+  return styleFor()
+      .onHovered(styleFor(hovered: true).onFocusVisible(focusVisible))
       .onFocusVisible(focusVisible);
 }
 

--- a/packages/remix_fortal/lib/src/recipes/link.dart
+++ b/packages/remix_fortal/lib/src/recipes/link.dart
@@ -36,8 +36,8 @@ BadgeStyler fortalLinkStyle(
   }
 
   // Every upstream underline rule is gated behind `:where(:any-link, button)`,
-  // so a link with no callback stays plain accent-coloured text. Focus replaces
-  // the underline with the outline rather than stacking both.
+  // so a link with no callback stays plain accent-coloured text. A focus-visible
+  // outline replaces the underline rather than stacking both.
   final underlined =
       actionable &&
       !focused &&
@@ -94,6 +94,38 @@ BadgeStyler fortalLinkStyle(
   }
 
   return style;
+}
+
+BadgeStyler _fortalInteractiveLinkStyle(
+  BuildContext context, {
+  FortalTextSize? size,
+  FortalTextWeight? weight,
+  required FortalLinkUnderline underline,
+  required bool softWrap,
+  required bool truncate,
+  required bool highContrast,
+}) {
+  BadgeStyler resolve({bool hovered = false, bool focused = false}) {
+    return fortalLinkStyle(
+      context,
+      size: size,
+      weight: weight,
+      underline: underline,
+      softWrap: softWrap,
+      truncate: truncate,
+      highContrast: highContrast,
+      actionable: true,
+      hovered: hovered,
+      focused: focused,
+    );
+  }
+
+  final focusVisible = resolve(
+    focused: true,
+  ).label(.decoration(TextDecoration.none));
+  return resolve()
+      .onHovered(resolve(hovered: true).onFocusVisible(focusVisible))
+      .onFocusVisible(focusVisible);
 }
 
 /// Token-backed text that becomes an accessible link only when actionable.
@@ -189,18 +221,19 @@ class _FortalLinkState extends State<FortalLink> {
         if (_focused != focused) setState(() => _focused = focused);
       },
       excludeSemantics: true,
-      builder: (context, state, child) => fortalLinkStyle(
-        context,
-        size: widget.size,
-        weight: widget.weight,
-        underline: widget.underline,
-        softWrap: widget.softWrap,
-        truncate: widget.truncate,
-        highContrast: widget.highContrast,
-        actionable: true,
-        hovered: state.states.contains(WidgetState.hovered),
-        focused: state.states.contains(WidgetState.focused),
-      )(label: widget.text),
+      builder: (context, _, _) => StyleBuilder<BadgeSpec>(
+        style: _fortalInteractiveLinkStyle(
+          context,
+          size: widget.size,
+          weight: widget.weight,
+          underline: widget.underline,
+          softWrap: widget.softWrap,
+          truncate: widget.truncate,
+          highContrast: widget.highContrast,
+        ),
+        controller: NakedButtonState.controllerOf(context),
+        builder: (_, spec) => RemixBadge(label: widget.text, styleSpec: spec),
+      ),
     );
 
     final link = Semantics(

--- a/packages/remix_fortal/lib/src/recipes/menu.dart
+++ b/packages/remix_fortal/lib/src/recipes/menu.dart
@@ -99,6 +99,8 @@ MenuItemStyler _fortalMenuItemStyler(
       .trailingIcon(.color(FortalTokens.grayA8()))
       .indicator(.color(FortalTokens.grayA8()));
 
+  // Naked's focused item is Radix's roving `data-highlighted` item, not a
+  // CSS focus ring, so this intentionally follows raw focus.
   return base
       .onHovered(highlighted)
       .onFocused(highlighted)
@@ -145,6 +147,7 @@ MenuItemStyler _fortalMenuSubmenuItemStyler(
         variant == .solid ? FortalTokens.grayA3() : FortalTokens.accentA3(),
       )
       .onHovered(highlighted)
+      // Roving `data-highlighted` state, not a focus-visible ring.
       .onFocused(highlighted)
       .onPressed(highlighted);
 

--- a/packages/remix_fortal/lib/src/recipes/radio.dart
+++ b/packages/remix_fortal/lib/src/recipes/radio.dart
@@ -59,7 +59,7 @@ RadioStyler _fortalRadioBaseStyler(FortalRadioSize size) {
       behindContent: _fortalRadioLayer(),
       overContent: _fortalRadioLayer(),
     ),
-  ).onFocused(
+  ).onFocusVisible(
     .containerEffects(
       RemixBoxEffectsMix(
         outline: BorderSideMix(

--- a/packages/remix_fortal/lib/src/recipes/segmented_control.dart
+++ b/packages/remix_fortal/lib/src/recipes/segmented_control.dart
@@ -125,7 +125,7 @@ SegmentedControlItemStyler _fortalSegmentedControlItemStyle(
             .onHovered(.color(Colors.transparent))
             .onDisabled(disabledSelected),
       )
-      .onFocused(
+      .onFocusVisible(
         SegmentedControlItemStyler()
             .borderRadiusAll(metrics.radius)
             .containerEffects(

--- a/packages/remix_fortal/lib/src/recipes/select.dart
+++ b/packages/remix_fortal/lib/src/recipes/select.dart
@@ -48,7 +48,7 @@ SelectTriggerStyler _fortalSelectTriggerStyler(
       )
       .icon(.color(FortalTokens.gray12()))
       .chevron(.color(FortalTokens.gray12()).size(size == .size3 ? 11 : 9))
-      .onFocused(
+      .onFocusVisible(
         .containerEffects(
           RemixBoxEffectsMix(overContent: _fortalSelectFocusRing()),
         ),
@@ -266,6 +266,8 @@ SelectMenuItemStyler _fortalSelectItemStyler(
     .soft => SelectMenuItemStyler().color(FortalTokens.accentA4()),
   };
 
+  // Naked's focused option is Radix's roving `data-highlighted` item, not a
+  // CSS focus ring, so this intentionally follows raw focus.
   return base
       .onHovered(highlighted)
       .onFocused(highlighted)

--- a/packages/remix_fortal/lib/src/recipes/switch.dart
+++ b/packages/remix_fortal/lib/src/recipes/switch.dart
@@ -61,7 +61,7 @@ SwitchStyler _fortalSwitchBaseStyler(FortalSwitchSize size) {
         ),
       )
       .thumbColor(Colors.white)
-      .onFocused(
+      .onFocusVisible(
         .trackEffects(
           RemixBoxEffectsMix(
             outline: BorderSideMix(

--- a/packages/remix_fortal/lib/src/recipes/tabs.dart
+++ b/packages/remix_fortal/lib/src/recipes/tabs.dart
@@ -80,16 +80,18 @@ TabStyler fortalTabStyle({
             .spacing(FortalTokens.space2()),
       )
       .onHovered(
-        .label(
-          .color(FortalTokens.gray12()),
-        ).icon(.color(FortalTokens.gray12())).color(FortalTokens.grayA3()),
+        .label(.color(FortalTokens.gray12()))
+            .icon(.color(FortalTokens.gray12()))
+            .color(FortalTokens.grayA3())
+            .onFocusVisible(.color(FortalTokens.accentA3())),
       )
-      .onFocused(
+      .onFocusVisible(
         // Solid `focus-8` where the other three rings use alpha `focus-a8`.
         // See fortalFocusRing: unresolved whether that is intentional.
-        TabStyler()
-            .fortalFocusRing(color: FortalTokens.focus8(), strokeAlign: null)
-            .onHovered(.color(FortalTokens.accentA3())),
+        TabStyler().fortalFocusRing(
+          color: FortalTokens.focus8(),
+          strokeAlign: null,
+        ),
       )
       .onSelected(
         .label(

--- a/packages/remix_fortal/lib/src/recipes/textfield.dart
+++ b/packages/remix_fortal/lib/src/recipes/textfield.dart
@@ -103,6 +103,8 @@ TextFieldStyler _fortalTextInputBaseStyle({
           ),
         )
         .wrap(.iconTheme(color: FortalTokens.gray11(), size: 16.0))
+        // Radix keys text-input rings from :focus/:focus-within, so unlike
+        // control focus rings this intentionally follows raw focus.
         .onFocused(
           .containerEffects(fortalFocusOutline(focusColor, offset: -1)),
         );
@@ -218,6 +220,8 @@ TextFieldStyler _fortalApplyNeutralTextInput(TextFieldStyler base) =>
       ),
     );
 
+// Keep the disabled-color branch on raw focus for the same :focus-within
+// contract as the enabled text input.
 TextFieldStyler _fortalTextInputDisabledBaseStyle() =>
     TextFieldStyler(
       text: .color(

--- a/packages/remix_fortal/lib/src/recipes/toggle.dart
+++ b/packages/remix_fortal/lib/src/recipes/toggle.dart
@@ -65,7 +65,7 @@ ToggleStyler _fortalToggleGhostStyler(
             .onHovered(ToggleStyler().backgroundColor(FortalTokens.accent4()))
             .onPressed(ToggleStyler().backgroundColor(FortalTokens.accent5())),
       )
-      .onFocused(_fortalToggleFocusStyler())
+      .onFocusVisible(_fortalToggleFocusStyler())
       .onDisabled(_fortalToggleDisabledStyler());
 }
 
@@ -92,7 +92,7 @@ ToggleStyler _fortalToggleOutlineStyler(
             .onHovered(ToggleStyler().backgroundColor(FortalTokens.accentA4()))
             .onPressed(ToggleStyler().backgroundColor(FortalTokens.accentA5())),
       )
-      .onFocused(_fortalToggleFocusStyler())
+      .onFocusVisible(_fortalToggleFocusStyler())
       .onDisabled(_fortalToggleDisabledStyler(outlined: true));
 }
 

--- a/packages/remix_fortal/lib/src/recipes/toggle_group.dart
+++ b/packages/remix_fortal/lib/src/recipes/toggle_group.dart
@@ -74,7 +74,7 @@ ToggleGroupStyler fortalToggleGroupStyle({
                 ToggleGroupItemStyler().backgroundColor(selectedPressedColor),
               ),
         )
-        .onFocused(ToggleGroupItemStyler().fortalFocusRing())
+        .onFocusVisible(ToggleGroupItemStyler().fortalFocusRing())
         .onDisabled(
           ToggleGroupItemStyler()
               .backgroundColor(FortalTokens.grayA3())

--- a/packages/remix_fortal/pubspec.yaml
+++ b/packages/remix_fortal/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
   # package. `tool/fortal_parity/check.dart` (_checkRemixHostedPin) fails if the
   # two ever fall out of sync.
   remix: ^1.0.0-beta.2 # x-release-please-version
-  mix: ^2.2.0-beta.2
+  mix: ^2.2.0-beta.3
   mix_annotations: ^2.2.0-beta.1
   naked_ui: ^1.0.0-beta.8
 

--- a/packages/remix_fortal/test/components/button/button_widget_test.dart
+++ b/packages/remix_fortal/test/components/button/button_widget_test.dart
@@ -127,5 +127,68 @@ void main() {
         );
       }
     });
+
+    group('focus-visible ring', () {
+      late FocusHighlightStrategy previousStrategy;
+
+      setUp(() {
+        previousStrategy = FocusManager.instance.highlightStrategy;
+      });
+
+      tearDown(() {
+        FocusManager.instance.highlightStrategy = previousStrategy;
+      });
+
+      for (final autofocus in [false, true]) {
+        testWidgets(
+          '${autofocus ? 'autofocus' : 'programmatic focus'} follows highlight mode',
+          (tester) async {
+            FocusManager.instance.highlightStrategy =
+                FocusHighlightStrategy.alwaysTouch;
+            final focusNode = FocusNode();
+            addTearDown(focusNode.dispose);
+            late ButtonSpec resolved;
+
+            await tester.pumpRemixApp(
+              FortalButton.solid(
+                label: 'Continue',
+                onPressed: () {},
+                autofocus: autofocus,
+                focusNode: focusNode,
+                textBuilder: (context, spec, text) => Builder(
+                  builder: (context) {
+                    resolved = StyleSpecProvider.of<ButtonSpec>(context)!.spec;
+                    return StyledText(text, styleSpec: StyleSpec(spec: spec));
+                  },
+                ),
+              ),
+            );
+            await tester.pumpAndSettle();
+
+            if (!autofocus) {
+              focusNode.requestFocus();
+              await tester.pumpAndSettle();
+            }
+
+            expect(focusNode.hasFocus, isTrue);
+            expect(resolved.containerEffects?.outline.width ?? 0, 0);
+
+            FocusManager.instance.highlightStrategy =
+                FocusHighlightStrategy.alwaysTraditional;
+            await tester.pump();
+
+            expect(focusNode.hasFocus, isTrue);
+            expect(resolved.containerEffects?.outline.width, 2);
+
+            FocusManager.instance.highlightStrategy =
+                FocusHighlightStrategy.alwaysTouch;
+            await tester.pump();
+
+            expect(focusNode.hasFocus, isTrue);
+            expect(resolved.containerEffects?.outline.width ?? 0, 0);
+          },
+        );
+      }
+    });
   });
 }

--- a/packages/remix_fortal/test/components/card/card_fortal_parity_test.dart
+++ b/packages/remix_fortal/test/components/card/card_fortal_parity_test.dart
@@ -298,7 +298,7 @@ Future<CardSpec> _resolve(
       scaling: scaling,
       child: WidgetsApp(
         color: Colors.black,
-        builder: (context, child) => WidgetStateProvider(
+        builder: (context, child) => WidgetStateStyleOverride(
           states: states,
           child: Builder(
             builder: (context) {

--- a/packages/remix_fortal/test/components/segmented_control/segmented_control_fortal_parity_test.dart
+++ b/packages/remix_fortal/test/components/segmented_control/segmented_control_fortal_parity_test.dart
@@ -272,7 +272,7 @@ _resolve(
   await tester.pumpWidget(
     FortalScope(
       scaling: scaling,
-      child: WidgetStateProvider(
+      child: WidgetStateStyleOverride(
         states: states,
         child: Builder(
           builder: (context) {

--- a/packages/remix_fortal/test/components/select/select_fortal_parity_test.dart
+++ b/packages/remix_fortal/test/components/select/select_fortal_parity_test.dart
@@ -314,7 +314,7 @@ Future<SelectSpec> _resolve(
       radius: radius,
       child: WidgetsApp(
         color: Colors.black,
-        builder: (context, child) => WidgetStateProvider(
+        builder: (context, child) => WidgetStateStyleOverride(
           states: states,
           child: Builder(
             builder: (context) {

--- a/packages/remix_fortal/test/components/tabs/tabs_fortal_parity_test.dart
+++ b/packages/remix_fortal/test/components/tabs/tabs_fortal_parity_test.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:remix/remix.dart';
+import 'package:remix_fortal/remix_fortal.dart';
+
+void main() {
+  testWidgets('focus-visible hover keeps the Radix accent hover treatment', (
+    tester,
+  ) async {
+    final hovered = await _resolve(tester, const {WidgetState.hovered});
+    final focusedHovered = await _resolve(tester, const {
+      WidgetState.focused,
+      WidgetState.hovered,
+    });
+
+    expect(_containerColor(hovered.spec), hovered.grayA3);
+    expect(_containerColor(focusedHovered.spec), focusedHovered.accentA3);
+    expect(_containerBorder(focusedHovered.spec)?.top.width, 2);
+  });
+}
+
+Future<({TabSpec spec, Color grayA3, Color accentA3})> _resolve(
+  WidgetTester tester,
+  Set<WidgetState> states,
+) async {
+  late ({TabSpec spec, Color grayA3, Color accentA3}) result;
+
+  await tester.pumpWidget(
+    FortalScope(
+      child: WidgetsApp(
+        color: Colors.black,
+        builder: (context, child) => WidgetStateStyleOverride(
+          states: states,
+          child: Builder(
+            builder: (context) {
+              result = (
+                spec: fortalTabStyle().build(context).spec,
+                grayA3: MixScope.tokenOf(FortalTokens.grayA3, context),
+                accentA3: MixScope.tokenOf(FortalTokens.accentA3, context),
+              );
+
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      ),
+    ),
+  );
+
+  return result;
+}
+
+Color? _containerColor(TabSpec spec) {
+  return _containerDecoration(spec)?.color;
+}
+
+Border? _containerBorder(TabSpec spec) =>
+    _containerDecoration(spec)?.border as Border?;
+
+BoxDecoration? _containerDecoration(TabSpec spec) =>
+    spec.container.spec.box?.spec.decoration as BoxDecoration?;

--- a/packages/remix_fortal/test/components/typography/typography_test.dart
+++ b/packages/remix_fortal/test/components/typography/typography_test.dart
@@ -1,3 +1,5 @@
+import 'dart:ui' show PointerDeviceKind;
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -342,26 +344,95 @@ void main() {
   });
 
   group('focus', () {
-    testWidgets('focused link draws the outline without moving layout', (
+    testWidgets('link focus treatment follows the highlight mode', (
       tester,
     ) async {
+      final previousStrategy = FocusManager.instance.highlightStrategy;
+      addTearDown(() {
+        FocusManager.instance.highlightStrategy = previousStrategy;
+      });
+      FocusManager.instance.highlightStrategy =
+          FocusHighlightStrategy.alwaysTouch;
       final focusNode = FocusNode();
       addTearDown(focusNode.dispose);
       await _pump(
         tester,
-        FortalLink('focus me', focusNode: focusNode, onPressed: _noop),
+        FortalLink(
+          'focus me',
+          underline: FortalLinkUnderline.always,
+          focusNode: focusNode,
+          onPressed: _noop,
+        ),
       );
       final idleSize = tester.getSize(find.text('focus me'));
+      expect(_underlined(tester, 'focus me'), isTrue);
 
       focusNode.requestFocus();
+      await tester.pumpAndSettle();
+
+      expect(focusNode.hasFocus, isTrue);
+      expect(_surface(tester).containerEffects?.outline.width ?? 0, 0);
+      expect(_underlined(tester, 'focus me'), isTrue);
+      expect(tester.getSize(find.text('focus me')), idleSize);
+
+      FocusManager.instance.highlightStrategy =
+          FocusHighlightStrategy.alwaysTraditional;
       await tester.pump();
 
       final effects = _surface(tester).containerEffects!;
       expect(effects.outline.width, 2);
       expect(effects.outlineOffset, 2);
-      expect(tester.getSize(find.text('focus me')), idleSize);
-      // Focus replaces the underline rather than stacking both.
       expect(_underlined(tester, 'focus me'), isFalse);
+      expect(tester.getSize(find.text('focus me')), idleSize);
+
+      FocusManager.instance.highlightStrategy =
+          FocusHighlightStrategy.alwaysTouch;
+      await tester.pump();
+
+      expect(_surface(tester).containerEffects?.outline.width ?? 0, 0);
+      expect(_underlined(tester, 'focus me'), isTrue);
+    });
+
+    testWidgets('focus-visible outline takes precedence over hover underline', (
+      tester,
+    ) async {
+      final previousStrategy = FocusManager.instance.highlightStrategy;
+      addTearDown(() {
+        FocusManager.instance.highlightStrategy = previousStrategy;
+      });
+      FocusManager.instance.highlightStrategy =
+          FocusHighlightStrategy.alwaysTraditional;
+      final focusNode = FocusNode();
+      addTearDown(focusNode.dispose);
+
+      await _pump(
+        tester,
+        FortalLink(
+          'hover me',
+          underline: FortalLinkUnderline.hover,
+          focusNode: focusNode,
+          onPressed: _noop,
+        ),
+      );
+      expect(_underlined(tester, 'hover me'), isFalse);
+
+      final mouse = await tester.createGesture(kind: PointerDeviceKind.mouse);
+      addTearDown(mouse.removePointer);
+      await mouse.addPointer(location: Offset.zero);
+      await mouse.moveTo(tester.getCenter(find.text('hover me')));
+      await tester.pump();
+      expect(_underlined(tester, 'hover me'), isTrue);
+
+      focusNode.requestFocus();
+      await tester.pumpAndSettle();
+      expect(_surface(tester).containerEffects?.outline.width, 2);
+      expect(_underlined(tester, 'hover me'), isFalse);
+
+      FocusManager.instance.highlightStrategy =
+          FocusHighlightStrategy.alwaysTouch;
+      await tester.pump();
+      expect(_surface(tester).containerEffects?.outline.width ?? 0, 0);
+      expect(_underlined(tester, 'hover me'), isTrue);
     });
   });
 
@@ -578,7 +649,8 @@ Text _text(WidgetTester tester, String text) =>
 
 BadgeSpec _surface(WidgetTester tester) {
   final widget = tester.widget<RemixBadge>(find.byType(RemixBadge));
-  return widget.style.resolve(tester.element(find.byType(RemixBadge))).spec;
+  return widget.styleSpec ??
+      widget.style.resolve(tester.element(find.byType(RemixBadge))).spec;
 }
 
 Color? _boxColor(BadgeSpec spec) =>

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -420,10 +420,10 @@ packages:
     dependency: transitive
     description:
       name: mix
-      sha256: a9bf197827ee630d16476f5b057e88dda26608bbfb20dd7838f0d1ef7963a8df
+      sha256: "24149169ecabd6264264afb30bde350a73449f9790f8257578320c26fbc3e72e"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0-beta.2"
+    version: "2.2.0-beta.3"
   mix_annotations:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,7 +43,7 @@ melos:
       # tool/check_consumer_mix.dart enforces the same equality for anyone who
       # edits a pubspec without bootstrapping.
       dependencies:
-        mix: ^2.2.0-beta.2
+        mix: ^2.2.0-beta.3
         mix_annotations: ^2.2.0-beta.1
       dev_dependencies:
         mix_generator: ^2.2.0-beta.2


### PR DESCRIPTION
## Description

Remix exposed raw `WidgetState.focused` to styles, so Fortal painted focus rings for autofocus and programmatic focus even when Flutter's `FocusManager.highlightMode` was `touch`. Radix applies these control rings with `:focus-visible` instead.

This change:

- requires hosted `mix 2.2.0-beta.3` and uses Mix's typed `onFocusVisible` styler API and `FocusVisibleVariant` directly, without a Remix extension or duplicate variant;
- moves Fortal control rings, link focus treatment, and the slider thumb effect to that modality-aware condition while preserving actual semantic focus and the raw focus used for Radix `data-highlighted` menu/select items and text-field `:focus`/`:focus-within` behavior;
- keeps targeted highlight-mode rebuilding for Remix visuals that read the mode directly and for manually mounted composite `WidgetStateProvider` scopes;
- covers controller-driven widgets, links across touch, traditional, and hover states, segmented and toggle groups, slider focus through fluent and raw style specs, autofocus and programmatic focus, Tabs compound states, and forced visual states used by parity tooling;
- updates the Slider API documentation, segmented-control example, and dashboard focus-ring demo.

The upstream typed focus-visible API shipped in [Mix 2.2.0-beta.3](https://pub.dev/packages/mix/versions/2.2.0-beta.3) via [conceptadev/mix#1007](https://github.com/conceptadev/mix/pull/1007).

## Validation

- `fvm dart run melos run ci` — passed toolchain checks, hosted Mix beta.3 resolution, clean generated sources, documentation validation, Fortal parity, and all 2,893 tests
- `fvm flutter analyze` — passed with no issues
- `git diff --check origin/main...HEAD` — passed

## Related Issues

Closes #122

---

## Checklist

**Note**: Updating the `pubspec.yaml` and `CHANGELOG.md` is not required. These are handled automatically during the release process.

- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors.
- [x] I have updated or added relevant documentation (doc comments with `///`).
- [x] I am prepared to follow up on review comments in a timely manner.

## Breaking Change

Does this PR require users of the package to manually update their code?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.
