### PR TITLE
fix(remix): correct focus-visible state handling

### DIFF
--- a/packages/remix/lib/src/components/slider/slider_widget.dart
+++ b/packages/remix/lib/src/components/slider/slider_widget.dart
@@ -125,10 +125,12 @@ class RemixSlider extends StatelessWidget {
             final trackThickness = spec.trackThickness > 0
                 ? spec.trackThickness
                 : SliderSpec.defaultTrackStrokeWidth;
-            final shouldShowThumbFocusEffect =
-                state.focusedThumbIndex == 0 &&
-                RemixFocusHighlightModeProvider.of(context) ==
-                    FocusHighlightMode.traditional;
+            final override = WidgetStateStyleOverride.maybeOf(context);
+            final shouldShowThumbFocusEffect = override != null
+                ? override.states.contains(WidgetState.focused)
+                : state.focusedThumbIndex == 0 &&
+                      RemixFocusHighlightModeProvider.of(context) ==
+                          FocusHighlightMode.traditional;
 
             // Slider height accommodates both thumb and track:
             // - thumb.height + trackThickness: ensures thumb has clearance above/below

--- a/packages/remix/lib/src/utilities/remix_style.dart
+++ b/packages/remix/lib/src/utilities/remix_style.dart
@@ -118,10 +118,7 @@ class RemixStyleSpecBuilder<S extends Spec<S>> extends StatelessWidget {
       );
     }
 
-    if (!trackFocusHighlightMode ||
-        RemixFocusHighlightModeProvider._hasScope(context)) {
-      return result;
-    }
+    if (!trackFocusHighlightMode) return result;
 
     return RemixFocusHighlightModeProvider._(child: result);
   }
@@ -138,12 +135,6 @@ final class RemixFocusHighlightModeProvider extends StatefulWidget {
             .dependOnInheritedWidgetOfExactType<_RemixFocusHighlightModeScope>()
             ?.mode ??
         FocusManager.instance.highlightMode;
-  }
-
-  static bool _hasScope(BuildContext context) {
-    return context
-            .getInheritedWidgetOfExactType<_RemixFocusHighlightModeScope>() !=
-        null;
   }
 
   final Widget child;

--- a/packages/remix/pubspec.yaml
+++ b/packages/remix/pubspec.yaml
@@ -25,7 +25,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  mix: ^2.2.0-beta.3
+  mix: ^2.2.0-beta.4
   mix_annotations: ^2.2.0-beta.1
   naked_ui: ^1.0.0-beta.8
 

--- a/packages/remix/test/components/slider/slider_widget_test.dart
+++ b/packages/remix/test/components/slider/slider_widget_test.dart
@@ -564,6 +564,37 @@ void main() {
           expect(_sliderThumb(tester).containerEffects?.outline.width, 0);
         });
       }
+
+      testWidgets('forced focus state renders the thumb focus effect', (
+        tester,
+      ) async {
+        final previousStrategy = FocusManager.instance.highlightStrategy;
+        addTearDown(() {
+          FocusManager.instance.highlightStrategy = previousStrategy;
+        });
+        FocusManager.instance.highlightStrategy =
+            FocusHighlightStrategy.alwaysTouch;
+        final style = SliderStyler(
+          thumb: BoxStyler().size(20, 20),
+          thumbFocusEffects: RemixBoxEffectsMix(
+            outline: BorderSideMix(
+              color: Colors.red,
+              width: 3,
+              strokeAlign: BorderSide.strokeAlignInside,
+            ),
+          ),
+        );
+
+        await tester.pumpRemixApp(
+          WidgetStateStyleOverride(
+            states: const {WidgetState.focused},
+            child: RemixSlider(value: 0.5, onChanged: (value) {}, style: style),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(_sliderThumb(tester).containerEffects?.outline.width, 3);
+      });
     });
 
     group('Snap Divisions', () {

--- a/packages/remix/test/components/slider/slider_widget_test.dart
+++ b/packages/remix/test/components/slider/slider_widget_test.dart
@@ -519,16 +519,7 @@ void main() {
               FocusHighlightStrategy.alwaysTouch;
           final focusNode = FocusNode();
           addTearDown(focusNode.dispose);
-          final style = SliderStyler(
-            thumb: BoxStyler().size(20, 20),
-            thumbFocusEffects: RemixBoxEffectsMix(
-              outline: BorderSideMix(
-                color: Colors.red,
-                width: 3,
-                strokeAlign: BorderSide.strokeAlignInside,
-              ),
-            ),
-          );
+          final style = _sliderFocusStyle();
 
           await tester.pumpRemixApp(
             Builder(
@@ -574,16 +565,7 @@ void main() {
         });
         FocusManager.instance.highlightStrategy =
             FocusHighlightStrategy.alwaysTouch;
-        final style = SliderStyler(
-          thumb: BoxStyler().size(20, 20),
-          thumbFocusEffects: RemixBoxEffectsMix(
-            outline: BorderSideMix(
-              color: Colors.red,
-              width: 3,
-              strokeAlign: BorderSide.strokeAlignInside,
-            ),
-          ),
-        );
+        final style = _sliderFocusStyle();
 
         await tester.pumpRemixApp(
           WidgetStateStyleOverride(
@@ -891,4 +873,17 @@ RemixBoxWithEffects _sliderThumb(WidgetTester tester) {
       .singleWhere(
         (widget) => widget.styleSpec.spec.constraints?.maxWidth == 20,
       );
+}
+
+SliderStyler _sliderFocusStyle() {
+  return SliderStyler(
+    thumb: BoxStyler().size(20, 20),
+    thumbFocusEffects: RemixBoxEffectsMix(
+      outline: BorderSideMix(
+        color: Colors.red,
+        width: 3,
+        strokeAlign: BorderSide.strokeAlignInside,
+      ),
+    ),
+  );
 }

--- a/packages/remix_fortal/lib/src/recipes/link.dart
+++ b/packages/remix_fortal/lib/src/recipes/link.dart
@@ -124,7 +124,7 @@ BadgeStyler _fortalInteractiveLinkStyle(
     focused: true,
   ).label(.decoration(TextDecoration.none));
   return styleFor()
-      .onHovered(styleFor(hovered: true).onFocusVisible(focusVisible))
+      .onHovered(styleFor(hovered: true))
       .onFocusVisible(focusVisible);
 }
 

--- a/packages/remix_fortal/lib/src/recipes/toggle.dart
+++ b/packages/remix_fortal/lib/src/recipes/toggle.dart
@@ -90,7 +90,10 @@ ToggleStyler _fortalToggleOutlineStyler(
             )
             .borderAll(color: FortalTokens.accentA5())
             .onHovered(ToggleStyler().backgroundColor(FortalTokens.accentA4()))
-            .onPressed(ToggleStyler().backgroundColor(FortalTokens.accentA5())),
+            .onPressed(ToggleStyler().backgroundColor(FortalTokens.accentA5()))
+            // Mix currently gives widget states priority over onFocusVisible;
+            // remove once it sorts variants by widgetStateDependencies.
+            .onFocusVisible(_fortalToggleFocusStyler()),
       )
       .onFocusVisible(_fortalToggleFocusStyler())
       .onDisabled(_fortalToggleDisabledStyler(outlined: true));

--- a/packages/remix_fortal/lib/src/recipes/toggle.dart
+++ b/packages/remix_fortal/lib/src/recipes/toggle.dart
@@ -90,9 +90,7 @@ ToggleStyler _fortalToggleOutlineStyler(
             )
             .borderAll(color: FortalTokens.accentA5())
             .onHovered(ToggleStyler().backgroundColor(FortalTokens.accentA4()))
-            .onPressed(ToggleStyler().backgroundColor(FortalTokens.accentA5()))
-            // Selection resolves after the outer focus style, so reapply it here.
-            .onFocusVisible(_fortalToggleFocusStyler()),
+            .onPressed(ToggleStyler().backgroundColor(FortalTokens.accentA5())),
       )
       .onFocusVisible(_fortalToggleFocusStyler())
       .onDisabled(_fortalToggleDisabledStyler(outlined: true));

--- a/packages/remix_fortal/lib/src/recipes/toggle.dart
+++ b/packages/remix_fortal/lib/src/recipes/toggle.dart
@@ -91,8 +91,7 @@ ToggleStyler _fortalToggleOutlineStyler(
             .borderAll(color: FortalTokens.accentA5())
             .onHovered(ToggleStyler().backgroundColor(FortalTokens.accentA4()))
             .onPressed(ToggleStyler().backgroundColor(FortalTokens.accentA5()))
-            // Mix currently gives widget states priority over onFocusVisible;
-            // remove once it sorts variants by widgetStateDependencies.
+            // Selection resolves after the outer focus style, so reapply it here.
             .onFocusVisible(_fortalToggleFocusStyler()),
       )
       .onFocusVisible(_fortalToggleFocusStyler())

--- a/packages/remix_fortal/pubspec.yaml
+++ b/packages/remix_fortal/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
   # package. `tool/fortal_parity/check.dart` (_checkRemixHostedPin) fails if the
   # two ever fall out of sync.
   remix: ^1.0.0-beta.2 # x-release-please-version
-  mix: ^2.2.0-beta.3
+  mix: ^2.2.0-beta.4
   mix_annotations: ^2.2.0-beta.1
   naked_ui: ^1.0.0-beta.8
 

--- a/packages/remix_fortal/test/components/card/card_fortal_parity_test.dart
+++ b/packages/remix_fortal/test/components/card/card_fortal_parity_test.dart
@@ -1,10 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:remix/remix.dart';
-// `RemixBoxWithEffects` is `@internal` to `remix`, but this sibling package's
-// tests need it to inspect how a Remix component renders a Fortal recipe.
-// Suppressed per-use below, so unrelated internal-member uses remain flagged.
-import 'package:remix/src/rendering/remix_box_effects.dart';
 import 'package:remix_fortal/remix_fortal.dart';
 
 import '../../helpers/test_helpers.dart';
@@ -52,13 +48,8 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      // ignore: invalid_use_of_internal_member
-      final effectsFinder = find.byType(RemixBoxWithEffects);
-      // ignore: invalid_use_of_internal_member
-      final card = tester.widget<RemixBoxWithEffects>(
-        find.descendant(of: find.byType(RemixCard), matching: effectsFinder),
-      );
-      expect(card.containerEffects?.outline.width, 0);
+      final spec = tester.resolvedSpecOf<CardSpec>(find.text('Card'));
+      expect(spec.containerEffects?.outline.width, 0);
     });
   });
 

--- a/packages/remix_fortal/test/components/card/card_fortal_parity_test.dart
+++ b/packages/remix_fortal/test/components/card/card_fortal_parity_test.dart
@@ -1,7 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:remix/remix.dart';
+// `RemixBoxWithEffects` is `@internal` to `remix`, but this sibling package's
+// tests need it to inspect how a Remix component renders a Fortal recipe.
+// Suppressed per-use below, so unrelated internal-member uses remain flagged.
+import 'package:remix/src/rendering/remix_box_effects.dart';
 import 'package:remix_fortal/remix_fortal.dart';
+
+import '../../helpers/test_helpers.dart';
 
 void main() {
   test('public contract has the pinned enum order and defaults', () {
@@ -21,6 +27,39 @@ void main() {
     const card = FortalCard(child: Text('Card'));
     expect(card.size, FortalCardSize.size1);
     expect(card.variant, FortalCardVariant.surface);
+  });
+
+  group('focus-visible behavior', () {
+    late FocusHighlightStrategy previousStrategy;
+
+    setUp(() {
+      previousStrategy = FocusManager.instance.highlightStrategy;
+    });
+
+    tearDown(() {
+      FocusManager.instance.highlightStrategy = previousStrategy;
+    });
+
+    testWidgets('focused card hides its ring in touch mode', (tester) async {
+      FocusManager.instance.highlightStrategy =
+          FocusHighlightStrategy.alwaysTouch;
+
+      await tester.pumpRemixApp(
+        WidgetStateProvider(
+          states: const {WidgetState.focused},
+          child: const FortalCard(child: Text('Card')),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // ignore: invalid_use_of_internal_member
+      final effectsFinder = find.byType(RemixBoxWithEffects);
+      // ignore: invalid_use_of_internal_member
+      final card = tester.widget<RemixBoxWithEffects>(
+        find.descendant(of: find.byType(RemixCard), matching: effectsFinder),
+      );
+      expect(card.containerEffects?.outline.width, 0);
+    });
   });
 
   group('geometry', () {

--- a/packages/remix_fortal/test/components/segmented_control/segmented_control_fortal_parity_test.dart
+++ b/packages/remix_fortal/test/components/segmented_control/segmented_control_fortal_parity_test.dart
@@ -1,10 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:remix/remix.dart';
-// `RemixBoxWithEffects` is `@internal` to `remix`, but this sibling package's
-// tests need it to inspect how a Remix component renders a Fortal recipe.
-// Suppressed per-use below, so unrelated internal-member uses remain flagged.
-import 'package:remix/src/rendering/remix_box_effects.dart';
 import 'package:remix_fortal/remix_fortal.dart';
 
 import '../../helpers/test_helpers.dart';
@@ -46,16 +42,10 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(focusNode.hasFocus, isTrue);
-      // ignore: invalid_use_of_internal_member
-      final effectsFinder = find.byType(RemixBoxWithEffects);
-      // ignore: invalid_use_of_internal_member
-      final item = tester.widget<RemixBoxWithEffects>(
-        find.descendant(
-          of: find.byType(RemixSegmentedControl<String>),
-          matching: effectsFinder,
-        ),
+      final spec = tester.resolvedSpecOf<SegmentedControlItemSpec>(
+        find.text('Alpha'),
       );
-      expect(item.containerEffects?.outline.width, 0);
+      expect(spec.containerEffects?.outline.width, 0);
     });
   });
 

--- a/packages/remix_fortal/test/components/segmented_control/segmented_control_fortal_parity_test.dart
+++ b/packages/remix_fortal/test/components/segmented_control/segmented_control_fortal_parity_test.dart
@@ -1,9 +1,64 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:remix/remix.dart';
+// `RemixBoxWithEffects` is `@internal` to `remix`, but this sibling package's
+// tests need it to inspect how a Remix component renders a Fortal recipe.
+// Suppressed per-use below, so unrelated internal-member uses remain flagged.
+import 'package:remix/src/rendering/remix_box_effects.dart';
 import 'package:remix_fortal/remix_fortal.dart';
 
+import '../../helpers/test_helpers.dart';
+
 void main() {
+  group('focus-visible behavior', () {
+    late FocusHighlightStrategy previousStrategy;
+
+    setUp(() {
+      previousStrategy = FocusManager.instance.highlightStrategy;
+    });
+
+    tearDown(() {
+      FocusManager.instance.highlightStrategy = previousStrategy;
+    });
+
+    testWidgets('focused item hides its ring in touch mode', (tester) async {
+      FocusManager.instance.highlightStrategy =
+          FocusHighlightStrategy.alwaysTouch;
+      final focusNode = FocusNode();
+      addTearDown(focusNode.dispose);
+
+      await tester.pumpRemixApp(
+        FortalSegmentedControl<String>(
+          items: [
+            RemixSegmentedControlItem(
+              value: 'a',
+              label: 'Alpha',
+              focusNode: focusNode,
+            ),
+          ],
+          selectedValue: null,
+          onChanged: (_) {},
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      focusNode.requestFocus();
+      await tester.pumpAndSettle();
+
+      expect(focusNode.hasFocus, isTrue);
+      // ignore: invalid_use_of_internal_member
+      final effectsFinder = find.byType(RemixBoxWithEffects);
+      // ignore: invalid_use_of_internal_member
+      final item = tester.widget<RemixBoxWithEffects>(
+        find.descendant(
+          of: find.byType(RemixSegmentedControl<String>),
+          matching: effectsFinder,
+        ),
+      );
+      expect(item.containerEffects?.outline.width, 0);
+    });
+  });
+
   for (final (size, height, fontSize, paddingX, gap, radius, activeSpacing)
       in const [
         (FortalSegmentedControlSize.size1, 24.0, 12.0, 12.0, 4.0, 4.0, -0.12),

--- a/packages/remix_fortal/test/components/select/select_fortal_parity_test.dart
+++ b/packages/remix_fortal/test/components/select/select_fortal_parity_test.dart
@@ -1,11 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:remix/remix.dart';
-// `RemixFlexBoxWithEffects` is `@internal` to `remix`, but this sibling
-// package's tests need it to inspect how a Remix component renders a Fortal
-// recipe. Suppressed per-use below, so unrelated internal-member uses remain
-// flagged.
-import 'package:remix/src/rendering/remix_box_effects.dart';
 import 'package:remix_fortal/remix_fortal.dart';
 
 import '../../helpers/test_helpers.dart';
@@ -42,16 +37,10 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(focusNode.hasFocus, isTrue);
-      // ignore: invalid_use_of_internal_member
-      final effectsFinder = find.byType(RemixFlexBoxWithEffects);
-      // ignore: invalid_use_of_internal_member
-      final trigger = tester.widget<RemixFlexBoxWithEffects>(
-        find.descendant(
-          of: find.byType(RemixSelect<String>),
-          matching: effectsFinder,
-        ),
+      final spec = tester.resolvedSpecOf<SelectTriggerSpec>(
+        find.text('Choose'),
       );
-      expect(trigger.containerEffects?.overContent, isNull);
+      expect(spec.containerEffects?.overContent, isNull);
     });
   });
 

--- a/packages/remix_fortal/test/components/select/select_fortal_parity_test.dart
+++ b/packages/remix_fortal/test/components/select/select_fortal_parity_test.dart
@@ -1,9 +1,60 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:remix/remix.dart';
+// `RemixFlexBoxWithEffects` is `@internal` to `remix`, but this sibling
+// package's tests need it to inspect how a Remix component renders a Fortal
+// recipe. Suppressed per-use below, so unrelated internal-member uses remain
+// flagged.
+import 'package:remix/src/rendering/remix_box_effects.dart';
 import 'package:remix_fortal/remix_fortal.dart';
 
+import '../../helpers/test_helpers.dart';
+
 void main() {
+  group('focus-visible behavior', () {
+    late FocusHighlightStrategy previousStrategy;
+
+    setUp(() {
+      previousStrategy = FocusManager.instance.highlightStrategy;
+    });
+
+    tearDown(() {
+      FocusManager.instance.highlightStrategy = previousStrategy;
+    });
+
+    testWidgets('focused select hides its ring in touch mode', (tester) async {
+      FocusManager.instance.highlightStrategy =
+          FocusHighlightStrategy.alwaysTouch;
+      final focusNode = FocusNode();
+      addTearDown(focusNode.dispose);
+
+      await tester.pumpRemixApp(
+        FortalSelect<String>(
+          trigger: const RemixSelectTrigger(placeholder: 'Choose'),
+          items: const [RemixSelectItem(value: 'a', label: 'Apple')],
+          onChanged: (_) {},
+          focusNode: focusNode,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      focusNode.requestFocus();
+      await tester.pumpAndSettle();
+
+      expect(focusNode.hasFocus, isTrue);
+      // ignore: invalid_use_of_internal_member
+      final effectsFinder = find.byType(RemixFlexBoxWithEffects);
+      // ignore: invalid_use_of_internal_member
+      final trigger = tester.widget<RemixFlexBoxWithEffects>(
+        find.descendant(
+          of: find.byType(RemixSelect<String>),
+          matching: effectsFinder,
+        ),
+      );
+      expect(trigger.containerEffects?.overContent, isNull);
+    });
+  });
+
   group('Fortal Select geometry', () {
     for (final (size, expected)
         in <

--- a/packages/remix_fortal/test/components/toggle/toggle_widget_test.dart
+++ b/packages/remix_fortal/test/components/toggle/toggle_widget_test.dart
@@ -231,16 +231,8 @@ void main() {
 }
 
 Color? _outlineBorderColor(WidgetTester tester) {
-  for (final box in tester.widgetList<DecoratedBox>(
-    find.descendant(
-      of: find.byType(RemixToggle),
-      matching: find.byType(DecoratedBox),
-    ),
-  )) {
-    final decoration = box.decoration;
-    if (decoration is BoxDecoration && decoration.border is Border) {
-      return (decoration.border! as Border).top.color;
-    }
-  }
-  return null;
+  final spec = tester.resolvedSpecOf<ToggleSpec>(find.text('T'));
+  final decoration = spec.container.spec.box?.spec.decoration;
+  if (decoration is! BoxDecoration || decoration.border is! Border) return null;
+  return (decoration.border! as Border).top.color;
 }

--- a/packages/remix_fortal/test/components/toggle/toggle_widget_test.dart
+++ b/packages/remix_fortal/test/components/toggle/toggle_widget_test.dart
@@ -146,5 +146,101 @@ void main() {
       expect(tester.takeException(), isNull);
       expect(find.byType(Flexible), findsNothing);
     });
+
+    group('focus-visible ring', () {
+      late FocusHighlightStrategy previousStrategy;
+
+      setUp(() {
+        previousStrategy = FocusManager.instance.highlightStrategy;
+      });
+
+      tearDown(() {
+        FocusManager.instance.highlightStrategy = previousStrategy;
+      });
+
+      testWidgets('outline toggle keeps focus ring when selected', (
+        tester,
+      ) async {
+        FocusManager.instance.highlightStrategy =
+            FocusHighlightStrategy.alwaysTraditional;
+        final focusRingColor = await resolveInFortalScope(
+          tester,
+          (context) => MixScope.tokenOf(FortalTokens.focusA8, context),
+        );
+
+        Future<Color?> borderColorFor({required bool selected}) async {
+          final focusNode = FocusNode();
+          addTearDown(focusNode.dispose);
+          await tester.pumpRemixApp(
+            RemixToggle(
+              selected: selected,
+              onChanged: (_) {},
+              label: 'T',
+              focusNode: focusNode,
+              style: fortalToggleStyle(variant: .outline),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          focusNode.requestFocus();
+          await tester.pumpAndSettle();
+
+          expect(focusNode.hasFocus, isTrue);
+          return _outlineBorderColor(tester);
+        }
+
+        final unselected = await borderColorFor(selected: false);
+        final selected = await borderColorFor(selected: true);
+
+        expect(unselected, focusRingColor);
+        expect(
+          selected,
+          unselected,
+          reason: 'focus ring must survive selection',
+        );
+      });
+
+      testWidgets('outline toggle hides focus ring in touch mode', (
+        tester,
+      ) async {
+        FocusManager.instance.highlightStrategy =
+            FocusHighlightStrategy.alwaysTouch;
+        final focusNode = FocusNode();
+        addTearDown(focusNode.dispose);
+
+        await tester.pumpRemixApp(
+          RemixToggle(
+            selected: false,
+            onChanged: (_) {},
+            label: 'T',
+            focusNode: focusNode,
+            style: fortalToggleStyle(variant: .outline),
+          ),
+        );
+        await tester.pumpAndSettle();
+        final unfocused = _outlineBorderColor(tester);
+
+        focusNode.requestFocus();
+        await tester.pumpAndSettle();
+
+        expect(focusNode.hasFocus, isTrue);
+        expect(_outlineBorderColor(tester), unfocused);
+      });
+    });
   });
+}
+
+Color? _outlineBorderColor(WidgetTester tester) {
+  for (final box in tester.widgetList<DecoratedBox>(
+    find.descendant(
+      of: find.byType(RemixToggle),
+      matching: find.byType(DecoratedBox),
+    ),
+  )) {
+    final decoration = box.decoration;
+    if (decoration is BoxDecoration && decoration.border is Border) {
+      return (decoration.border! as Border).top.color;
+    }
+  }
+  return null;
 }

--- a/packages/remix_fortal/test/helpers/test_helpers.dart
+++ b/packages/remix_fortal/test/helpers/test_helpers.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:remix/remix.dart';
 import 'package:remix_fortal/remix_fortal.dart';
 
 /// Fortal's counterpart to `packages/remix/test/helpers/test_helpers.dart`.
@@ -27,6 +28,15 @@ extension WidgetTesterHelpers on WidgetTester {
         ),
       ),
     );
+  }
+
+  /// Returns the resolved Mix spec available to a rendered descendant.
+  S resolvedSpecOf<S extends Spec<S>>(Finder finder) {
+    final context = element(finder);
+    final provider = context
+        .getInheritedWidgetOfExactType<StyleSpecProvider<S>>();
+    expect(provider, isNotNull, reason: 'No StyleSpecProvider<$S> found');
+    return provider!.spec.spec;
   }
 }
 

--- a/packages/remix_fortal/test/helpers/test_helpers.dart
+++ b/packages/remix_fortal/test/helpers/test_helpers.dart
@@ -30,7 +30,7 @@ extension WidgetTesterHelpers on WidgetTester {
     );
   }
 
-  /// Returns the resolved Mix spec available to a rendered descendant.
+  /// Returns the resolved Mix spec for [finder].
   S resolvedSpecOf<S extends Spec<S>>(Finder finder) {
     final context = element(finder);
     final provider = context

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -420,10 +420,10 @@ packages:
     dependency: transitive
     description:
       name: mix
-      sha256: "24149169ecabd6264264afb30bde350a73449f9790f8257578320c26fbc3e72e"
+      sha256: "824337a20e80da644f2ca47d73e8f2b05bd2a2507ba803f952e4a0dae707d308"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0-beta.3"
+    version: "2.2.0-beta.4"
   mix_annotations:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,7 +43,7 @@ melos:
       # tool/check_consumer_mix.dart enforces the same equality for anyone who
       # edits a pubspec without bootstrapping.
       dependencies:
-        mix: ^2.2.0-beta.3
+        mix: ^2.2.0-beta.4
         mix_annotations: ^2.2.0-beta.1
       dev_dependencies:
         mix_generator: ^2.2.0-beta.2


### PR DESCRIPTION
## Description

Correct the focus-visible follow-ups from #125:

- update `mix` to `2.2.0-beta.4`, where state-dependent context variants such as `onFocusVisible` compete with widget-state variants by declaration order
- remove the now-redundant nested focus branches from Fortal Toggle and Link while retaining combined-state regression coverage
- make slider forced-state previews render `thumbFocusEffects` consistently with `FocusVisibleVariant`
- remove the redundant nested focus-highlight scope check and add behavioral touch-mode coverage for toggle, card, select, and segmented control recipes

`RemixSlider` derives its thumb focus effect outside Mix style resolution, so it now treats `WidgetStateStyleOverride` as authoritative just as `FocusVisibleVariant` does. Mix beta.4 fixes focus-visible merge priority upstream, eliminating the consumer-side duplication previously needed when focus competed with selection or hover.

## Validation

- `fvm dart run tool/check_consumer_mix.dart` — both published packages resolve hosted Mix `2.2.0-beta.4` and match their declared constraint
- `fvm dart run melos run ci` — generated sources, docs, Fortal parity, and all 2,899 tests passed
- `fvm flutter analyze` — no issues found

## Related Issues

Follow-up to #125. Uses the variant-ordering fix from conceptadev/mix#1016.

---

## Checklist

**Note**: Updating the `pubspec.yaml` and `CHANGELOG.md` is not required. These are handled automatically during the release process.

- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors.
- [x] I have updated or added relevant documentation (doc comments with `///`).
- [x] I am prepared to follow up on review comments in a timely manner.

## Breaking Change

Does this PR require users of the package to manually update their code?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.
