### PR TITLE
fix(fortal): restore dialog and popover layout defaults

### DIFF
--- a/docs/components/dialog.mdx
+++ b/docs/components/dialog.mdx
@@ -96,8 +96,9 @@ Future<void> showDeleteDialog(BuildContext context) async {
 Remix includes a Fortal-themed widget for this component:
 
 `FortalDialog` defaults to `FortalDialogSize.size3`,
-`FortalDialogAlign.center`, a 600 logical-pixel maximum width, and `modal: true`.
-Set `align: FortalDialogAlign.start` to place the surface at the top instead.
+`FortalDialogAlign.center`, fills the available width up to 600 logical pixels,
+preserves safe viewport insets, and uses `modal: true`. Set
+`align: FortalDialogAlign.start` to place the surface at the safe top inset.
 
 <CodeGroup title="Fortal widget" defaultLanguage="dart">
 ```dart

--- a/docs/components/dialog.mdx
+++ b/docs/components/dialog.mdx
@@ -31,22 +31,20 @@ class DialogExample extends StatelessWidget {
       onPressed: () {
         showRemixDialog(
           context: context,
-          builder: (context) => Center(
-            child: FortalDialog(
-              title: 'Revoke access',
-              description:
-                  'This application will no longer be accessible.',
-              actions: [
-                FortalButton.ghost(
-                  label: 'Cancel',
-                  onPressed: () => Navigator.pop(context),
-                ),
-                FortalButton(
-                  label: 'Revoke access',
-                  onPressed: () => Navigator.pop(context),
-                ),
-              ],
-            ),
+          builder: (context) => FortalDialog(
+            title: 'Revoke access',
+            description:
+                'This application will no longer be accessible.',
+            actions: [
+              FortalButton.ghost(
+                label: 'Cancel',
+                onPressed: () => Navigator.pop(context),
+              ),
+              FortalButton(
+                label: 'Revoke access',
+                onPressed: () => Navigator.pop(context),
+              ),
+            ],
           ),
         );
       },
@@ -74,21 +72,19 @@ Future<void> showDeleteDialog(BuildContext context) async {
   await showRemixAlertDialog<void>(
     context: context,
     semanticLabel: 'Delete project confirmation',
-    builder: (context) => Center(
-      child: FortalDialog(
-        title: 'Delete project?',
-        description: 'This permanently deletes the project and all of its data.',
-        actions: [
-          FortalButton.ghost(
-            label: 'Cancel',
-            onPressed: () => Navigator.pop(context),
-          ),
-          FortalButton(
-            label: 'Delete project',
-            onPressed: () => Navigator.pop(context),
-          ),
-        ],
-      ),
+    builder: (context) => FortalDialog(
+      title: 'Delete project?',
+      description: 'This permanently deletes the project and all of its data.',
+      actions: [
+        FortalButton.ghost(
+          label: 'Cancel',
+          onPressed: () => Navigator.pop(context),
+        ),
+        FortalButton(
+          label: 'Delete project',
+          onPressed: () => Navigator.pop(context),
+        ),
+      ],
     ),
   );
 }
@@ -98,6 +94,10 @@ Future<void> showDeleteDialog(BuildContext context) async {
 ## Fortal widgets
 
 Remix includes a Fortal-themed widget for this component:
+
+`FortalDialog` defaults to `FortalDialogSize.size3`,
+`FortalDialogAlign.center`, a 600 logical-pixel maximum width, and `modal: true`.
+Set `align: FortalDialogAlign.start` to place the surface at the top instead.
 
 <CodeGroup title="Fortal widget" defaultLanguage="dart">
 ```dart
@@ -110,6 +110,7 @@ class FortalDialogExample extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return FortalDialog(
+      align: FortalDialogAlign.center,
       title: 'Confirm changes',
       description: 'Save these settings before leaving?',
       actions: [

--- a/docs/components/popover.mdx
+++ b/docs/components/popover.mdx
@@ -122,8 +122,10 @@ final styledPopover = RemixPopover(
 );
 ```
 
-The `FortalPopover` preset adds Fortal spacing, border, radius, surface color,
-shadow, and a maximum width. Content remains fully composable.
+The `FortalPopover` preset defaults to `FortalPopoverSize.size2`, adds Fortal
+spacing, border, radius, surface color, and shadow, constrains the surface to a
+maximum width of 480 logical pixels, and renders no arrow. Content remains
+fully composable.
 
 ## Keyboard and accessibility
 

--- a/packages/remix_fortal/CHANGELOG.md
+++ b/packages/remix_fortal/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.1.0-beta.1
 
+- **FIX**: Match the pinned Radix Themes dialog and popover layout defaults.
+  `FortalDialog` now defaults to centered placement, exposes `start` and
+  `center` alignment options, and has a 600-pixel maximum width;
+  `FortalPopover` has a 480-pixel maximum width.
 - Initial release. Fortal — the Radix Themes-inspired preset theme for
   [Remix](https://pub.dev/packages/remix) — now ships as its own package.
   `FortalScope`, `FortalTokens`, the `Fortal*` widgets, and the `fortal*Style()`

--- a/packages/remix_fortal/CHANGELOG.md
+++ b/packages/remix_fortal/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 - **FIX**: Match the pinned Radix Themes dialog and popover layout defaults.
   `FortalDialog` now defaults to centered placement, exposes `start` and
-  `center` alignment options, and has a 600-pixel maximum width;
+  `center` alignment options, fills up to 600 pixels, and preserves safe
+  viewport insets;
   `FortalPopover` has a 480-pixel maximum width.
 - Initial release. Fortal — the Radix Themes-inspired preset theme for
   [Remix](https://pub.dev/packages/remix) — now ships as its own package.

--- a/packages/remix_fortal/lib/src/recipes/dialog.dart
+++ b/packages/remix_fortal/lib/src/recipes/dialog.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 import 'package:mix_annotations/mix_annotations.dart';
 import 'package:remix/remix.dart';
@@ -12,10 +14,25 @@ enum FortalDialogSize { size1, size2, size3, size4 }
 /// Fortal dialog vertical alignment matching Radix Themes 3.3.0.
 enum FortalDialogAlign { start, center }
 
+final _dialogViewportInsets = ContextToken<EdgeInsetsGeometry>((context) {
+  final safeArea = MediaQuery.paddingOf(context);
+  final viewportHeight = MediaQuery.sizeOf(context).height;
+  final horizontal = FortalTokens.space4.resolve(context);
+  final vertical = FortalTokens.space6.resolve(context);
+
+  return EdgeInsets.fromLTRB(
+    math.max(safeArea.left, horizontal),
+    math.max(safeArea.top, vertical),
+    math.max(safeArea.right, horizontal),
+    math.max(safeArea.bottom, math.max(vertical, viewportHeight * 0.06)),
+  );
+});
+
 /// Fortal-themed preset for [RemixDialog].
 ///
 /// The generated [FortalDialog] defaults to [FortalDialogSize.size3],
-/// [FortalDialogAlign.center], a 600-pixel maximum width, and a modal dialog.
+/// [FortalDialogAlign.center], fills up to 600 logical pixels, preserves safe
+/// viewport insets, and is modal.
 @MixWidget(target: RemixDialog.new)
 DialogStyler fortalDialogStyle({
   FortalDialogSize size = FortalDialogSize.size3,
@@ -37,7 +54,14 @@ DialogStyler fortalDialogStyle({
   };
 
   return DialogStyler()
-      .wrap(.align(alignment: alignment))
+      .wrap(
+        .modifier(
+          PaddingModifierMix.create(padding: Prop.token(_dialogViewportInsets)),
+        ).align(alignment: alignment).orderOfModifiers([
+          PaddingModifier,
+          AlignModifier,
+        ]),
+      )
       .title(
         .style(FortalTokens.text5.mix())
             .fontWeight(FortalTokens.fontWeightBold())
@@ -58,7 +82,7 @@ DialogStyler fortalDialogStyle({
             .spacing(FortalTokens.space3())
             .marginTop(FortalTokens.space5()),
       )
-      .maxWidth(600)
+      .width(600)
       .padding(.all(padding))
       .borderRadius(.all(radius))
       .color(FortalTokens.colorPanel())

--- a/packages/remix_fortal/lib/src/recipes/dialog.dart
+++ b/packages/remix_fortal/lib/src/recipes/dialog.dart
@@ -9,10 +9,17 @@ part 'dialog.g.dart';
 /// Fortal dialog size presets matching Radix Themes 3.3.0.
 enum FortalDialogSize { size1, size2, size3, size4 }
 
+/// Fortal dialog vertical alignment matching Radix Themes 3.3.0.
+enum FortalDialogAlign { start, center }
+
 /// Fortal-themed preset for [RemixDialog].
+///
+/// The generated [FortalDialog] defaults to [FortalDialogSize.size3],
+/// [FortalDialogAlign.center], a 600-pixel maximum width, and a modal dialog.
 @MixWidget(target: RemixDialog.new)
 DialogStyler fortalDialogStyle({
   FortalDialogSize size = FortalDialogSize.size3,
+  FortalDialogAlign align = FortalDialogAlign.center,
 }) {
   final radius = switch (size) {
     FortalDialogSize.size1 || FortalDialogSize.size2 => FortalTokens.radius4(),
@@ -24,8 +31,13 @@ DialogStyler fortalDialogStyle({
     FortalDialogSize.size3 => FortalTokens.space5(),
     FortalDialogSize.size4 => FortalTokens.space6(),
   };
+  final alignment = switch (align) {
+    FortalDialogAlign.start => Alignment.topCenter,
+    FortalDialogAlign.center => Alignment.center,
+  };
 
   return DialogStyler()
+      .wrap(.align(alignment: alignment))
       .title(
         .style(FortalTokens.text5.mix())
             .fontWeight(FortalTokens.fontWeightBold())
@@ -46,6 +58,7 @@ DialogStyler fortalDialogStyle({
             .spacing(FortalTokens.space3())
             .marginTop(FortalTokens.space5()),
       )
+      .maxWidth(600)
       .padding(.all(padding))
       .borderRadius(.all(radius))
       .color(FortalTokens.colorPanel())

--- a/packages/remix_fortal/lib/src/recipes/dialog.g.dart
+++ b/packages/remix_fortal/lib/src/recipes/dialog.g.dart
@@ -7,10 +7,14 @@ part of 'dialog.dart';
 // **************************************************************************
 
 /// Fortal-themed preset for [RemixDialog].
+///
+/// The generated [FortalDialog] defaults to [FortalDialogSize.size3],
+/// [FortalDialogAlign.center], a 600-pixel maximum width, and a modal dialog.
 class FortalDialog extends StatelessWidget {
   const FortalDialog({
     super.key,
     this.size = FortalDialogSize.size3,
+    this.align = FortalDialogAlign.center,
     this.child,
     this.title,
     this.description,
@@ -21,6 +25,8 @@ class FortalDialog extends StatelessWidget {
   });
 
   final FortalDialogSize size;
+
+  final FortalDialogAlign align;
 
   final Widget? child;
 
@@ -40,7 +46,7 @@ class FortalDialog extends StatelessWidget {
   Widget build(BuildContext context) {
     return RemixDialog(
       key: this.key,
-      style: fortalDialogStyle(size: this.size),
+      style: fortalDialogStyle(size: this.size, align: this.align),
       child: this.child,
       title: this.title,
       description: this.description,

--- a/packages/remix_fortal/lib/src/recipes/dialog.g.dart
+++ b/packages/remix_fortal/lib/src/recipes/dialog.g.dart
@@ -9,7 +9,8 @@ part of 'dialog.dart';
 /// Fortal-themed preset for [RemixDialog].
 ///
 /// The generated [FortalDialog] defaults to [FortalDialogSize.size3],
-/// [FortalDialogAlign.center], a 600-pixel maximum width, and a modal dialog.
+/// [FortalDialogAlign.center], fills up to 600 logical pixels, preserves safe
+/// viewport insets, and is modal.
 class FortalDialog extends StatelessWidget {
   const FortalDialog({
     super.key,

--- a/packages/remix_fortal/lib/src/recipes/popover.dart
+++ b/packages/remix_fortal/lib/src/recipes/popover.dart
@@ -10,6 +10,9 @@ part 'popover.g.dart';
 enum FortalPopoverSize { size1, size2, size3, size4 }
 
 /// Fortal-themed preset for [RemixPopover].
+///
+/// The generated [FortalPopover] defaults to [FortalPopoverSize.size2], a
+/// 480-pixel maximum width, and no arrow.
 @MixWidget(target: RemixPopover.new)
 PopoverStyler fortalPopoverStyle({
   FortalPopoverSize size = FortalPopoverSize.size2,
@@ -28,6 +31,7 @@ PopoverStyler fortalPopoverStyle({
   };
 
   return PopoverStyler()
+      .maxWidth(480)
       .paddingAll(padding)
       .borderRadiusAll(radius)
       .color(FortalTokens.colorPanel())

--- a/packages/remix_fortal/lib/src/recipes/popover.g.dart
+++ b/packages/remix_fortal/lib/src/recipes/popover.g.dart
@@ -7,6 +7,9 @@ part of 'popover.dart';
 // **************************************************************************
 
 /// Fortal-themed preset for [RemixPopover].
+///
+/// The generated [FortalPopover] defaults to [FortalPopoverSize.size2], a
+/// 480-pixel maximum width, and no arrow.
 class FortalPopover extends StatelessWidget {
   const FortalPopover({
     super.key,

--- a/packages/remix_fortal/reference/radix_themes_3_3_0/coverage_evidence.json
+++ b/packages/remix_fortal/reference/radix_themes_3_3_0/coverage_evidence.json
@@ -271,6 +271,11 @@
   "dialog": [
     {
       "test": "test/components/dialog/dialog_widget_test.dart",
+      "case": "public contract has the pinned align order and default",
+      "covers": ["enum:align.start", "enum:align.center"]
+    },
+    {
+      "test": "test/components/dialog/dialog_widget_test.dart",
       "case": "opens and renders alert content",
       "covers": ["state:closed", "state:open"]
     },

--- a/packages/remix_fortal/test/components/dialog/dialog_widget_test.dart
+++ b/packages/remix_fortal/test/components/dialog/dialog_widget_test.dart
@@ -6,19 +6,37 @@ import 'package:remix_fortal/remix_fortal.dart';
 
 import '../../helpers/test_helpers.dart';
 
+Future<Rect> _pumpDialogSurface(
+  WidgetTester tester,
+  FortalDialog dialog, {
+  MediaQueryData? mediaQueryData,
+}) async {
+  Widget child = SizedBox.expand(child: dialog);
+  if (mediaQueryData != null) {
+    child = MediaQuery(data: mediaQueryData, child: child);
+  }
+  await tester.pumpRemixApp(child);
+  await tester.pumpAndSettle();
+
+  final align = find.descendant(
+    of: find.byType(RemixDialog),
+    matching: find.byType(Align),
+  );
+  final surface = tester.widget<Align>(align).child!;
+
+  return tester.getRect(find.byWidget(surface));
+}
+
 void main() {
-  testWidgets('default style constrains the dialog to 600 pixels', (
+  testWidgets('default surface fills available width up to 600 pixels', (
     tester,
   ) async {
-    final resolved = await resolveInFortalScope(
+    final rect = await _pumpDialogSurface(
       tester,
-      (context) => fortalDialogStyle().build(context),
+      const FortalDialog(title: 'Short'),
     );
 
-    expect(
-      resolved.spec.container.spec.constraints,
-      const BoxConstraints(maxWidth: 600),
-    );
+    expect(rect.width, 600);
   });
 
   test('public contract has the pinned align order and default', () {
@@ -31,39 +49,35 @@ void main() {
     expect(dialog.align, FortalDialogAlign.center);
   });
 
-  testWidgets('default alignment centers the rendered surface', (tester) async {
-    await tester.pumpRemixApp(
-      const SizedBox.expand(child: FortalDialog(title: 'Centered')),
-    );
-    await tester.pumpAndSettle();
-
-    final align = find.descendant(
-      of: find.byType(RemixDialog),
-      matching: find.byType(Align),
-    );
-    expect(align, findsOneWidget);
-    expect(tester.widget<Align>(align).alignment, Alignment.center);
-  });
-
-  testWidgets('start alignment places the rendered surface at the top', (
-    tester,
-  ) async {
-    await tester.pumpRemixApp(
-      const SizedBox.expand(
-        child: FortalDialog(
-          align: FortalDialogAlign.start,
-          title: 'Start aligned',
-        ),
+  testWidgets('start alignment respects the safe top inset', (tester) async {
+    final rect = await _pumpDialogSurface(
+      tester,
+      const FortalDialog(
+        align: FortalDialogAlign.start,
+        title: 'Start aligned',
+      ),
+      mediaQueryData: const MediaQueryData(
+        size: Size(800, 600),
+        padding: EdgeInsets.fromLTRB(24, 48, 28, 40),
       ),
     );
-    await tester.pumpAndSettle();
 
-    final align = find.descendant(
-      of: find.byType(RemixDialog),
-      matching: find.byType(Align),
+    expect(rect.top, 48);
+  });
+
+  testWidgets('default alignment centers within the safe padded viewport', (
+    tester,
+  ) async {
+    final rect = await _pumpDialogSurface(
+      tester,
+      const FortalDialog(title: 'Centered safely'),
+      mediaQueryData: const MediaQueryData(
+        size: Size(800, 600),
+        padding: EdgeInsets.fromLTRB(24, 48, 28, 40),
+      ),
     );
-    expect(align, findsOneWidget);
-    expect(tester.widget<Align>(align).alignment, Alignment.topCenter);
+
+    expect(rect.center.dy, 304);
   });
 
   testWidgets('bounded large-text structured content does not overflow', (

--- a/packages/remix_fortal/test/components/dialog/dialog_widget_test.dart
+++ b/packages/remix_fortal/test/components/dialog/dialog_widget_test.dart
@@ -7,6 +7,65 @@ import 'package:remix_fortal/remix_fortal.dart';
 import '../../helpers/test_helpers.dart';
 
 void main() {
+  testWidgets('default style constrains the dialog to 600 pixels', (
+    tester,
+  ) async {
+    final resolved = await resolveInFortalScope(
+      tester,
+      (context) => fortalDialogStyle().build(context),
+    );
+
+    expect(
+      resolved.spec.container.spec.constraints,
+      const BoxConstraints(maxWidth: 600),
+    );
+  });
+
+  test('public contract has the pinned align order and default', () {
+    const dialog = FortalDialog(title: 'Defaults');
+
+    expect(FortalDialogAlign.values, const [
+      FortalDialogAlign.start,
+      FortalDialogAlign.center,
+    ]);
+    expect(dialog.align, FortalDialogAlign.center);
+  });
+
+  testWidgets('default alignment centers the rendered surface', (tester) async {
+    await tester.pumpRemixApp(
+      const SizedBox.expand(child: FortalDialog(title: 'Centered')),
+    );
+    await tester.pumpAndSettle();
+
+    final align = find.descendant(
+      of: find.byType(RemixDialog),
+      matching: find.byType(Align),
+    );
+    expect(align, findsOneWidget);
+    expect(tester.widget<Align>(align).alignment, Alignment.center);
+  });
+
+  testWidgets('start alignment places the rendered surface at the top', (
+    tester,
+  ) async {
+    await tester.pumpRemixApp(
+      const SizedBox.expand(
+        child: FortalDialog(
+          align: FortalDialogAlign.start,
+          title: 'Start aligned',
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final align = find.descendant(
+      of: find.byType(RemixDialog),
+      matching: find.byType(Align),
+    );
+    expect(align, findsOneWidget);
+    expect(tester.widget<Align>(align).alignment, Alignment.topCenter);
+  });
+
   testWidgets('bounded large-text structured content does not overflow', (
     tester,
   ) async {

--- a/packages/remix_fortal/test/components/popover/popover_widget_test.dart
+++ b/packages/remix_fortal/test/components/popover/popover_widget_test.dart
@@ -5,6 +5,20 @@ import 'package:remix_fortal/remix_fortal.dart';
 import '../../helpers/test_helpers.dart';
 
 void main() {
+  testWidgets('default style constrains the popover to 480 pixels', (
+    tester,
+  ) async {
+    final resolved = await resolveInFortalScope(
+      tester,
+      (context) => fortalPopoverStyle().build(context),
+    );
+
+    expect(
+      resolved.spec.container.spec.constraints,
+      const BoxConstraints(maxWidth: 480),
+    );
+  });
+
   testWidgets('FortalPopover supplies the themed overlay style', (
     tester,
   ) async {


### PR DESCRIPTION
## Description

Restores the layout defaults declared by the pinned Radix 3.3.0 parity manifest:

- `FortalDialog` now defaults to centered placement and a maximum width of 600 logical pixels.
- `FortalDialogAlign.start` opts into top-centered placement.
- `FortalPopover` now has a maximum width of 480 logical pixels.
- Generated APIs, parity coverage, widget tests, and documentation now describe and verify the same contract.

Previously, expanding dialog and popover children could produce unconstrained surfaces, and dialog callers had to add their own `Center` wrapper even though centered placement was the declared default.

### Examples

Before, callers centered dialogs manually:

```dart
builder: (context) => Center(
  child: FortalDialog(
    title: 'Confirm changes',
    child: const Text('Review the changes before continuing.'),
  ),
);
```

Now centering and the 600-pixel maximum width are defaults:

```dart
builder: (context) => const FortalDialog(
  title: 'Confirm changes',
  child: Text('Review the changes before continuing.'),
);
```

Top-centered placement is explicit:

```dart
builder: (context) => const FortalDialog(
  align: FortalDialogAlign.start,
  title: 'Confirm changes',
);
```

Popover content is constrained by the Fortal preset even when a child requests more space:

```dart
FortalPopover(
  popoverChild: const SizedBox(width: 640),
  child: const Text('Open'),
);
```

### Validation

- `fvm flutter analyze --fatal-infos` from `packages/remix_fortal`
- `fvm dart run melos run ci --no-select`, including clean code generation, docs validation, Fortal parity checks, and all package tests

## Related Issues

Closes #128.

---

## Checklist

**Note**: Updating the `pubspec.yaml` and `CHANGELOG.md` is not required. These are handled automatically during the release process.

- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors.
- [x] I have updated or added relevant documentation (doc comments with `///`).
- [x] I am prepared to follow up on review comments in a timely manner.

## Breaking Change

Does this PR require users of the package to manually update their code?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.