### PR TITLE
feat(fortal): add chart recipes and dashboard gallery

### DIFF
--- a/apps/dashboard/README.md
+++ b/apps/dashboard/README.md
@@ -1,4 +1,4 @@
-# Remix dashboard
+# Dashboard
 
 A polished product dashboard demonstrating Remix's Fortal theme, components,
 and chart recipes built on `mix_chart`.

--- a/apps/dashboard/README.md
+++ b/apps/dashboard/README.md
@@ -1,6 +1,7 @@
 # Remix dashboard
 
-A polished product dashboard demonstrating Remix's Fortal theme and components.
+A polished product dashboard demonstrating Remix's Fortal theme, components,
+and chart recipes built on `mix_chart`.
 
 ## Preview
 

--- a/apps/dashboard/lib/main.dart
+++ b/apps/dashboard/lib/main.dart
@@ -57,7 +57,7 @@ class _DashboardAppState extends State<DashboardApp>
         radius: _settings.radius,
         scaling: _settings.scaling,
         child: MaterialApp(
-          title: 'Remix Dashboard',
+          title: 'Dashboard',
           debugShowCheckedModeBanner: false,
           scrollBehavior: const AppScrollBehavior(),
           themeMode: _settings.themeMode,

--- a/apps/dashboard/lib/pages/charts_page.dart
+++ b/apps/dashboard/lib/pages/charts_page.dart
@@ -56,7 +56,7 @@ class ChartsPage extends StatelessWidget {
             _ChartSection(
               title: 'Pie & donut',
               description:
-                  'Part-to-whole views with direct labels, legends, badges, and safe empty states.',
+                  'Part-to-whole views with clean legends, interaction, badges, and safe empty states.',
               cards: [
                 _trafficPie(palette),
                 _InteractiveProductMix(palette: palette),
@@ -387,14 +387,14 @@ Widget _trackedBars(List<Color> palette) => _ChartCard(
 );
 
 Widget _trafficPie(List<Color> palette) {
-  final slices = _channelSlices(palette);
+  final slices = _channelSlices();
   return _ChartCard(
     title: 'Traffic channels',
-    description: 'Direct labels use the strongest readable foreground.',
+    description: 'Legend-first labels keep the plot clean and easy to scan.',
     chartPadding: const EdgeInsets.symmetric(horizontal: 18, vertical: 12),
     chart: FortalPieChart(
       palette: palette,
-      showLabels: true,
+      showLabels: false,
       semanticsLabel: 'Traffic share by device',
       slices: slices,
       valueFormatter: (value) => '${value.toInt()}%',
@@ -436,7 +436,7 @@ class _InteractiveProductMixState extends State<_InteractiveProductMix> {
       chartPadding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
       chart: FortalPieChart(
         palette: widget.palette,
-        centerRadius: 52,
+        centerRadius: 40,
         semanticsLabel: 'Product mix',
         slices: slices,
         selectedSliceIds: {?_selected},
@@ -465,7 +465,7 @@ Widget _badgePie(BuildContext context, List<Color> palette) {
   final panel = MixScope.tokenOf(FortalTokens.colorPanel, context);
   final border = MixScope.tokenOf(FortalTokens.grayStroke6, context);
   final iconColor = MixScope.tokenOf(FortalTokens.gray12, context);
-  final base = _channelSlices(palette, showLabels: false);
+  final base = _channelSlices();
   final slices = [
     for (var index = 0; index < base.length; index++)
       PieSlice(
@@ -701,7 +701,7 @@ List<BarGroup> _trackedRevenue(List<Color> palette) {
   ];
 }
 
-List<PieSlice> _channelSlices(List<Color> palette, {bool showLabels = true}) {
+List<PieSlice> _channelSlices() {
   const source = [
     ('mobile', 'Mobile', 46.0),
     ('desktop', 'Desktop', 31.0),
@@ -714,16 +714,7 @@ List<PieSlice> _channelSlices(List<Color> palette, {bool showLabels = true}) {
         id: source[index].$1,
         label: source[index].$2,
         value: source[index].$3,
-        style: PieSliceStyler()
-            .radius(72)
-            .showLabel(showLabels)
-            .labelPosition(0.62)
-            .label(
-              TextStyler()
-                  .style(FortalTokens.text1.mix())
-                  .fontWeight(.w700)
-                  .color(_strongestForeground(palette[index])),
-            ),
+        style: PieSliceStyler().radius(72),
       ),
   ];
 }
@@ -733,35 +724,20 @@ List<PieSlice> _productSlices() => [
     id: 'core',
     label: 'Core',
     value: 54,
-    style: PieSliceStyler().radius(44),
+    style: PieSliceStyler().radius(36),
   ),
   PieSlice(
     id: 'teams',
     label: 'Teams',
     value: 27,
-    style: PieSliceStyler().radius(44),
+    style: PieSliceStyler().radius(36),
   ),
   PieSlice(
     id: 'enterprise',
     label: 'Enterprise',
     value: 19,
-    style: PieSliceStyler().radius(44),
+    style: PieSliceStyler().radius(36),
   ),
 ];
-
-Color _strongestForeground(Color background) {
-  const light = Colors.white;
-  const dark = Colors.black;
-  return _contrastRatio(background, light) >= _contrastRatio(background, dark)
-      ? light
-      : dark;
-}
-
-double _contrastRatio(Color a, Color b) {
-  final lighter = a.computeLuminance() >= b.computeLuminance() ? a : b;
-  final darker = identical(lighter, a) ? b : a;
-  return (lighter.computeLuminance() + 0.05) /
-      (darker.computeLuminance() + 0.05);
-}
 
 const _months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun'];

--- a/apps/dashboard/lib/pages/charts_page.dart
+++ b/apps/dashboard/lib/pages/charts_page.dart
@@ -4,6 +4,7 @@ import 'package:remix/remix.dart';
 import 'package:remix_fortal/remix_fortal.dart';
 
 import '../widgets/chart_legend.dart';
+import '../widgets/dashboard_chart_card.dart';
 import '../widgets/page_header.dart';
 import '../widgets/typography.dart';
 
@@ -116,50 +117,9 @@ class _ChartSection extends StatelessWidget {
   }
 }
 
-class _ChartCard extends StatelessWidget {
-  const _ChartCard({
-    required this.title,
-    required this.description,
-    required this.chart,
-    this.legend,
-    this.chartPadding,
-  });
-
-  final String title;
-  final String description;
-  final Widget chart;
-  final Widget? legend;
-  final EdgeInsets? chartPadding;
-
-  @override
-  Widget build(BuildContext context) {
-    final gap = MixScope.tokenOf(FortalTokens.space4, context);
-    final defaultInset = MixScope.tokenOf(FortalTokens.space2, context);
-
-    return FortalCard(
-      size: .size2,
-      child: Column(
-        crossAxisAlignment: .stretch,
-        children: [
-          CardHeading(title: title, description: description),
-          SizedBox(height: gap),
-          Expanded(
-            child: Padding(
-              padding:
-                  chartPadding ?? EdgeInsets.symmetric(vertical: defaultInset),
-              child: chart,
-            ),
-          ),
-          if (legend case final legend?) ...[SizedBox(height: gap), legend],
-        ],
-      ),
-    );
-  }
-}
-
 Widget _revenueMomentum(List<Color> palette) {
   final color = palette[0];
-  return _ChartCard(
+  return DashboardChartCard(
     title: 'Revenue momentum',
     description: 'Area fill and markers preserve exact point values.',
     chart: FortalLineChart(
@@ -197,7 +157,7 @@ Widget _revenueMomentum(List<Color> palette) {
   );
 }
 
-Widget _linePatterns(List<Color> palette) => _ChartCard(
+Widget _linePatterns(List<Color> palette) => DashboardChartCard(
   title: 'Per-series patterns',
   description: 'Solid circles and dashed squares reinforce color differences.',
   chart: FortalLineChart(
@@ -237,7 +197,7 @@ Widget _linePatterns(List<Color> palette) => _ChartCard(
   ),
 );
 
-Widget _stepGaps(List<Color> palette) => _ChartCard(
+Widget _stepGaps(List<Color> palette) => DashboardChartCard(
   title: 'Steps and gaps',
   description: 'Missing values remain honest gaps instead of invented data.',
   chart: FortalLineChart(
@@ -273,30 +233,33 @@ Widget _stepGaps(List<Color> palette) => _ChartCard(
   ),
 );
 
-Widget _viewportLabels(List<Color> palette) => _ChartCard(
+Widget _viewportLabels(List<Color> palette) => DashboardChartCard(
   title: 'Viewport labels',
   description:
       'Tokenized widget labels stay readable while panning and zooming.',
-  chart: FortalLineChart(
-    palette: palette,
-    showMarkers: true,
-    semanticsLabel: 'Revenue chart with scalable horizontal viewport',
-    series: [
-      LineSeries(
-        id: 'viewport-revenue',
-        label: 'Revenue',
-        points: _points('viewport', [18, 24, 22, 34, 31, 42, 48]),
+  chart: LayoutBuilder(
+    builder: (context, constraints) => FortalLineChart(
+      palette: palette,
+      showMarkers: true,
+      semanticsLabel: 'Revenue chart with scalable horizontal viewport',
+      series: [
+        LineSeries(
+          id: 'viewport-revenue',
+          label: 'Revenue',
+          points: _points('viewport', [18, 24, 22, 34, 31, 42, 48]),
+        ),
+      ],
+      viewport: ChartViewport(axis: .horizontal, maxScale: 3),
+      xAxis: ChartAxis.numeric(
+        min: 0,
+        max: 6,
+        interval: constraints.maxWidth < 360 ? 3 : 1,
+        labelFormatter: _weekdayLabel,
+        labelBuilder: (_, label) =>
+            FortalBadge.soft(size: .size1, label: label.formattedValue),
       ),
-    ],
-    viewport: ChartViewport(axis: .horizontal, maxScale: 3),
-    xAxis: ChartAxis.numeric(
-      min: 0,
-      max: 6,
-      interval: 1,
-      labelFormatter: _weekdayLabel,
-      labelBuilder: (_, label) => FortalBadge.soft(label: label.formattedValue),
+      yAxis: ChartAxis.numeric(min: 0, max: 60, interval: 10),
     ),
-    yAxis: ChartAxis.numeric(min: 0, max: 60, interval: 10),
   ),
   legend: ChartLegend(
     semanticLabel: 'Viewport revenue legend',
@@ -310,7 +273,7 @@ Widget _viewportLabels(List<Color> palette) => _ChartCard(
   ),
 );
 
-Widget _groupedBars(List<Color> palette) => _ChartCard(
+Widget _groupedBars(List<Color> palette) => DashboardChartCard(
   title: 'Actual versus plan',
   description: 'Solid and outlined bars remain distinct without color.',
   chart: FortalBarChart(
@@ -334,7 +297,7 @@ Widget _groupedBars(List<Color> palette) => _ChartCard(
   ),
 );
 
-Widget _stackedBars(List<Color> palette) => _ChartCard(
+Widget _stackedBars(List<Color> palette) => DashboardChartCard(
   title: 'Revenue mix',
   description: 'Stacked segments expose composition and totals together.',
   chart: FortalBarChart(
@@ -352,7 +315,7 @@ Widget _stackedBars(List<Color> palette) => _ChartCard(
   ),
 );
 
-Widget _floatingBars(List<Color> palette) => _ChartCard(
+Widget _floatingBars(List<Color> palette) => DashboardChartCard(
   title: 'Floating changes',
   description: 'Range bars encode gains and declines from a real baseline.',
   chart: FortalBarChart(
@@ -369,7 +332,7 @@ Widget _floatingBars(List<Color> palette) => _ChartCard(
   ),
 );
 
-Widget _trackedBars(List<Color> palette) => _ChartCard(
+Widget _trackedBars(List<Color> palette) => DashboardChartCard(
   title: 'Tracks and labels',
   description: 'Visible tracks provide scale context before interaction.',
   chart: FortalBarChart(
@@ -388,29 +351,21 @@ Widget _trackedBars(List<Color> palette) => _ChartCard(
 
 Widget _trafficPie(List<Color> palette) {
   final slices = _channelSlices();
-  return _ChartCard(
+  return DashboardChartCard(
     title: 'Traffic channels',
     description: 'Legend-first labels keep the plot clean and easy to scan.',
     chartPadding: const EdgeInsets.symmetric(horizontal: 18, vertical: 12),
-    chart: FortalPieChart(
-      palette: palette,
-      showLabels: false,
+    chart: PieChart(
+      style: fortalPieChartStyle(
+        palette: palette,
+      ).slice(PieSliceStyler().radius(72)),
       semanticsLabel: 'Traffic share by device',
       slices: slices,
       valueFormatter: (value) => '${value.toInt()}%',
     ),
     legend: ChartLegend(
       semanticLabel: 'Traffic channel legend',
-      items: [
-        for (var index = 0; index < slices.length; index++)
-          ChartLegendItem(
-            id: slices[index].id.toString(),
-            label: slices[index].label,
-            value: '${slices[index].value.toInt()}%',
-            color: palette[index],
-            pattern: .dot,
-          ),
-      ],
+      items: percentagePieLegendItems(slices: slices, palette: palette),
     ),
   );
 }
@@ -430,13 +385,15 @@ class _InteractiveProductMixState extends State<_InteractiveProductMix> {
   @override
   Widget build(BuildContext context) {
     final slices = _productSlices();
-    return _ChartCard(
+    return DashboardChartCard(
       title: 'Interactive product mix',
       description: 'Selection expands one stable slice and preserves its ID.',
       chartPadding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
-      chart: FortalPieChart(
-        palette: widget.palette,
-        centerRadius: 40,
+      chart: PieChart(
+        style: fortalPieChartStyle(
+          palette: widget.palette,
+          centerRadius: 40,
+        ).slice(PieSliceStyler().radius(36)),
         semanticsLabel: 'Product mix',
         slices: slices,
         selectedSliceIds: {?_selected},
@@ -445,16 +402,10 @@ class _InteractiveProductMixState extends State<_InteractiveProductMix> {
       ),
       legend: ChartLegend(
         semanticLabel: 'Product mix legend',
-        items: [
-          for (var index = 0; index < slices.length; index++)
-            ChartLegendItem(
-              id: slices[index].id.toString(),
-              label: slices[index].label,
-              value: '${slices[index].value.toInt()}%',
-              color: widget.palette[index],
-              pattern: .dot,
-            ),
-        ],
+        items: percentagePieLegendItems(
+          slices: slices,
+          palette: widget.palette,
+        ),
       ),
     );
   }
@@ -472,7 +423,6 @@ Widget _badgePie(BuildContext context, List<Color> palette) {
         id: base[index].id,
         label: base[index].label,
         value: base[index].value,
-        style: PieSliceStyler().radius(48).badgePosition(0.72),
         badge: Box(
           style: BoxStyler()
               .size(26, 26)
@@ -488,34 +438,27 @@ Widget _badgePie(BuildContext context, List<Color> palette) {
       ),
   ];
 
-  return _ChartCard(
+  return DashboardChartCard(
     title: 'Badge markers',
     description: 'Ordinary tokenized widgets can annotate individual slices.',
     chartPadding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
-    chart: FortalPieChart(
-      palette: palette,
-      centerRadius: 34,
+    chart: PieChart(
+      style: fortalPieChartStyle(
+        palette: palette,
+        centerRadius: 34,
+      ).slice(PieSliceStyler().radius(48).badgePosition(0.72)),
       semanticsLabel: 'Device traffic with badge markers',
       slices: slices,
       valueFormatter: (value) => '${value.toInt()}%',
     ),
     legend: ChartLegend(
       semanticLabel: 'Badge marker chart legend',
-      items: [
-        for (var index = 0; index < slices.length; index++)
-          ChartLegendItem(
-            id: slices[index].id.toString(),
-            label: slices[index].label,
-            value: '${slices[index].value.toInt()}%',
-            color: palette[index],
-            pattern: .dot,
-          ),
-      ],
+      items: percentagePieLegendItems(slices: slices, palette: palette),
     ),
   );
 }
 
-Widget _emptyPie(List<Color> palette) => _ChartCard(
+Widget _emptyPie(List<Color> palette) => DashboardChartCard(
   title: 'Safe empty state',
   description: 'Zero-value data produces an explicit, stable empty state.',
   chartPadding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
@@ -637,11 +580,11 @@ List<BarGroup> _stackedRevenue(List<Color> palette) {
 
 List<BarGroup> _floatingChanges(List<Color> palette) {
   const ranges = [
-    (13.0, 18.0),
-    (14.0, 18.0),
+    (12.0, 18.0),
+    (18.0, 14.0),
     (14.0, 22.0),
-    (17.0, 22.0),
-    (18.0, 25.0),
+    (22.0, 17.0),
+    (17.0, 25.0),
     (25.0, 31.0),
   ];
   return [
@@ -714,30 +657,14 @@ List<PieSlice> _channelSlices() {
         id: source[index].$1,
         label: source[index].$2,
         value: source[index].$3,
-        style: PieSliceStyler().radius(72),
       ),
   ];
 }
 
 List<PieSlice> _productSlices() => [
-  PieSlice(
-    id: 'core',
-    label: 'Core',
-    value: 54,
-    style: PieSliceStyler().radius(36),
-  ),
-  PieSlice(
-    id: 'teams',
-    label: 'Teams',
-    value: 27,
-    style: PieSliceStyler().radius(36),
-  ),
-  PieSlice(
-    id: 'enterprise',
-    label: 'Enterprise',
-    value: 19,
-    style: PieSliceStyler().radius(36),
-  ),
+  PieSlice(id: 'core', label: 'Core', value: 54),
+  PieSlice(id: 'teams', label: 'Teams', value: 27),
+  PieSlice(id: 'enterprise', label: 'Enterprise', value: 19),
 ];
 
 const _months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun'];

--- a/apps/dashboard/lib/pages/charts_page.dart
+++ b/apps/dashboard/lib/pages/charts_page.dart
@@ -1,0 +1,767 @@
+import 'package:flutter/material.dart';
+import 'package:mix_chart/mix_chart.dart';
+import 'package:remix/remix.dart';
+import 'package:remix_fortal/remix_fortal.dart';
+
+import '../widgets/chart_legend.dart';
+import '../widgets/page_header.dart';
+import '../widgets/typography.dart';
+
+class ChartsPage extends StatelessWidget {
+  const ChartsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = resolveFortalChartPalette(context);
+    final pageGap = MixScope.tokenOf(FortalTokens.space6, context);
+    final pagePadding = MediaQuery.sizeOf(context).width < 720
+        ? MixScope.tokenOf(FortalTokens.space5, context)
+        : pageGap;
+
+    return KeyedSubtree(
+      key: const ValueKey('charts-page'),
+      child: SingleChildScrollView(
+        padding: EdgeInsets.all(pagePadding),
+        child: Column(
+          crossAxisAlignment: .stretch,
+          spacing: pageGap,
+          children: [
+            const PageHeader(
+              title: 'Charts',
+              description:
+                  'Fortal-native chart patterns for comparison, composition, interaction, and empty states.',
+            ),
+            _ChartSection(
+              title: 'Line & area',
+              description:
+                  'Trends, comparisons, discontinuities, and scalable viewports.',
+              cards: [
+                _revenueMomentum(palette),
+                _linePatterns(palette),
+                _stepGaps(palette),
+                _viewportLabels(palette),
+              ],
+            ),
+            _ChartSection(
+              title: 'Bar charts',
+              description:
+                  'Grouped, stacked, floating, and tracked quantitative comparisons.',
+              cards: [
+                _groupedBars(palette),
+                _stackedBars(palette),
+                _floatingBars(palette),
+                _trackedBars(palette),
+              ],
+            ),
+            _ChartSection(
+              title: 'Pie & donut',
+              description:
+                  'Part-to-whole views with direct labels, legends, badges, and safe empty states.',
+              cards: [
+                _trafficPie(palette),
+                _InteractiveProductMix(palette: palette),
+                _badgePie(context, palette),
+                _emptyPie(palette),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ChartSection extends StatelessWidget {
+  const _ChartSection({
+    required this.title,
+    required this.description,
+    required this.cards,
+  });
+
+  final String title;
+  final String description;
+  final List<Widget> cards;
+
+  @override
+  Widget build(BuildContext context) {
+    final gap = MixScope.tokenOf(FortalTokens.space4, context);
+    final titleGap = MixScope.tokenOf(FortalTokens.space2, context);
+    final cardHeight = 420 * FortalTheme.of(context).scaling.factor;
+    final GridBoxStyler gridStyle = GridBoxStyler.equalColumns(2)
+        .autoRows(GridTrack.fixed(cardHeight))
+        .gap(gap)
+        .onConstraints(
+          const Breakpoint.maxWidth(860),
+          GridBoxStyler.equalColumns(1).gap(gap),
+        );
+
+    return Column(
+      crossAxisAlignment: .stretch,
+      spacing: gap,
+      children: [
+        Column(
+          crossAxisAlignment: .start,
+          spacing: titleGap,
+          children: [
+            SectionLabel(title),
+            StyledText(
+              description,
+              style: dashboardText(FortalTokens.text2, tone: .muted),
+            ),
+          ],
+        ),
+        GridBox(style: gridStyle, children: cards),
+      ],
+    );
+  }
+}
+
+class _ChartCard extends StatelessWidget {
+  const _ChartCard({
+    required this.title,
+    required this.description,
+    required this.chart,
+    this.legend,
+    this.chartPadding,
+  });
+
+  final String title;
+  final String description;
+  final Widget chart;
+  final Widget? legend;
+  final EdgeInsets? chartPadding;
+
+  @override
+  Widget build(BuildContext context) {
+    final gap = MixScope.tokenOf(FortalTokens.space4, context);
+    final defaultInset = MixScope.tokenOf(FortalTokens.space2, context);
+
+    return FortalCard(
+      size: .size2,
+      child: Column(
+        crossAxisAlignment: .stretch,
+        children: [
+          CardHeading(title: title, description: description),
+          SizedBox(height: gap),
+          Expanded(
+            child: Padding(
+              padding:
+                  chartPadding ?? EdgeInsets.symmetric(vertical: defaultInset),
+              child: chart,
+            ),
+          ),
+          if (legend case final legend?) ...[SizedBox(height: gap), legend],
+        ],
+      ),
+    );
+  }
+}
+
+Widget _revenueMomentum(List<Color> palette) {
+  final color = palette[0];
+  return _ChartCard(
+    title: 'Revenue momentum',
+    description: 'Area fill and markers preserve exact point values.',
+    chart: FortalLineChart(
+      palette: palette,
+      showMarkers: true,
+      semanticsLabel: 'Weekly revenue momentum',
+      series: [
+        LineSeries(
+          id: 'revenue',
+          label: 'Revenue',
+          points: _points('revenue', [18, 24, 22, 34, 31, 42, 48]),
+          style: LineSeriesStyler().belowArea(
+            ChartAreaStyler()
+                .show(true)
+                .gradient(
+                  LinearGradient(
+                    begin: Alignment.topCenter,
+                    end: Alignment.bottomCenter,
+                    colors: [
+                      color.withValues(alpha: 0.28),
+                      color.withValues(alpha: 0),
+                    ],
+                  ),
+                ),
+          ),
+        ),
+      ],
+      xAxis: _weekdayAxis(),
+      yAxis: _currencyAxis(max: 60),
+    ),
+    legend: ChartLegend(
+      semanticLabel: 'Revenue series legend',
+      items: [ChartLegendItem(id: 'revenue', label: 'Revenue', color: color)],
+    ),
+  );
+}
+
+Widget _linePatterns(List<Color> palette) => _ChartCard(
+  title: 'Per-series patterns',
+  description: 'Solid circles and dashed squares reinforce color differences.',
+  chart: FortalLineChart(
+    key: const ValueKey('charts-line-patterns'),
+    palette: palette,
+    showMarkers: true,
+    semanticsLabel: 'Weekly actual and planned revenue',
+    series: [
+      LineSeries(
+        id: 'actual',
+        label: 'Actual',
+        points: _points('actual', [18, 24, 22, 34, 31, 42, 48]),
+      ),
+      LineSeries(
+        id: 'plan',
+        label: 'Plan',
+        points: _points('plan', [16, 20, 25, 28, 34, 37, 41]),
+        style: LineSeriesStyler()
+            .stroke(ChartStrokeStyler().dashArray([6, 4]).width(2.5))
+            .marker(ChartMarkerStyler().show(true).shape(.square).radius(3.5)),
+      ),
+    ],
+    xAxis: _weekdayAxis(),
+    yAxis: _currencyAxis(max: 60),
+  ),
+  legend: ChartLegend(
+    semanticLabel: 'Actual and plan line patterns',
+    items: [
+      ChartLegendItem(id: 'actual', label: 'Actual', color: palette[0]),
+      ChartLegendItem(
+        id: 'plan',
+        label: 'Plan',
+        color: palette[1],
+        pattern: .dashed,
+      ),
+    ],
+  ),
+);
+
+Widget _stepGaps(List<Color> palette) => _ChartCard(
+  title: 'Steps and gaps',
+  description: 'Missing values remain honest gaps instead of invented data.',
+  chart: FortalLineChart(
+    palette: palette,
+    showMarkers: true,
+    semanticsLabel: 'Inventory levels with missing observations',
+    series: [
+      LineSeries(
+        id: 'inventory',
+        label: 'Inventory',
+        points: [
+          ChartPoint(id: 'inventory-0', x: 0, y: 32),
+          ChartPoint(id: 'inventory-1', x: 1, y: 27),
+          ChartPoint(id: 'inventory-2', x: 2, y: null),
+          ChartPoint(id: 'inventory-3', x: 3, y: null),
+          ChartPoint(id: 'inventory-4', x: 4, y: 19),
+          ChartPoint(id: 'inventory-5', x: 5, y: 25),
+          ChartPoint(id: 'inventory-6', x: 6, y: 22),
+        ],
+        style: LineSeriesStyler()
+            .curve(.stepAfter)
+            .marker(ChartMarkerStyler().show(true).shape(.square)),
+      ),
+    ],
+    xAxis: _weekdayAxis(),
+    yAxis: ChartAxis.numeric(min: 10, max: 35, interval: 5),
+  ),
+  legend: ChartLegend(
+    semanticLabel: 'Inventory series legend',
+    items: [
+      ChartLegendItem(id: 'inventory', label: 'Inventory', color: palette[0]),
+    ],
+  ),
+);
+
+Widget _viewportLabels(List<Color> palette) => _ChartCard(
+  title: 'Viewport labels',
+  description:
+      'Tokenized widget labels stay readable while panning and zooming.',
+  chart: FortalLineChart(
+    palette: palette,
+    showMarkers: true,
+    semanticsLabel: 'Revenue chart with scalable horizontal viewport',
+    series: [
+      LineSeries(
+        id: 'viewport-revenue',
+        label: 'Revenue',
+        points: _points('viewport', [18, 24, 22, 34, 31, 42, 48]),
+      ),
+    ],
+    viewport: ChartViewport(axis: .horizontal, maxScale: 3),
+    xAxis: ChartAxis.numeric(
+      min: 0,
+      max: 6,
+      interval: 1,
+      labelFormatter: _weekdayLabel,
+      labelBuilder: (_, label) => FortalBadge.soft(label: label.formattedValue),
+    ),
+    yAxis: ChartAxis.numeric(min: 0, max: 60, interval: 10),
+  ),
+  legend: ChartLegend(
+    semanticLabel: 'Viewport revenue legend',
+    items: [
+      ChartLegendItem(
+        id: 'viewport-revenue',
+        label: 'Revenue',
+        color: palette[0],
+      ),
+    ],
+  ),
+);
+
+Widget _groupedBars(List<Color> palette) => _ChartCard(
+  title: 'Actual versus plan',
+  description: 'Solid and outlined bars remain distinct without color.',
+  chart: FortalBarChart(
+    key: const ValueKey('charts-bar-grouped'),
+    palette: palette,
+    semanticsLabel: 'Monthly actual and planned revenue',
+    groups: _groupedRevenue(palette),
+    yAxis: _currencyAxis(max: 70),
+  ),
+  legend: ChartLegend(
+    semanticLabel: 'Actual and plan bar patterns',
+    items: [
+      ChartLegendItem(id: 'actual', label: 'Actual', color: palette[0]),
+      ChartLegendItem(
+        id: 'plan',
+        label: 'Plan',
+        color: palette[1],
+        pattern: .dashed,
+      ),
+    ],
+  ),
+);
+
+Widget _stackedBars(List<Color> palette) => _ChartCard(
+  title: 'Revenue mix',
+  description: 'Stacked segments expose composition and totals together.',
+  chart: FortalBarChart(
+    palette: palette,
+    semanticsLabel: 'Monthly product and services revenue',
+    groups: _stackedRevenue(palette),
+    yAxis: _currencyAxis(max: 70),
+  ),
+  legend: ChartLegend(
+    semanticLabel: 'Revenue mix legend',
+    items: [
+      ChartLegendItem(id: 'product', label: 'Product', color: palette[0]),
+      ChartLegendItem(id: 'services', label: 'Services', color: palette[1]),
+    ],
+  ),
+);
+
+Widget _floatingBars(List<Color> palette) => _ChartCard(
+  title: 'Floating changes',
+  description: 'Range bars encode gains and declines from a real baseline.',
+  chart: FortalBarChart(
+    palette: palette,
+    semanticsLabel: 'Monthly floating inventory changes',
+    groups: _floatingChanges(palette),
+    yAxis: ChartAxis.numeric(min: 10, max: 35, interval: 5),
+  ),
+  legend: ChartLegend(
+    semanticLabel: 'Floating changes legend',
+    items: [
+      ChartLegendItem(id: 'change', label: 'Change range', color: palette[2]),
+    ],
+  ),
+);
+
+Widget _trackedBars(List<Color> palette) => _ChartCard(
+  title: 'Tracks and labels',
+  description: 'Visible tracks provide scale context before interaction.',
+  chart: FortalBarChart(
+    palette: palette,
+    semanticsLabel: 'Monthly revenue against full-scale tracks',
+    groups: _trackedRevenue(palette),
+    yAxis: ChartAxis.numeric(min: 0, max: 70, interval: 10),
+  ),
+  legend: ChartLegend(
+    semanticLabel: 'Tracked revenue legend',
+    items: [
+      ChartLegendItem(id: 'tracked', label: 'Revenue', color: palette[0]),
+    ],
+  ),
+);
+
+Widget _trafficPie(List<Color> palette) {
+  final slices = _channelSlices(palette);
+  return _ChartCard(
+    title: 'Traffic channels',
+    description: 'Direct labels use the strongest readable foreground.',
+    chartPadding: const EdgeInsets.symmetric(horizontal: 18, vertical: 12),
+    chart: FortalPieChart(
+      palette: palette,
+      showLabels: true,
+      semanticsLabel: 'Traffic share by device',
+      slices: slices,
+      valueFormatter: (value) => '${value.toInt()}%',
+    ),
+    legend: ChartLegend(
+      semanticLabel: 'Traffic channel legend',
+      items: [
+        for (var index = 0; index < slices.length; index++)
+          ChartLegendItem(
+            id: slices[index].id.toString(),
+            label: slices[index].label,
+            value: '${slices[index].value.toInt()}%',
+            color: palette[index],
+            pattern: .dot,
+          ),
+      ],
+    ),
+  );
+}
+
+class _InteractiveProductMix extends StatefulWidget {
+  const _InteractiveProductMix({required this.palette});
+
+  final List<Color> palette;
+
+  @override
+  State<_InteractiveProductMix> createState() => _InteractiveProductMixState();
+}
+
+class _InteractiveProductMixState extends State<_InteractiveProductMix> {
+  Object? _selected = 'core';
+
+  @override
+  Widget build(BuildContext context) {
+    final slices = _productSlices();
+    return _ChartCard(
+      title: 'Interactive product mix',
+      description: 'Selection expands one stable slice and preserves its ID.',
+      chartPadding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+      chart: FortalPieChart(
+        palette: widget.palette,
+        centerRadius: 52,
+        semanticsLabel: 'Product mix',
+        slices: slices,
+        selectedSliceIds: {?_selected},
+        onSliceTap: (hit) => setState(() => _selected = hit.sliceId),
+        valueFormatter: (value) => '${value.toInt()}%',
+      ),
+      legend: ChartLegend(
+        semanticLabel: 'Product mix legend',
+        items: [
+          for (var index = 0; index < slices.length; index++)
+            ChartLegendItem(
+              id: slices[index].id.toString(),
+              label: slices[index].label,
+              value: '${slices[index].value.toInt()}%',
+              color: widget.palette[index],
+              pattern: .dot,
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+Widget _badgePie(BuildContext context, List<Color> palette) {
+  const icons = [Icons.phone_iphone, Icons.laptop_mac, Icons.tablet, Icons.tv];
+  final panel = MixScope.tokenOf(FortalTokens.colorPanel, context);
+  final border = MixScope.tokenOf(FortalTokens.grayStroke6, context);
+  final iconColor = MixScope.tokenOf(FortalTokens.gray12, context);
+  final base = _channelSlices(palette, showLabels: false);
+  final slices = [
+    for (var index = 0; index < base.length; index++)
+      PieSlice(
+        id: base[index].id,
+        label: base[index].label,
+        value: base[index].value,
+        style: PieSliceStyler().radius(48).badgePosition(0.72),
+        badge: Box(
+          style: BoxStyler()
+              .size(26, 26)
+              .alignment(.center)
+              .color(panel)
+              .borderAll(color: border)
+              .borderRounded(99),
+          child: StyledIcon(
+            icon: icons[index],
+            style: IconStyler().size(14).color(iconColor),
+          ),
+        ),
+      ),
+  ];
+
+  return _ChartCard(
+    title: 'Badge markers',
+    description: 'Ordinary tokenized widgets can annotate individual slices.',
+    chartPadding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+    chart: FortalPieChart(
+      palette: palette,
+      centerRadius: 34,
+      semanticsLabel: 'Device traffic with badge markers',
+      slices: slices,
+      valueFormatter: (value) => '${value.toInt()}%',
+    ),
+    legend: ChartLegend(
+      semanticLabel: 'Badge marker chart legend',
+      items: [
+        for (var index = 0; index < slices.length; index++)
+          ChartLegendItem(
+            id: slices[index].id.toString(),
+            label: slices[index].label,
+            value: '${slices[index].value.toInt()}%',
+            color: palette[index],
+            pattern: .dot,
+          ),
+      ],
+    ),
+  );
+}
+
+Widget _emptyPie(List<Color> palette) => _ChartCard(
+  title: 'Safe empty state',
+  description: 'Zero-value data produces an explicit, stable empty state.',
+  chartPadding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+  chart: Stack(
+    alignment: .center,
+    children: [
+      FortalPieChart(
+        palette: palette,
+        centerRadius: 52,
+        semanticsLabel: 'No channel data',
+        slices: [PieSlice(id: 'empty', label: 'No data', value: 0)],
+      ),
+      Column(
+        mainAxisSize: .min,
+        spacing: 6,
+        children: [
+          StyledIcon(
+            icon: Icons.inbox_outlined,
+            style: IconStyler().size(20).color(FortalTokens.gray11()),
+          ),
+          StyledText(
+            'No data yet',
+            style: dashboardText(FortalTokens.text1, tone: .muted),
+          ),
+        ],
+      ),
+    ],
+  ),
+);
+
+List<ChartPoint> _points(String id, List<double> values) => [
+  for (final (index, value) in values.indexed)
+    ChartPoint(id: '$id-$index', x: index.toDouble(), y: value),
+];
+
+ChartAxis _weekdayAxis() => ChartAxis.numeric(
+  min: 0,
+  max: 6,
+  interval: 1,
+  labelFormatter: _weekdayLabel,
+);
+
+ChartAxis _currencyAxis({required double max}) => ChartAxis.numeric(
+  min: 0,
+  max: max,
+  interval: 10,
+  labelFormatter: (value) => '\$${value.toInt()}k',
+);
+
+String _weekdayLabel(double value) {
+  const labels = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+  final index = value.round();
+  return index >= 0 && index < labels.length ? labels[index] : '';
+}
+
+List<BarGroup> _groupedRevenue(List<Color> palette) {
+  const actual = <double>[32, 41, 37, 52, 48, 59];
+  const plan = <double>[29, 36, 40, 45, 50, 54];
+  return [
+    for (var index = 0; index < actual.length; index++)
+      BarGroup(
+        id: 'month-$index',
+        label: _months[index],
+        bars: [
+          BarValue(
+            id: 'actual',
+            label: 'Actual',
+            toY: actual[index],
+            style: BarStyler().color(palette[0]),
+          ),
+          BarValue(
+            id: 'plan',
+            label: 'Plan',
+            toY: plan[index],
+            style: BarStyler()
+                .color(palette[1].withValues(alpha: 0.22))
+                .border(BorderSide(color: palette[1], width: 2))
+                .borderDashArray([4, 3]),
+          ),
+        ],
+      ),
+  ];
+}
+
+List<BarGroup> _stackedRevenue(List<Color> palette) {
+  const product = <double>[21, 28, 25, 34, 31, 38];
+  const services = <double>[11, 13, 12, 18, 17, 21];
+  return [
+    for (var index = 0; index < product.length; index++)
+      BarGroup(
+        id: 'stack-$index',
+        label: _months[index],
+        bars: [
+          BarValue(
+            id: 'revenue',
+            label: 'Revenue',
+            toY: product[index] + services[index],
+            segments: [
+              BarSegment(
+                id: 'product',
+                label: 'Product',
+                fromY: 0,
+                toY: product[index],
+                style: BarSegmentStyler().color(palette[0]),
+              ),
+              BarSegment(
+                id: 'services',
+                label: 'Services',
+                fromY: product[index],
+                toY: product[index] + services[index],
+                style: BarSegmentStyler().color(palette[1]),
+              ),
+            ],
+          ),
+        ],
+      ),
+  ];
+}
+
+List<BarGroup> _floatingChanges(List<Color> palette) {
+  const ranges = [
+    (13.0, 18.0),
+    (14.0, 18.0),
+    (14.0, 22.0),
+    (17.0, 22.0),
+    (18.0, 25.0),
+    (25.0, 31.0),
+  ];
+  return [
+    for (var index = 0; index < ranges.length; index++)
+      BarGroup(
+        id: 'floating-$index',
+        label: _months[index],
+        bars: [
+          BarValue(
+            id: 'change',
+            label: 'Change',
+            fromY: ranges[index].$1,
+            toY: ranges[index].$2,
+            style: BarStyler().gradient(
+              LinearGradient(
+                begin: Alignment.bottomCenter,
+                end: Alignment.topCenter,
+                colors: [palette[2], palette[5]],
+              ),
+            ),
+          ),
+        ],
+      ),
+  ];
+}
+
+List<BarGroup> _trackedRevenue(List<Color> palette) {
+  const values = <double>[32, 41, 37, 52, 48, 59];
+  return [
+    for (var index = 0; index < values.length; index++)
+      BarGroup(
+        id: 'tracked-$index',
+        label: _months[index],
+        bars: [
+          BarValue(
+            id: 'tracked',
+            label: 'Revenue',
+            toY: values[index],
+            style: BarStyler()
+                .color(palette[0])
+                .label(
+                  TextStyler()
+                      .style(FortalTokens.text1.mix())
+                      .fontWeight(.w700)
+                      .color(FortalTokens.gray12()),
+                )
+                .background(
+                  BarBackgroundStyler()
+                      .show(true)
+                      .fromY(0)
+                      .toY(70)
+                      .color(FortalTokens.grayA3()),
+                ),
+          ),
+        ],
+      ),
+  ];
+}
+
+List<PieSlice> _channelSlices(List<Color> palette, {bool showLabels = true}) {
+  const source = [
+    ('mobile', 'Mobile', 46.0),
+    ('desktop', 'Desktop', 31.0),
+    ('tablet', 'Tablet', 15.0),
+    ('other', 'Other', 8.0),
+  ];
+  return [
+    for (var index = 0; index < source.length; index++)
+      PieSlice(
+        id: source[index].$1,
+        label: source[index].$2,
+        value: source[index].$3,
+        style: PieSliceStyler()
+            .radius(72)
+            .showLabel(showLabels)
+            .labelPosition(0.62)
+            .label(
+              TextStyler()
+                  .style(FortalTokens.text1.mix())
+                  .fontWeight(.w700)
+                  .color(_strongestForeground(palette[index])),
+            ),
+      ),
+  ];
+}
+
+List<PieSlice> _productSlices() => [
+  PieSlice(
+    id: 'core',
+    label: 'Core',
+    value: 54,
+    style: PieSliceStyler().radius(44),
+  ),
+  PieSlice(
+    id: 'teams',
+    label: 'Teams',
+    value: 27,
+    style: PieSliceStyler().radius(44),
+  ),
+  PieSlice(
+    id: 'enterprise',
+    label: 'Enterprise',
+    value: 19,
+    style: PieSliceStyler().radius(44),
+  ),
+];
+
+Color _strongestForeground(Color background) {
+  const light = Colors.white;
+  const dark = Colors.black;
+  return _contrastRatio(background, light) >= _contrastRatio(background, dark)
+      ? light
+      : dark;
+}
+
+double _contrastRatio(Color a, Color b) {
+  final lighter = a.computeLuminance() >= b.computeLuminance() ? a : b;
+  final darker = identical(lighter, a) ? b : a;
+  return (lighter.computeLuminance() + 0.05) /
+      (darker.computeLuminance() + 0.05);
+}
+
+const _months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun'];

--- a/apps/dashboard/lib/pages/overview_page.dart
+++ b/apps/dashboard/lib/pages/overview_page.dart
@@ -5,6 +5,7 @@ import 'package:remix_fortal/remix_fortal.dart';
 import '../data/activity.dart';
 import '../data/models.dart';
 import '../data/orders.dart';
+import '../widgets/analytics_charts.dart';
 import '../widgets/data_table_cell_text.dart';
 import '../widgets/page_header.dart';
 import '../widgets/stat_card.dart';
@@ -60,6 +61,7 @@ class OverviewPage extends StatelessWidget {
                 ),
               ],
             ),
+            const AnalyticsCharts(),
             if (constraints.maxWidth >= 1050)
               Row(
                 crossAxisAlignment: .start,

--- a/apps/dashboard/lib/shell/dashboard_page.dart
+++ b/apps/dashboard/lib/shell/dashboard_page.dart
@@ -21,6 +21,7 @@ enum DashboardPage {
   customers(DashboardSection.data, 'Customers', Icons.people_outline),
   orders(DashboardSection.data, 'Orders', Icons.receipt_long_outlined),
   settings(DashboardSection.settings, 'Settings', Icons.settings_outlined),
+  charts(DashboardSection.components, 'Charts', Icons.insert_chart_outlined),
   galleryActions(
     DashboardSection.components,
     'Actions',

--- a/apps/dashboard/lib/shell/dashboard_shell.dart
+++ b/apps/dashboard/lib/shell/dashboard_shell.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../pages/charts_page.dart';
 import '../pages/customers_page.dart';
 import '../pages/gallery/gallery_actions_page.dart';
 import '../pages/gallery/gallery_display_page.dart';
@@ -39,6 +40,7 @@ class _DashboardShellState extends State<DashboardShell> {
       CustomersPage(globalQuery: _searchQuery),
       OrdersPage(globalQuery: _searchQuery),
       const SettingsPage(),
+      const ChartsPage(),
       const GalleryActionsPage(),
       const GalleryFormsPage(),
       const GalleryDisplayPage(),

--- a/apps/dashboard/lib/shell/sidebar.dart
+++ b/apps/dashboard/lib/shell/sidebar.dart
@@ -69,19 +69,12 @@ class _Brand extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.all(16),
-      child: Row(
-        spacing: 12,
-        children: [
-          // The brand mark is a solid avatar: accent-9 on accent-contrast,
-          // and it follows the theme's radius setting like every other surface.
-          const FortalAvatar.solid(icon: Icons.auto_awesome, size: .size2),
-          StyledText(
-            'Remix',
-            style: dashboardText(FortalTokens.text5, weight: .w700),
-          ),
-        ],
+    return Box(
+      key: const ValueKey('dashboard-brand'),
+      style: BoxStyler().paddingAll(FortalTokens.space4()),
+      child: StyledText(
+        'Dashboard',
+        style: dashboardText(FortalTokens.text5, weight: .w700),
       ),
     );
   }

--- a/apps/dashboard/lib/widgets/analytics_charts.dart
+++ b/apps/dashboard/lib/widgets/analytics_charts.dart
@@ -4,7 +4,7 @@ import 'package:remix/remix.dart';
 import 'package:remix_fortal/remix_fortal.dart';
 
 import 'chart_legend.dart';
-import 'page_header.dart';
+import 'dashboard_chart_card.dart';
 
 class AnalyticsCharts extends StatelessWidget {
   const AnalyticsCharts({super.key});
@@ -14,179 +14,103 @@ class AnalyticsCharts extends StatelessWidget {
     final palette = resolveFortalChartPalette(context);
     final gap = MixScope.tokenOf(FortalTokens.space4, context);
     final chartInset = MixScope.tokenOf(FortalTokens.space2, context);
-
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        final width = constraints.maxWidth;
-        final columns = width >= 1120
-            ? 3
-            : width >= 720
-            ? 2
-            : 1;
-        final itemWidth = (width - (columns - 1) * gap) / columns;
-
-        return Wrap(
-          spacing: gap,
-          runSpacing: gap,
-          children: [
-            SizedBox(
-              width: itemWidth,
-              child: _AnalyticsCard(
-                title: 'Revenue trend',
-                description: 'Seven-day net revenue',
-                child: FortalLineChart(
-                  palette: palette,
-                  semanticsLabel: 'Seven-day net revenue',
-                  showMarkers: true,
-                  series: [_revenueSeries()],
-                  xAxis: ChartAxis.numeric(
-                    min: 0,
-                    max: 6,
-                    interval: 1,
-                    labelFormatter: _dayLabel,
-                  ),
-                  yAxis: ChartAxis.numeric(
-                    min: 0,
-                    max: 100,
-                    interval: 25,
-                    labelFormatter: _currencyLabel,
-                  ),
-                ),
-              ),
-            ),
-            SizedBox(
-              width: itemWidth,
-              child: _AnalyticsCard(
-                title: 'Order volume',
-                description: 'Actual versus plan',
-                legend: ChartLegend(
-                  key: const ValueKey('overview-order-legend'),
-                  semanticLabel: 'Order volume series',
-                  items: [
-                    ChartLegendItem(
-                      id: 'actual',
-                      label: 'Actual',
-                      color: palette[0],
-                    ),
-                    ChartLegendItem(
-                      id: 'plan',
-                      label: 'Plan',
-                      color: palette[1],
-                      pattern: .dashed,
-                    ),
-                  ],
-                ),
-                child: FortalBarChart(
-                  key: const ValueKey('overview-order-chart'),
-                  palette: palette,
-                  semanticsLabel: 'Quarterly actual and planned orders',
-                  groups: _orderGroups(palette),
-                  xAxis: ChartAxis.numeric(
-                    min: 0,
-                    max: 3,
-                    interval: 1,
-                    labelFormatter: _quarterLabel,
-                  ),
-                  yAxis: ChartAxis.numeric(min: 0, max: 100, interval: 25),
-                ),
-              ),
-            ),
-            SizedBox(
-              width: itemWidth,
-              child: _AnalyticsCard(
-                title: 'Channel mix',
-                description: 'Revenue contribution',
-                chartPadding: EdgeInsets.symmetric(
-                  horizontal: chartInset,
-                  vertical: chartInset,
-                ),
-                chartPaddingKey: const ValueKey(
-                  'overview-channel-chart-safe-area',
-                ),
-                legend: ChartLegend(
-                  key: const ValueKey('overview-channel-legend'),
-                  semanticLabel: 'Revenue contribution legend',
-                  items: [
-                    ChartLegendItem(
-                      id: 'direct',
-                      label: 'Direct',
-                      value: '46%',
-                      color: palette[0],
-                      pattern: .dot,
-                    ),
-                    ChartLegendItem(
-                      id: 'partners',
-                      label: 'Partners',
-                      value: '31%',
-                      color: palette[1],
-                      pattern: .dot,
-                    ),
-                    ChartLegendItem(
-                      id: 'marketplace',
-                      label: 'Marketplace',
-                      value: '23%',
-                      color: palette[2],
-                      pattern: .dot,
-                    ),
-                  ],
-                ),
-                child: FortalPieChart(
-                  palette: palette,
-                  semanticsLabel: 'Revenue contribution by channel',
-                  centerRadius: 44,
-                  slices: _channelSlices(),
-                  valueFormatter: (value) => '${value.toInt()}%',
-                ),
-              ),
-            ),
-          ],
+    final cardPadding = MixScope.tokenOf(FortalTokens.space4, context);
+    final cardHeight = 328 + cardPadding * 2;
+    final slices = _channelSlices();
+    final gridStyle = GridBoxStyler.equalColumns(3)
+        .autoRows(GridTrack.fixed(cardHeight))
+        .gap(gap)
+        .onConstraints(
+          const Breakpoint.maxWidth(1119),
+          GridBoxStyler.equalColumns(2).gap(gap),
+        )
+        .onConstraints(
+          const Breakpoint.maxWidth(719),
+          GridBoxStyler.equalColumns(1).gap(gap),
         );
-      },
-    );
-  }
-}
 
-class _AnalyticsCard extends StatelessWidget {
-  const _AnalyticsCard({
-    required this.title,
-    required this.description,
-    required this.child,
-    this.legend,
-    this.chartPadding = EdgeInsets.zero,
-    this.chartPaddingKey,
-  });
-
-  final String title;
-  final String description;
-  final Widget child;
-  final Widget? legend;
-  final EdgeInsets chartPadding;
-  final Key? chartPaddingKey;
-
-  @override
-  Widget build(BuildContext context) {
-    final gap = MixScope.tokenOf(FortalTokens.space4, context);
-
-    return FortalCard(
-      size: .size2,
-      child: SizedBox(
-        height: 328,
-        child: Column(
-          crossAxisAlignment: .stretch,
-          children: [
-            CardHeading(title: title, description: description),
-            SizedBox(height: gap),
-            Expanded(
-              child: Padding(
-                key: chartPaddingKey,
-                padding: chartPadding,
-                child: child,
-              ),
+    return GridBox(
+      key: const ValueKey('overview-chart-grid'),
+      style: gridStyle,
+      children: [
+        DashboardChartCard(
+          title: 'Revenue trend',
+          description: 'Seven-day net revenue',
+          chartPadding: EdgeInsets.zero,
+          chart: FortalLineChart(
+            palette: palette,
+            semanticsLabel: 'Seven-day net revenue',
+            showMarkers: true,
+            series: [_revenueSeries()],
+            xAxis: ChartAxis.numeric(
+              min: 0,
+              max: 6,
+              interval: 1,
+              labelFormatter: _dayLabel,
             ),
-            if (legend case final legend?) ...[SizedBox(height: gap), legend],
-          ],
+            yAxis: ChartAxis.numeric(
+              min: 0,
+              max: 100,
+              interval: 25,
+              labelFormatter: _currencyLabel,
+            ),
+          ),
         ),
-      ),
+        DashboardChartCard(
+          title: 'Order volume',
+          description: 'Actual versus plan',
+          chartPadding: EdgeInsets.zero,
+          legend: ChartLegend(
+            key: const ValueKey('overview-order-legend'),
+            semanticLabel: 'Order volume series',
+            items: [
+              ChartLegendItem(id: 'actual', label: 'Actual', color: palette[0]),
+              ChartLegendItem(
+                id: 'plan',
+                label: 'Plan',
+                color: palette[1],
+                pattern: .dashed,
+              ),
+            ],
+          ),
+          chart: FortalBarChart(
+            key: const ValueKey('overview-order-chart'),
+            palette: palette,
+            semanticsLabel: 'Quarterly actual and planned orders',
+            groups: _orderGroups(palette),
+            xAxis: ChartAxis.numeric(
+              min: 0,
+              max: 3,
+              interval: 1,
+              labelFormatter: _quarterLabel,
+            ),
+            yAxis: ChartAxis.numeric(min: 0, max: 100, interval: 25),
+          ),
+        ),
+        DashboardChartCard(
+          title: 'Channel mix',
+          description: 'Revenue contribution',
+          chartPadding: EdgeInsets.symmetric(
+            horizontal: chartInset,
+            vertical: chartInset,
+          ),
+          chartPaddingKey: const ValueKey('overview-channel-chart-safe-area'),
+          legend: ChartLegend(
+            key: const ValueKey('overview-channel-legend'),
+            semanticLabel: 'Revenue contribution legend',
+            items: percentagePieLegendItems(slices: slices, palette: palette),
+          ),
+          chart: PieChart(
+            style: fortalPieChartStyle(
+              palette: palette,
+              centerRadius: 44,
+            ).slice(PieSliceStyler().radius(36)),
+            semanticsLabel: 'Revenue contribution by channel',
+            slices: slices,
+            valueFormatter: (value) => '${value.toInt()}%',
+          ),
+        ),
+      ],
     );
   }
 }
@@ -241,24 +165,9 @@ BarGroup _orderGroup(
 );
 
 List<PieSlice> _channelSlices() => [
-  PieSlice(
-    id: 'direct',
-    label: 'Direct',
-    value: 46,
-    style: PieSliceStyler().radius(36),
-  ),
-  PieSlice(
-    id: 'partners',
-    label: 'Partners',
-    value: 31,
-    style: PieSliceStyler().radius(36),
-  ),
-  PieSlice(
-    id: 'marketplace',
-    label: 'Marketplace',
-    value: 23,
-    style: PieSliceStyler().radius(36),
-  ),
+  PieSlice(id: 'direct', label: 'Direct', value: 46),
+  PieSlice(id: 'partners', label: 'Partners', value: 31),
+  PieSlice(id: 'marketplace', label: 'Marketplace', value: 23),
 ];
 
 String _dayLabel(double value) {

--- a/apps/dashboard/lib/widgets/analytics_charts.dart
+++ b/apps/dashboard/lib/widgets/analytics_charts.dart
@@ -1,0 +1,276 @@
+import 'package:flutter/material.dart';
+import 'package:mix_chart/mix_chart.dart';
+import 'package:remix/remix.dart';
+import 'package:remix_fortal/remix_fortal.dart';
+
+import 'chart_legend.dart';
+import 'page_header.dart';
+
+class AnalyticsCharts extends StatelessWidget {
+  const AnalyticsCharts({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = resolveFortalChartPalette(context);
+    final gap = MixScope.tokenOf(FortalTokens.space4, context);
+    final chartInset = MixScope.tokenOf(FortalTokens.space2, context);
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final width = constraints.maxWidth;
+        final columns = width >= 1120
+            ? 3
+            : width >= 720
+            ? 2
+            : 1;
+        final itemWidth = (width - (columns - 1) * gap) / columns;
+
+        return Wrap(
+          spacing: gap,
+          runSpacing: gap,
+          children: [
+            SizedBox(
+              width: itemWidth,
+              child: _AnalyticsCard(
+                title: 'Revenue trend',
+                description: 'Seven-day net revenue',
+                child: FortalLineChart(
+                  palette: palette,
+                  semanticsLabel: 'Seven-day net revenue',
+                  showMarkers: true,
+                  series: [_revenueSeries()],
+                  xAxis: ChartAxis.numeric(
+                    min: 0,
+                    max: 6,
+                    interval: 1,
+                    labelFormatter: _dayLabel,
+                  ),
+                  yAxis: ChartAxis.numeric(
+                    min: 0,
+                    max: 100,
+                    interval: 25,
+                    labelFormatter: _currencyLabel,
+                  ),
+                ),
+              ),
+            ),
+            SizedBox(
+              width: itemWidth,
+              child: _AnalyticsCard(
+                title: 'Order volume',
+                description: 'Actual versus plan',
+                legend: ChartLegend(
+                  key: const ValueKey('overview-order-legend'),
+                  semanticLabel: 'Order volume series',
+                  items: [
+                    ChartLegendItem(
+                      id: 'actual',
+                      label: 'Actual',
+                      color: palette[0],
+                    ),
+                    ChartLegendItem(
+                      id: 'plan',
+                      label: 'Plan',
+                      color: palette[1],
+                      pattern: .dashed,
+                    ),
+                  ],
+                ),
+                child: FortalBarChart(
+                  key: const ValueKey('overview-order-chart'),
+                  palette: palette,
+                  semanticsLabel: 'Quarterly actual and planned orders',
+                  groups: _orderGroups(palette),
+                  xAxis: ChartAxis.numeric(
+                    min: 0,
+                    max: 3,
+                    interval: 1,
+                    labelFormatter: _quarterLabel,
+                  ),
+                  yAxis: ChartAxis.numeric(min: 0, max: 100, interval: 25),
+                ),
+              ),
+            ),
+            SizedBox(
+              width: itemWidth,
+              child: _AnalyticsCard(
+                title: 'Channel mix',
+                description: 'Revenue contribution',
+                chartPadding: EdgeInsets.symmetric(
+                  horizontal: chartInset,
+                  vertical: chartInset,
+                ),
+                chartPaddingKey: const ValueKey(
+                  'overview-channel-chart-safe-area',
+                ),
+                legend: ChartLegend(
+                  key: const ValueKey('overview-channel-legend'),
+                  semanticLabel: 'Revenue contribution legend',
+                  items: [
+                    ChartLegendItem(
+                      id: 'direct',
+                      label: 'Direct',
+                      value: '46%',
+                      color: palette[0],
+                      pattern: .dot,
+                    ),
+                    ChartLegendItem(
+                      id: 'partners',
+                      label: 'Partners',
+                      value: '31%',
+                      color: palette[1],
+                      pattern: .dot,
+                    ),
+                    ChartLegendItem(
+                      id: 'marketplace',
+                      label: 'Marketplace',
+                      value: '23%',
+                      color: palette[2],
+                      pattern: .dot,
+                    ),
+                  ],
+                ),
+                child: FortalPieChart(
+                  palette: palette,
+                  semanticsLabel: 'Revenue contribution by channel',
+                  centerRadius: 44,
+                  slices: _channelSlices(),
+                  valueFormatter: (value) => '${value.toInt()}%',
+                ),
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _AnalyticsCard extends StatelessWidget {
+  const _AnalyticsCard({
+    required this.title,
+    required this.description,
+    required this.child,
+    this.legend,
+    this.chartPadding = EdgeInsets.zero,
+    this.chartPaddingKey,
+  });
+
+  final String title;
+  final String description;
+  final Widget child;
+  final Widget? legend;
+  final EdgeInsets chartPadding;
+  final Key? chartPaddingKey;
+
+  @override
+  Widget build(BuildContext context) {
+    final gap = MixScope.tokenOf(FortalTokens.space4, context);
+
+    return FortalCard(
+      size: .size2,
+      child: SizedBox(
+        height: 328,
+        child: Column(
+          crossAxisAlignment: .stretch,
+          children: [
+            CardHeading(title: title, description: description),
+            SizedBox(height: gap),
+            Expanded(
+              child: Padding(
+                key: chartPaddingKey,
+                padding: chartPadding,
+                child: child,
+              ),
+            ),
+            if (legend case final legend?) ...[SizedBox(height: gap), legend],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+LineSeries _revenueSeries() => LineSeries(
+  id: 'revenue',
+  label: 'Revenue',
+  points: [
+    ChartPoint(id: 'mon', x: 0, y: 42),
+    ChartPoint(id: 'tue', x: 1, y: 54),
+    ChartPoint(id: 'wed', x: 2, y: 48),
+    ChartPoint(id: 'thu', x: 3, y: 66),
+    ChartPoint(id: 'fri', x: 4, y: 62),
+    ChartPoint(id: 'sat', x: 5, y: 78),
+    ChartPoint(id: 'sun', x: 6, y: 84),
+  ],
+);
+
+List<BarGroup> _orderGroups(List<Color> palette) => [
+  _orderGroup('q1', 'Q1', 52, 48, palette),
+  _orderGroup('q2', 'Q2', 68, 64, palette),
+  _orderGroup('q3', 'Q3', 74, 78, palette),
+  _orderGroup('q4', 'Q4', 88, 82, palette),
+];
+
+BarGroup _orderGroup(
+  String id,
+  String label,
+  double actual,
+  double plan,
+  List<Color> palette,
+) => BarGroup(
+  id: id,
+  label: label,
+  bars: [
+    BarValue(
+      id: 'actual',
+      label: 'Actual',
+      toY: actual,
+      style: BarStyler().color(palette[0]),
+    ),
+    BarValue(
+      id: 'plan',
+      label: 'Plan',
+      toY: plan,
+      style: BarStyler()
+          .color(palette[1].withValues(alpha: 0.22))
+          .border(BorderSide(color: palette[1], width: 2))
+          .borderDashArray([4, 3]),
+    ),
+  ],
+);
+
+List<PieSlice> _channelSlices() => [
+  PieSlice(
+    id: 'direct',
+    label: 'Direct',
+    value: 46,
+    style: PieSliceStyler().radius(36),
+  ),
+  PieSlice(
+    id: 'partners',
+    label: 'Partners',
+    value: 31,
+    style: PieSliceStyler().radius(36),
+  ),
+  PieSlice(
+    id: 'marketplace',
+    label: 'Marketplace',
+    value: 23,
+    style: PieSliceStyler().radius(36),
+  ),
+];
+
+String _dayLabel(double value) {
+  const labels = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+  final index = value.round();
+  return index >= 0 && index < labels.length ? labels[index] : '';
+}
+
+String _quarterLabel(double value) {
+  const labels = ['Q1', 'Q2', 'Q3', 'Q4'];
+  final index = value.round();
+  return index >= 0 && index < labels.length ? labels[index] : '';
+}
+
+String _currencyLabel(double value) => '\$${value.toInt()}k';

--- a/apps/dashboard/lib/widgets/chart_legend.dart
+++ b/apps/dashboard/lib/widgets/chart_legend.dart
@@ -51,6 +51,7 @@ class ChartLegend extends StatelessWidget {
               RowBox(
                 style: FlexBoxStyler()
                     .spacing(itemGap)
+                    .mainAxisSize(.min)
                     .crossAxisAlignment(.center),
                 children: [
                   _LegendMark(item),

--- a/apps/dashboard/lib/widgets/chart_legend.dart
+++ b/apps/dashboard/lib/widgets/chart_legend.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:mix_chart/mix_chart.dart';
 import 'package:remix/remix.dart';
 import 'package:remix_fortal/remix_fortal.dart';
 
@@ -23,6 +24,28 @@ final class ChartLegendItem {
   final ChartLegendPattern pattern;
 
   String get displayLabel => value == null ? label : '$label $value';
+}
+
+List<ChartLegendItem> percentagePieLegendItems({
+  required List<PieSlice> slices,
+  required List<Color> palette,
+  ChartLegendPattern pattern = .dot,
+}) {
+  assert(
+    palette.length >= slices.length,
+    'The palette must provide a color for every pie slice.',
+  );
+
+  return List.unmodifiable([
+    for (final (index, slice) in slices.indexed)
+      ChartLegendItem(
+        id: slice.id.toString(),
+        label: slice.label,
+        value: '${slice.value.toInt()}%',
+        color: palette[index],
+        pattern: pattern,
+      ),
+  ]);
 }
 
 class ChartLegend extends StatelessWidget {

--- a/apps/dashboard/lib/widgets/chart_legend.dart
+++ b/apps/dashboard/lib/widgets/chart_legend.dart
@@ -1,0 +1,115 @@
+import 'package:flutter/material.dart';
+import 'package:remix/remix.dart';
+import 'package:remix_fortal/remix_fortal.dart';
+
+import 'typography.dart';
+
+enum ChartLegendPattern { solid, dashed, outlined, dot }
+
+@immutable
+final class ChartLegendItem {
+  const ChartLegendItem({
+    required this.id,
+    required this.label,
+    required this.color,
+    this.value,
+    this.pattern = .solid,
+  });
+
+  final String id;
+  final String label;
+  final String? value;
+  final Color color;
+  final ChartLegendPattern pattern;
+
+  String get displayLabel => value == null ? label : '$label $value';
+}
+
+class ChartLegend extends StatelessWidget {
+  const ChartLegend({
+    super.key,
+    required this.items,
+    required this.semanticLabel,
+  });
+
+  final List<ChartLegendItem> items;
+  final String semanticLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    final itemGap = MixScope.tokenOf(FortalTokens.space2, context);
+    final groupGap = MixScope.tokenOf(FortalTokens.space4, context);
+
+    return Semantics(
+      container: true,
+      label: semanticLabel,
+      child: ExcludeSemantics(
+        child: WrapBox(
+          style: WrapBoxStyler().spacing(groupGap).runSpacing(itemGap),
+          children: [
+            for (final item in items)
+              RowBox(
+                style: FlexBoxStyler()
+                    .spacing(itemGap)
+                    .crossAxisAlignment(.center),
+                children: [
+                  _LegendMark(item),
+                  StyledText(
+                    item.displayLabel,
+                    style: dashboardText(
+                      FortalTokens.text1,
+                      weight: .w500,
+                      tone: .muted,
+                    ),
+                  ),
+                ],
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _LegendMark extends StatelessWidget {
+  const _LegendMark(this.item);
+
+  final ChartLegendItem item;
+
+  @override
+  Widget build(BuildContext context) {
+    final radius = MixScope.tokenOf(FortalTokens.radius2, context).x;
+    final key = ValueKey('legend-pattern-${item.id}-${item.pattern.name}');
+
+    return switch (item.pattern) {
+      .solid => Box(
+        key: key,
+        style: BoxStyler().size(18, 4).color(item.color).borderRounded(radius),
+      ),
+      .dashed => RowBox(
+        key: key,
+        style: FlexBoxStyler().spacing(3).crossAxisAlignment(.center),
+        children: [
+          for (var index = 0; index < 2; index++)
+            Box(
+              style: BoxStyler()
+                  .size(7, 4)
+                  .color(item.color)
+                  .borderRounded(radius),
+            ),
+        ],
+      ),
+      .outlined => Box(
+        key: key,
+        style: BoxStyler()
+            .size(14, 14)
+            .borderAll(color: item.color, width: 2)
+            .borderRounded(radius),
+      ),
+      .dot => Box(
+        key: key,
+        style: BoxStyler().size(10, 10).color(item.color).borderRounded(99),
+      ),
+    };
+  }
+}

--- a/apps/dashboard/lib/widgets/dashboard_chart_card.dart
+++ b/apps/dashboard/lib/widgets/dashboard_chart_card.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:remix/remix.dart';
+import 'package:remix_fortal/remix_fortal.dart';
+
+import 'page_header.dart';
+
+/// Dashboard surface shared by overview and gallery charts.
+class DashboardChartCard extends StatelessWidget {
+  const DashboardChartCard({
+    super.key,
+    required this.title,
+    required this.description,
+    required this.chart,
+    this.legend,
+    this.chartPadding,
+    this.chartPaddingKey,
+  });
+
+  final String title;
+  final String description;
+  final Widget chart;
+  final Widget? legend;
+  final EdgeInsets? chartPadding;
+  final Key? chartPaddingKey;
+
+  @override
+  Widget build(BuildContext context) {
+    final gap = MixScope.tokenOf(FortalTokens.space4, context);
+    final defaultInset = MixScope.tokenOf(FortalTokens.space2, context);
+
+    return FortalCard(
+      size: .size2,
+      child: Column(
+        crossAxisAlignment: .stretch,
+        children: [
+          CardHeading(title: title, description: description),
+          SizedBox(height: gap),
+          Expanded(
+            child: Padding(
+              key: chartPaddingKey,
+              padding:
+                  chartPadding ?? EdgeInsets.symmetric(vertical: defaultInset),
+              child: chart,
+            ),
+          ),
+          if (legend case final legend?) ...[SizedBox(height: gap), legend],
+        ],
+      ),
+    );
+  }
+}

--- a/apps/dashboard/macos/Runner/Configs/AppInfo.xcconfig
+++ b/apps/dashboard/macos/Runner/Configs/AppInfo.xcconfig
@@ -5,7 +5,7 @@
 // 'flutter create' template.
 
 // The application's name. By default this is also the title of the Flutter window.
-PRODUCT_NAME = Remix Dashboard
+PRODUCT_NAME = Dashboard
 
 // The application's bundle identifier
 PRODUCT_BUNDLE_IDENTIFIER = com.bitwild.remix.dashboard

--- a/apps/dashboard/pubspec.yaml
+++ b/apps/dashboard/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
     sdk: flutter
   # Workspace resolution uses the local packages during development; these
   # hosted constraints keep the app manifest deployable outside the workspace.
+  mix_chart: ^0.0.1-beta.0
   remix: ^1.0.0-beta.2
   remix_fortal: ^0.1.0-beta.1
 

--- a/apps/dashboard/pubspec.yaml
+++ b/apps/dashboard/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
   # Workspace resolution uses the local packages during development; these
   # hosted constraints keep the app manifest deployable outside the workspace.
-  mix_chart: ^0.0.1-beta.0
+  mix_chart: ^0.0.1-beta.1
   remix: ^1.0.0-beta.2
   remix_fortal: ^0.1.0-beta.1
 

--- a/apps/dashboard/test/app_smoke_test.dart
+++ b/apps/dashboard/test/app_smoke_test.dart
@@ -23,6 +23,24 @@ void main() {
     expect(find.text('Overview'), findsWidgets);
   });
 
+  testWidgets('uses a text-only Dashboard brand', (tester) async {
+    await tester.pumpWidget(const DashboardApp());
+
+    final app = tester.widget<MaterialApp>(find.byType(MaterialApp));
+    expect(app.title, 'Dashboard');
+
+    final brand = find.byKey(const ValueKey('dashboard-brand'));
+    expect(brand, findsOneWidget);
+    expect(
+      find.descendant(of: brand, matching: find.text('Dashboard')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(of: brand, matching: find.byIcon(Icons.auto_awesome)),
+      findsNothing,
+    );
+  });
+
   testWidgets('account surfaces preserve their avatar and profile triggers', (
     tester,
   ) async {

--- a/apps/dashboard/test/app_smoke_test.dart
+++ b/apps/dashboard/test/app_smoke_test.dart
@@ -5,6 +5,7 @@ import 'package:dashboard/shell/dashboard_shell.dart';
 import 'package:dashboard/theme/theme_settings.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mix_chart/mix_chart.dart';
 import 'package:remix/remix.dart';
 import 'package:remix_fortal/remix_fortal.dart';
 
@@ -192,7 +193,7 @@ void main() {
       expect(find.text('Channel mix'), findsOneWidget);
       expect(find.byType(FortalLineChart), findsOneWidget);
       expect(find.byType(FortalBarChart), findsOneWidget);
-      expect(find.byType(FortalPieChart), findsOneWidget);
+      expect(find.byType(PieChart), findsOneWidget);
       expect(find.text('Recent activity'), findsOneWidget);
       expect(find.text('Recent orders'), findsOneWidget);
       expect(find.text('View all'), findsOneWidget);

--- a/apps/dashboard/test/app_smoke_test.dart
+++ b/apps/dashboard/test/app_smoke_test.dart
@@ -163,16 +163,23 @@ void main() {
     expect(find.text('1–10 of 24'), findsOneWidget);
   });
 
-  testWidgets('overview presents metrics, activity, and recent orders', (
-    tester,
-  ) async {
-    await tester.pumpWidget(const DashboardApp());
+  testWidgets(
+    'overview presents metrics, charts, activity, and recent orders',
+    (tester) async {
+      await tester.pumpWidget(const DashboardApp());
 
-    expect(find.text('\$84,420'), findsOneWidget);
-    expect(find.text('Recent activity'), findsOneWidget);
-    expect(find.text('Recent orders'), findsOneWidget);
-    expect(find.text('View all'), findsOneWidget);
-  });
+      expect(find.text('\$84,420'), findsOneWidget);
+      expect(find.text('Revenue trend'), findsOneWidget);
+      expect(find.text('Order volume'), findsOneWidget);
+      expect(find.text('Channel mix'), findsOneWidget);
+      expect(find.byType(FortalLineChart), findsOneWidget);
+      expect(find.byType(FortalBarChart), findsOneWidget);
+      expect(find.byType(FortalPieChart), findsOneWidget);
+      expect(find.text('Recent activity'), findsOneWidget);
+      expect(find.text('Recent orders'), findsOneWidget);
+      expect(find.text('View all'), findsOneWidget);
+    },
+  );
 
   testWidgets('a status reads the same on every page that shows it', (
     tester,
@@ -309,6 +316,8 @@ void main() {
       'customers': 'Manage customer access, plans, and account status.',
       'orders': 'Review transactions and fulfillment status.',
       'settings': 'Manage your profile, preferences, and workspace.',
+      'charts':
+          'Fortal-native chart patterns for comparison, composition, interaction, and empty states.',
       'galleryActions':
           'Interactive actions across every Fortal variant and size.',
       'galleryForms':
@@ -396,9 +405,7 @@ void main() {
     await tester.pump();
     expect(find.text('10 selected'), findsOneWidget);
 
-    final next = find
-        .byKey(const ValueKey('remix-data-table-next-page'))
-        .first;
+    final next = find.byKey(const ValueKey('remix-data-table-next-page')).first;
     await tester.ensureVisible(next);
     await tester.tap(next);
     await tester.pump();

--- a/apps/dashboard/test/chart_gallery_test.dart
+++ b/apps/dashboard/test/chart_gallery_test.dart
@@ -1,5 +1,6 @@
 import 'package:dashboard/main.dart';
 import 'package:dashboard/theme/theme_settings.dart';
+import 'package:dashboard/widgets/analytics_charts.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mix_chart/mix_chart.dart';
@@ -31,7 +32,8 @@ void main() {
     );
     expect(find.byType(FortalLineChart), findsNWidgets(4));
     expect(find.byType(FortalBarChart), findsNWidgets(4));
-    expect(find.byType(FortalPieChart), findsNWidgets(4));
+    expect(find.byType(PieChart), findsNWidgets(4));
+    expect(find.byType(FortalPieChart), findsOneWidget);
 
     for (final title in const [
       'Revenue momentum',
@@ -77,10 +79,8 @@ void main() {
     )) {
       expect(chart.palette, palette);
     }
-    for (final chart in tester.widgetList<FortalPieChart>(
-      find.byType(FortalPieChart),
-    )) {
-      expect(chart.palette, palette);
+    for (final chart in tester.widgetList<PieChart>(find.byType(PieChart))) {
+      expect(chart.style.build(context).spec.palette, palette);
     }
 
     final quantitativeAxes = <ChartAxis>[
@@ -120,20 +120,17 @@ void main() {
     expect(planBar.borderDashArray, [4, 3]);
     expect(planBar.border!.color, palette[1]);
 
-    final badgeChart = tester
-        .widgetList<FortalPieChart>(find.byType(FortalPieChart))
-        .singleWhere(
-          (chart) =>
-              chart.slices.isNotEmpty &&
-              chart.slices.every((slice) => slice.badge != null),
-        );
-    for (final slice in badgeChart.slices) {
-      final badgeSpec = slice.style!.resolve(context).spec;
-      final badgePosition = badgeSpec.badgePosition;
-      expect(badgePosition, lessThanOrEqualTo(0.75));
-      expect(badgeSpec.radius, isNotNull);
-      expect(badgeSpec.radius!, lessThanOrEqualTo(48));
-    }
+    final badgeChart = tester.widget<PieChart>(
+      find.byWidgetPredicate(
+        (widget) =>
+            widget is PieChart &&
+            widget.semanticsLabel == 'Device traffic with badge markers',
+      ),
+    );
+    final badgeSpec = badgeChart.style.build(context).spec.slice!.spec;
+    expect(badgeSpec.badgePosition, 0.72);
+    expect(badgeSpec.radius, 48);
+    expect(badgeChart.slices.every((slice) => slice.style == null), isTrue);
 
     expect(
       find.byKey(const ValueKey('legend-pattern-plan-dashed')),
@@ -154,20 +151,21 @@ void main() {
     final padding = tester.widget<Padding>(safeArea).padding as EdgeInsets;
     expect(padding.vertical, greaterThanOrEqualTo(16));
 
-    final donut = tester.widget<FortalPieChart>(
+    final donut = tester.widget<PieChart>(
       find.byWidgetPredicate(
         (widget) =>
-            widget is FortalPieChart &&
+            widget is PieChart &&
             widget.semanticsLabel == 'Revenue contribution by channel',
       ),
     );
-    expect(donut.slices.every((slice) => slice.style != null), isTrue);
     final donutContext = tester.element(safeArea);
-    for (final slice in donut.slices) {
-      final radius = slice.style!.resolve(donutContext).spec.radius;
-      expect(radius, isNotNull);
-      expect(donut.centerRadius + radius!, lessThanOrEqualTo(80));
-    }
+    final donutSpec = donut.style.build(donutContext).spec;
+    expect(donut.slices.every((slice) => slice.style == null), isTrue);
+    expect(donutSpec.slice!.spec.radius, 36);
+    expect(
+      donutSpec.centerRadius! + donutSpec.slice!.spec.radius!,
+      lessThanOrEqualTo(80),
+    );
 
     expect(find.byKey(const ValueKey('overview-order-legend')), findsOneWidget);
     expect(
@@ -189,14 +187,24 @@ void main() {
   testWidgets('traffic pie keeps names in its clean legend', (tester) async {
     await _pumpCompactCharts(tester);
 
-    final traffic = tester.widget<FortalPieChart>(
+    final traffic = tester.widget<PieChart>(
       find.byWidgetPredicate(
         (widget) =>
-            widget is FortalPieChart &&
+            widget is PieChart &&
             widget.semanticsLabel == 'Traffic share by device',
       ),
     );
-    expect(traffic.showLabels, isFalse);
+    final trafficContext = tester.element(
+      find.byWidgetPredicate(
+        (widget) =>
+            widget is PieChart &&
+            widget.semanticsLabel == 'Traffic share by device',
+      ),
+    );
+    final trafficSpec = traffic.style.build(trafficContext).spec;
+    expect(trafficSpec.slice!.spec.showLabel, isFalse);
+    expect(trafficSpec.slice!.spec.radius, 72);
+    expect(traffic.slices.every((slice) => slice.style == null), isTrue);
 
     expect(tester.takeException(), isNull);
   });
@@ -207,28 +215,22 @@ void main() {
     await _pumpCompactCharts(tester);
 
     final interactiveFinder = find.byWidgetPredicate(
-      (widget) =>
-          widget is FortalPieChart && widget.semanticsLabel == 'Product mix',
+      (widget) => widget is PieChart && widget.semanticsLabel == 'Product mix',
     );
-    final interactive = tester.widget<FortalPieChart>(interactiveFinder);
+    final interactive = tester.widget<PieChart>(interactiveFinder);
     final availableRadius = tester.getSize(interactiveFinder).shortestSide / 2;
     final chartContext = tester.element(interactiveFinder);
+    final chartSpec = interactive.style.build(chartContext).spec;
 
-    const selectedSliceExpansion = 8.0;
     const visualClearance = 4.0;
-    for (final slice in interactive.slices.where(
-      (slice) => interactive.selectedSliceIds.contains(slice.id),
-    )) {
-      final radius = slice.style!.resolve(chartContext).spec.radius;
-      expect(radius, isNotNull);
-      expect(
-        interactive.centerRadius +
-            radius! +
-            selectedSliceExpansion +
-            visualClearance,
-        lessThanOrEqualTo(availableRadius),
-      );
-    }
+    expect(interactive.selectedSliceIds, isNotEmpty);
+    expect(
+      chartSpec.centerRadius! +
+          chartSpec.slice!.spec.radius! +
+          chartSpec.selectedSliceRadiusOffset! +
+          visualClearance,
+      lessThanOrEqualTo(availableRadius),
+    );
 
     expect(tester.takeException(), isNull);
   });
@@ -244,6 +246,109 @@ void main() {
 
     expect(teamsCenter.dy, closeTo(coreCenter.dy, 0.5));
     expect(enterpriseCenter.dy - coreCenter.dy, lessThanOrEqualTo(24.5));
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('floating bars preserve gains and genuine declines', (
+    tester,
+  ) async {
+    await _pumpCompactCharts(tester);
+
+    final chart = tester.widget<FortalBarChart>(
+      find.byWidgetPredicate(
+        (widget) =>
+            widget is FortalBarChart &&
+            widget.semanticsLabel == 'Monthly floating inventory changes',
+      ),
+    );
+    final ranges = [
+      for (final group in chart.groups)
+        (group.bars.single.fromY, group.bars.single.toY),
+    ];
+
+    expect(ranges, const [
+      (12.0, 18.0),
+      (18.0, 14.0),
+      (14.0, 22.0),
+      (22.0, 17.0),
+      (17.0, 25.0),
+      (25.0, 31.0),
+    ]);
+    expect(ranges.where((range) => range.$2 < range.$1), hasLength(2));
+  });
+
+  testWidgets('compact viewport badges do not overlap adjacent labels', (
+    tester,
+  ) async {
+    await _pumpCompactCharts(tester);
+
+    final viewportChart = find.byWidgetPredicate(
+      (widget) =>
+          widget is FortalLineChart &&
+          widget.semanticsLabel ==
+              'Revenue chart with scalable horizontal viewport',
+    );
+    final badges = find.descendant(
+      of: viewportChart,
+      matching: find.byType(FortalBadge),
+    );
+    expect(badges, findsWidgets);
+    for (final badge in tester.widgetList<FortalBadge>(badges)) {
+      expect(badge.size, FortalBadgeSize.size1);
+    }
+
+    final rects = [
+      for (final element in badges.evaluate())
+        tester.getRect(find.byWidget(element.widget)),
+    ]..sort((left, right) => left.left.compareTo(right.left));
+    for (var index = 1; index < rects.length; index++) {
+      expect(
+        rects[index - 1].overlaps(rects[index]),
+        isFalse,
+        reason: '${rects[index - 1]} overlaps ${rects[index]}',
+      );
+    }
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('overview charts use a three two one responsive grid', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(1400, 1400);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    Future<List<Offset>> pumpAt(double width) async {
+      await tester.pumpWidget(
+        FortalScope(
+          child: MaterialApp(
+            home: Align(
+              alignment: Alignment.topLeft,
+              child: SizedBox(width: width, child: const AnalyticsCharts()),
+            ),
+          ),
+        ),
+      );
+      expect(find.byKey(const ValueKey('overview-chart-grid')), findsOneWidget);
+      return [
+        tester.getCenter(find.text('Revenue trend')),
+        tester.getCenter(find.text('Order volume')),
+        tester.getCenter(find.text('Channel mix')),
+      ];
+    }
+
+    final wide = await pumpAt(1200);
+    expect(wide[1].dy, closeTo(wide[0].dy, 0.5));
+    expect(wide[2].dy, closeTo(wide[0].dy, 0.5));
+
+    final medium = await pumpAt(1000);
+    expect(medium[1].dy, closeTo(medium[0].dy, 0.5));
+    expect(medium[2].dy, greaterThan(medium[0].dy));
+
+    final compact = await pumpAt(700);
+    expect(compact[1].dy, greaterThan(compact[0].dy));
+    expect(compact[2].dy, greaterThan(compact[1].dy));
     expect(tester.takeException(), isNull);
   });
 }

--- a/apps/dashboard/test/chart_gallery_test.dart
+++ b/apps/dashboard/test/chart_gallery_test.dart
@@ -1,0 +1,213 @@
+import 'package:dashboard/main.dart';
+import 'package:dashboard/theme/theme_settings.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mix_chart/mix_chart.dart';
+import 'package:remix_fortal/remix_fortal.dart';
+
+void main() {
+  testWidgets('charts destination presents every Fortal chart family', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(1440, 1200);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      const DashboardApp(initialSettings: ThemeSettings(appearance: .light)),
+    );
+
+    final destination = find.byKey(const ValueKey('nav-charts'));
+    expect(destination, findsOneWidget);
+    await tester.tap(destination);
+    await tester.pump();
+
+    expect(
+      find.text(
+        'Fortal-native chart patterns for comparison, composition, interaction, and empty states.',
+      ),
+      findsOneWidget,
+    );
+    expect(find.byType(FortalLineChart), findsNWidgets(4));
+    expect(find.byType(FortalBarChart), findsNWidgets(4));
+    expect(find.byType(FortalPieChart), findsNWidgets(4));
+
+    for (final title in const [
+      'Revenue momentum',
+      'Per-series patterns',
+      'Steps and gaps',
+      'Viewport labels',
+      'Actual versus plan',
+      'Revenue mix',
+      'Floating changes',
+      'Tracks and labels',
+      'Traffic channels',
+      'Interactive product mix',
+      'Badge markers',
+      'Safe empty state',
+    ]) {
+      expect(find.text(title), findsOneWidget, reason: title);
+    }
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('gallery colors and comparison patterns follow Fortal', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const DashboardApp(
+        initialSettings: ThemeSettings(appearance: .dark, accentColor: .orange),
+      ),
+    );
+    await tester.tap(find.byKey(const ValueKey('nav-charts')));
+    await tester.pump();
+
+    final page = find.byKey(const ValueKey('charts-page'));
+    final context = tester.element(page);
+    final palette = resolveFortalChartPalette(context);
+
+    for (final chart in tester.widgetList<FortalLineChart>(
+      find.byType(FortalLineChart),
+    )) {
+      expect(chart.palette, palette);
+    }
+    for (final chart in tester.widgetList<FortalBarChart>(
+      find.byType(FortalBarChart),
+    )) {
+      expect(chart.palette, palette);
+    }
+    for (final chart in tester.widgetList<FortalPieChart>(
+      find.byType(FortalPieChart),
+    )) {
+      expect(chart.palette, palette);
+    }
+
+    final quantitativeAxes = <ChartAxis>[
+      for (final chart in tester.widgetList<FortalLineChart>(
+        find.byType(FortalLineChart),
+      ))
+        ?chart.yAxis,
+      for (final chart in tester.widgetList<FortalBarChart>(
+        find.byType(FortalBarChart),
+      ))
+        ?chart.yAxis,
+    ];
+    for (final axis in quantitativeAxes) {
+      final tickCount = (axis.max! - axis.min!) / axis.interval!;
+      expect(tickCount, closeTo(tickCount.roundToDouble(), 0.0001));
+    }
+
+    final comparison = tester.widget<FortalLineChart>(
+      find.byWidgetPredicate(
+        (widget) =>
+            widget is FortalLineChart &&
+            widget.key == const ValueKey('charts-line-patterns'),
+      ),
+    );
+    final planLine = comparison.series.last.style!.resolve(context).spec;
+    expect(planLine.stroke!.spec.dashArray, [6, 4]);
+    expect(planLine.marker!.spec.shape, ChartMarkerShape.square);
+
+    final grouped = tester.widget<FortalBarChart>(
+      find.byWidgetPredicate(
+        (widget) =>
+            widget is FortalBarChart &&
+            widget.key == const ValueKey('charts-bar-grouped'),
+      ),
+    );
+    final planBar = grouped.groups.first.bars.last.style!.resolve(context).spec;
+    expect(planBar.borderDashArray, [4, 3]);
+    expect(planBar.border!.color, palette[1]);
+
+    final badgeChart = tester
+        .widgetList<FortalPieChart>(find.byType(FortalPieChart))
+        .singleWhere(
+          (chart) =>
+              chart.slices.isNotEmpty &&
+              chart.slices.every((slice) => slice.badge != null),
+        );
+    for (final slice in badgeChart.slices) {
+      final badgeSpec = slice.style!.resolve(context).spec;
+      final badgePosition = badgeSpec.badgePosition;
+      expect(badgePosition, lessThanOrEqualTo(0.75));
+      expect(badgeSpec.radius, isNotNull);
+      expect(badgeSpec.radius!, lessThanOrEqualTo(48));
+    }
+
+    final labeledPie = tester
+        .widgetList<FortalPieChart>(find.byType(FortalPieChart))
+        .singleWhere((chart) => chart.showLabels);
+    for (final (index, slice) in labeledPie.slices.indexed) {
+      final labelColor = slice.style!
+          .resolve(context)
+          .spec
+          .label!
+          .spec
+          .style!
+          .color!;
+      expect(
+        _contrastRatio(labelColor, palette[index]),
+        greaterThanOrEqualTo(4.5),
+      );
+    }
+
+    expect(
+      find.byKey(const ValueKey('legend-pattern-plan-dashed')),
+      findsWidgets,
+    );
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('overview donut has safe space and visible data legends', (
+    tester,
+  ) async {
+    await tester.pumpWidget(const DashboardApp());
+
+    final safeArea = find.byKey(
+      const ValueKey('overview-channel-chart-safe-area'),
+    );
+    expect(safeArea, findsOneWidget);
+    final padding = tester.widget<Padding>(safeArea).padding as EdgeInsets;
+    expect(padding.vertical, greaterThanOrEqualTo(16));
+
+    final donut = tester.widget<FortalPieChart>(
+      find.byWidgetPredicate(
+        (widget) =>
+            widget is FortalPieChart &&
+            widget.semanticsLabel == 'Revenue contribution by channel',
+      ),
+    );
+    expect(donut.slices.every((slice) => slice.style != null), isTrue);
+    final donutContext = tester.element(safeArea);
+    for (final slice in donut.slices) {
+      final radius = slice.style!.resolve(donutContext).spec.radius;
+      expect(radius, isNotNull);
+      expect(donut.centerRadius + radius!, lessThanOrEqualTo(80));
+    }
+
+    expect(find.byKey(const ValueKey('overview-order-legend')), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('overview-channel-legend')),
+      findsOneWidget,
+    );
+    for (final label in const [
+      'Actual',
+      'Plan',
+      'Direct 46%',
+      'Partners 31%',
+      'Marketplace 23%',
+    ]) {
+      expect(find.text(label), findsOneWidget, reason: label);
+    }
+    expect(tester.takeException(), isNull);
+  });
+}
+
+double _contrastRatio(Color a, Color b) {
+  final aLuminance = a.computeLuminance();
+  final bLuminance = b.computeLuminance();
+  final lighter = aLuminance >= bLuminance ? aLuminance : bLuminance;
+  final darker = aLuminance >= bLuminance ? bLuminance : aLuminance;
+  return (lighter + 0.05) / (darker + 0.05);
+}

--- a/apps/dashboard/test/chart_gallery_test.dart
+++ b/apps/dashboard/test/chart_gallery_test.dart
@@ -135,23 +135,6 @@ void main() {
       expect(badgeSpec.radius!, lessThanOrEqualTo(48));
     }
 
-    final labeledPie = tester
-        .widgetList<FortalPieChart>(find.byType(FortalPieChart))
-        .singleWhere((chart) => chart.showLabels);
-    for (final (index, slice) in labeledPie.slices.indexed) {
-      final labelColor = slice.style!
-          .resolve(context)
-          .spec
-          .label!
-          .spec
-          .style!
-          .color!;
-      expect(
-        _contrastRatio(labelColor, palette[index]),
-        greaterThanOrEqualTo(4.5),
-      );
-    }
-
     expect(
       find.byKey(const ValueKey('legend-pattern-plan-dashed')),
       findsWidgets,
@@ -202,12 +185,82 @@ void main() {
     }
     expect(tester.takeException(), isNull);
   });
+
+  testWidgets('traffic pie keeps names in its clean legend', (tester) async {
+    await _pumpCompactCharts(tester);
+
+    final traffic = tester.widget<FortalPieChart>(
+      find.byWidgetPredicate(
+        (widget) =>
+            widget is FortalPieChart &&
+            widget.semanticsLabel == 'Traffic share by device',
+      ),
+    );
+    expect(traffic.showLabels, isFalse);
+
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('selected gallery donut preserves visual clearance', (
+    tester,
+  ) async {
+    await _pumpCompactCharts(tester);
+
+    final interactiveFinder = find.byWidgetPredicate(
+      (widget) =>
+          widget is FortalPieChart && widget.semanticsLabel == 'Product mix',
+    );
+    final interactive = tester.widget<FortalPieChart>(interactiveFinder);
+    final availableRadius = tester.getSize(interactiveFinder).shortestSide / 2;
+    final chartContext = tester.element(interactiveFinder);
+
+    const selectedSliceExpansion = 8.0;
+    const visualClearance = 4.0;
+    for (final slice in interactive.slices.where(
+      (slice) => interactive.selectedSliceIds.contains(slice.id),
+    )) {
+      final radius = slice.style!.resolve(chartContext).spec.radius;
+      expect(radius, isNotNull);
+      expect(
+        interactive.centerRadius +
+            radius! +
+            selectedSliceExpansion +
+            visualClearance,
+        lessThanOrEqualTo(availableRadius),
+      );
+    }
+
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('compact pie legends use the available horizontal space', (
+    tester,
+  ) async {
+    await _pumpCompactCharts(tester);
+
+    final coreCenter = tester.getCenter(find.text('Core 54%'));
+    final teamsCenter = tester.getCenter(find.text('Teams 27%'));
+    final enterpriseCenter = tester.getCenter(find.text('Enterprise 19%'));
+
+    expect(teamsCenter.dy, closeTo(coreCenter.dy, 0.5));
+    expect(enterpriseCenter.dy - coreCenter.dy, lessThanOrEqualTo(24.5));
+    expect(tester.takeException(), isNull);
+  });
 }
 
-double _contrastRatio(Color a, Color b) {
-  final aLuminance = a.computeLuminance();
-  final bLuminance = b.computeLuminance();
-  final lighter = aLuminance >= bLuminance ? aLuminance : bLuminance;
-  final darker = aLuminance >= bLuminance ? bLuminance : aLuminance;
-  return (lighter + 0.05) / (darker + 0.05);
+Future<void> _pumpCompactCharts(WidgetTester tester) async {
+  tester.view.physicalSize = const Size(390, 844);
+  tester.view.devicePixelRatio = 1;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+
+  await tester.pumpWidget(const DashboardApp());
+  await tester.tap(find.byKey(const ValueKey('dashboard-menu')).first);
+  for (var frame = 0; frame < 5; frame++) {
+    await tester.pump(const Duration(milliseconds: 100));
+  }
+  await tester.tap(find.byKey(const ValueKey('nav-charts')).first);
+  for (var frame = 0; frame < 5; frame++) {
+    await tester.pump(const Duration(milliseconds: 100));
+  }
 }

--- a/apps/dashboard/web/index.html
+++ b/apps/dashboard/web/index.html
@@ -23,13 +23,13 @@
   <!-- iOS meta tags & icons -->
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
-  <meta name="apple-mobile-web-app-title" content="Remix Dashboard">
+  <meta name="apple-mobile-web-app-title" content="Dashboard">
   <link rel="apple-touch-icon" href="icons/Icon-192.png">
 
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="favicon.png"/>
 
-  <title>Remix Dashboard</title>
+  <title>Dashboard</title>
   <link rel="manifest" href="manifest.json">
 </head>
 <body>

--- a/apps/dashboard/web/manifest.json
+++ b/apps/dashboard/web/manifest.json
@@ -1,6 +1,6 @@
 {
-    "name": "Remix Dashboard",
-    "short_name": "Remix Dashboard",
+    "name": "Dashboard",
+    "short_name": "Dashboard",
     "start_url": ".",
     "display": "standalone",
     "background_color": "#0175C2",

--- a/docs/fortal.mdx
+++ b/docs/fortal.mdx
@@ -98,6 +98,39 @@ final style = ButtonStyler()
   .label(TextStyler().color(FortalTokens.accentContrast()));
 ```
 
+## Charts
+
+Fortal provides themed line, bar, and pie recipes backed by `mix_chart`. Add
+both packages because `remix_fortal` deliberately does not re-export its
+dependencies:
+
+```bash
+flutter pub add mix_chart remix_fortal
+```
+
+```dart
+import 'package:mix_chart/mix_chart.dart';
+import 'package:remix_fortal/remix_fortal.dart';
+
+final chart = FortalLineChart(
+  semanticsLabel: 'Weekly revenue',
+  series: [
+    LineSeries(
+      id: 'revenue',
+      label: 'Revenue',
+      points: [
+        ChartPoint(id: 'mon', x: 0, y: 18),
+        ChartPoint(id: 'tue', x: 1, y: 31),
+      ],
+    ),
+  ],
+);
+```
+
+Use `FortalLineChart`, `FortalBarChart`, and `FortalPieChart` for the ready-made
+widgets. Their matching `fortal*ChartStyle()` recipes can style the underlying
+`mix_chart` widgets directly.
+
 ## Covered components
 
 Every Remix component has a matching Fortal recipe and generated widget. See the

--- a/packages/remix_fortal/CHANGELOG.md
+++ b/packages/remix_fortal/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 0.1.0-beta.1
 
+- **FEAT**: Add Fortal-themed line, bar, and pie chart recipes and generated
+  widgets backed by `mix_chart`.
 - **FIX**: Match the pinned Radix Themes dialog and popover layout defaults.
   `FortalDialog` now defaults to centered placement, exposes `start` and
   `center` alignment options, fills up to 600 pixels, and preserves safe

--- a/packages/remix_fortal/README.md
+++ b/packages/remix_fortal/README.md
@@ -69,6 +69,39 @@ final style = fortalButtonStyle(variant: FortalButtonVariant.solid)
   .onHovered(.scale(1.05));
 ```
 
+## Charts
+
+Fortal includes themed line, bar, and pie chart recipes backed by
+[`mix_chart`](https://pub.dev/packages/mix_chart). Add `mix_chart` directly when
+constructing chart data; Fortal intentionally does not re-export dependencies.
+
+```bash
+flutter pub add mix_chart remix_fortal
+```
+
+```dart
+import 'package:mix_chart/mix_chart.dart';
+import 'package:remix_fortal/remix_fortal.dart';
+
+final chart = FortalLineChart(
+  semanticsLabel: 'Weekly revenue',
+  series: [
+    LineSeries(
+      id: 'revenue',
+      label: 'Revenue',
+      points: [
+        ChartPoint(id: 'mon', x: 0, y: 18),
+        ChartPoint(id: 'tue', x: 1, y: 31),
+      ],
+    ),
+  ],
+);
+```
+
+The generated widgets are `FortalLineChart`, `FortalBarChart`, and
+`FortalPieChart`. Use `fortalLineChartStyle`, `fortalBarChartStyle`, or
+`fortalPieChartStyle` when composing the underlying `mix_chart` widgets.
+
 ## Design tokens
 
 Fortal styles are built on a token system that includes:
@@ -108,6 +141,7 @@ Every Remix component has a matching Fortal recipe and generated widget:
 - **FortalAvatar**, **FortalBadge**, **FortalCard**, **FortalDataList**
 - **FortalDataTable**, **FortalDivider**, **FortalProgress**
 - **FortalSkeleton**, **FortalSpinner**
+- **FortalLineChart**, **FortalBarChart**, **FortalPieChart**
 
 ### Layout & Navigation
 - **FortalTabBar**, **FortalTab**, **FortalTabView**, **FortalAccordion**

--- a/packages/remix_fortal/README.md
+++ b/packages/remix_fortal/README.md
@@ -100,7 +100,20 @@ final chart = FortalLineChart(
 
 The generated widgets are `FortalLineChart`, `FortalBarChart`, and
 `FortalPieChart`. Use `fortalLineChartStyle`, `fortalBarChartStyle`, or
-`fortalPieChartStyle` when composing the underlying `mix_chart` widgets.
+`fortalPieChartStyle` when composing the underlying `mix_chart` widgets. Keep
+shared geometry on the chart-level slice style so individual slices remain
+data-only:
+
+```dart
+final donut = PieChart(
+  style: fortalPieChartStyle(centerRadius: 40)
+      .slice(PieSliceStyler().radius(36)),
+  slices: [
+    PieSlice(id: 'core', label: 'Core', value: 54),
+    PieSlice(id: 'teams', label: 'Teams', value: 46),
+  ],
+);
+```
 
 ## Design tokens
 

--- a/packages/remix_fortal/lib/remix_fortal.dart
+++ b/packages/remix_fortal/lib/remix_fortal.dart
@@ -17,6 +17,7 @@ export 'src/recipes/badge.dart';
 export 'src/recipes/button.dart';
 export 'src/recipes/callout.dart';
 export 'src/recipes/card.dart';
+export 'src/recipes/chart.dart';
 export 'src/recipes/checkbox.dart';
 export 'src/recipes/code.dart';
 export 'src/recipes/data_list.dart';

--- a/packages/remix_fortal/lib/src/recipes/chart.dart
+++ b/packages/remix_fortal/lib/src/recipes/chart.dart
@@ -1,0 +1,242 @@
+import 'package:flutter/material.dart';
+import 'package:mix_annotations/mix_annotations.dart';
+import 'package:mix_chart/mix_chart.dart';
+import 'package:remix/remix.dart';
+
+import '../fortal/fortal.dart';
+
+part 'chart.g.dart';
+
+final _standardPaletteToken = ContextToken<List<Color>>(
+  _resolveStandardPalette,
+);
+final _highContrastPaletteToken = ContextToken<List<Color>>(
+  _resolveHighContrastPalette,
+);
+final _tooltipBorderToken = ContextToken<BorderSide>(_resolveTooltipBorder);
+final _tooltipRadiusToken = ContextToken<BorderRadius>(_resolveTooltipRadius);
+final _tooltipPaddingToken = ContextToken<EdgeInsets>(_resolveTooltipPadding);
+final _barRadiusToken = ContextToken<BorderRadius>(_resolveBarRadius);
+final _lineWidthToken = ContextToken<double>(_resolveLineWidth);
+final _highContrastLineWidthToken = ContextToken<double>(
+  _resolveHighContrastLineWidth,
+);
+
+/// Returns the categorical palette used by Fortal charts in the current scope.
+///
+/// The first entry follows the configured Fortal accent. Remaining entries use
+/// Radix color families selected for clear categorical separation. Set
+/// [highContrast] to use step 12 instead of the standard solid-color step 9.
+List<Color> resolveFortalChartPalette(
+  BuildContext context, {
+  bool highContrast = false,
+}) {
+  final theme = FortalTheme.of(context);
+  final colors = resolveFortalTokens(theme);
+  final step = highContrast ? 12 : 9;
+  final candidates = <Color>[
+    colors.accent.scale.step(step),
+    for (final family in [cyan, orange, ruby, green, violet, amber, blue])
+      (theme.isDark ? family.dark : family.light).scale.step(step),
+  ];
+
+  return List<Color>.unmodifiable(candidates.toSet());
+}
+
+/// Fortal presentation for a Mix line or area chart.
+///
+/// Generates [FortalLineChart] through `mix_generator`. The plot remains
+/// transparent so callers can compose it inside any Fortal surface.
+@MixWidget(target: LineChart.new)
+LineChartStyler fortalLineChartStyle({
+  bool highContrast = false,
+  bool showMarkers = false,
+  List<Color>? palette,
+}) {
+  final style = LineChartStyler()
+      .frame(_fortalFrameStyle())
+      .axis(_fortalAxisStyle())
+      .topAxis(_hiddenAxisStyle())
+      .rightAxis(_hiddenAxisStyle())
+      .grid(_fortalGridStyle())
+      .series(
+        LineSeriesStyler()
+            .curve(.curved)
+            .smoothness(0.18)
+            .preventCurveOvershooting(true)
+            .roundStrokeCap(true)
+            .roundStrokeJoin(true)
+            .stroke(
+              ChartStrokeStyler().width(
+                highContrast
+                    ? _highContrastLineWidthToken()
+                    : _lineWidthToken(),
+              ),
+            )
+            .marker(
+              ChartMarkerStyler()
+                  .show(showMarkers)
+                  .radius(FortalTokens.space1())
+                  .borderColor(FortalTokens.colorPanel())
+                  .borderWidth(FortalTokens.borderWidth2()),
+            ),
+      )
+      .tooltip(_fortalTooltipStyle());
+
+  return style.merge(
+    LineChartStyler.create(
+      palette: _paletteProp(highContrast: highContrast, palette: palette),
+    ),
+  );
+}
+
+/// Fortal presentation for a Mix grouped, stacked, or floating bar chart.
+///
+/// Generates [FortalBarChart] through `mix_generator`.
+@MixWidget(target: BarChart.new)
+BarChartStyler fortalBarChartStyle({
+  bool highContrast = false,
+  List<Color>? palette,
+}) {
+  final bar = BarStyler.create(
+    borderRadius: Prop.token(_barRadiusToken),
+  ).width(FortalTokens.space4());
+  final style = BarChartStyler()
+      .frame(_fortalFrameStyle())
+      .axis(_fortalAxisStyle())
+      .topAxis(_hiddenAxisStyle())
+      .rightAxis(_hiddenAxisStyle())
+      .grid(_fortalGridStyle())
+      .bar(bar)
+      .groupSpacing(FortalTokens.space4())
+      .barSpacing(FortalTokens.space2())
+      .tooltip(_fortalTooltipStyle());
+
+  return style.merge(
+    BarChartStyler.create(
+      palette: _paletteProp(highContrast: highContrast, palette: palette),
+    ),
+  );
+}
+
+/// Fortal presentation for a Mix pie or donut chart.
+///
+/// A positive [centerRadius] renders a donut. Labels are hidden by default so
+/// category names can be presented in a caller-owned legend without forcing
+/// low-contrast text onto arbitrary categorical colors. Generates
+/// [FortalPieChart] through `mix_generator`.
+@MixWidget(target: PieChart.new)
+PieChartStyler fortalPieChartStyle({
+  bool highContrast = false,
+  double centerRadius = 0,
+  bool showLabels = false,
+  List<Color>? palette,
+}) {
+  final style = PieChartStyler()
+      .frame(_fortalFrameStyle())
+      .centerRadius(centerRadius)
+      .centerColor(FortalTokens.colorPanel())
+      .sliceSpacing(FortalTokens.borderWidth2())
+      .slice(
+        PieSliceStyler()
+            .showLabel(showLabels)
+            .cornerRadius(FortalTokens.borderWidth2())
+            .label(
+              TextStyler()
+                  .style(FortalTokens.text1.mix())
+                  .fontWeight(.w600)
+                  .color(FortalTokens.accentContrast()),
+            ),
+      )
+      .tooltip(_fortalTooltipStyle());
+
+  return style.merge(
+    PieChartStyler.create(
+      palette: _paletteProp(highContrast: highContrast, palette: palette),
+    ),
+  );
+}
+
+Prop<List<Color>> _paletteProp({
+  required bool highContrast,
+  required List<Color>? palette,
+}) {
+  if (palette != null) return Prop.value(List<Color>.unmodifiable(palette));
+
+  return Prop.token(
+    highContrast ? _highContrastPaletteToken : _standardPaletteToken,
+  );
+}
+
+ChartFrameStyler _fortalFrameStyle() => ChartFrameStyler()
+    .backgroundColor(Colors.transparent)
+    .showBorder(false)
+    .clip(true);
+
+ChartAxisStyler _fortalAxisStyle() => ChartAxisStyler()
+    .showLabels(true)
+    .label(
+      TextStyler().style(FortalTokens.text1.mix()).color(FortalTokens.gray11()),
+    )
+    .labelSpace(FortalTokens.space2())
+    .fitInside(true)
+    .fitInsideDistance(FortalTokens.space1())
+    .drawBelowEverything(true);
+
+ChartAxisStyler _hiddenAxisStyle() => ChartAxisStyler().showLabels(false);
+
+ChartGridStyler _fortalGridStyle() => ChartGridStyler()
+    .show(true)
+    .showHorizontal(true)
+    .showVertical(false)
+    .stroke(
+      ChartStrokeStyler()
+          .color(FortalTokens.grayA5())
+          .width(FortalTokens.borderWidth1()),
+    );
+
+ChartTooltipStyler _fortalTooltipStyle() =>
+    ChartTooltipStyler.create(
+          border: Prop.token(_tooltipBorderToken),
+          borderRadius: Prop.token(_tooltipRadiusToken),
+          padding: Prop.token(_tooltipPaddingToken),
+        )
+        .backgroundColor(FortalTokens.colorPanel())
+        .margin(FortalTokens.space2())
+        .maxWidth(280)
+        .fitHorizontally(true)
+        .fitVertically(true)
+        .text(
+          TextStyler()
+              .style(FortalTokens.text1.mix())
+              .fontWeight(.w500)
+              .color(FortalTokens.gray12()),
+        );
+
+List<Color> _resolveStandardPalette(BuildContext context) =>
+    resolveFortalChartPalette(context);
+
+List<Color> _resolveHighContrastPalette(BuildContext context) =>
+    resolveFortalChartPalette(context, highContrast: true);
+
+BorderSide _resolveTooltipBorder(BuildContext context) => BorderSide(
+  color: FortalTokens.grayStroke6.resolve(context),
+  width: FortalTokens.borderWidth1.resolve(context),
+);
+
+BorderRadius _resolveTooltipRadius(BuildContext context) =>
+    BorderRadius.all(FortalTokens.radius3.resolve(context));
+
+EdgeInsets _resolveTooltipPadding(BuildContext context) => EdgeInsets.symmetric(
+  horizontal: FortalTokens.space3.resolve(context),
+  vertical: FortalTokens.space2.resolve(context),
+);
+
+BorderRadius _resolveBarRadius(BuildContext context) =>
+    BorderRadius.all(FortalTokens.radius2.resolve(context));
+
+double _resolveLineWidth(BuildContext context) =>
+    2 * FortalTheme.of(context).scaling.factor;
+
+double _resolveHighContrastLineWidth(BuildContext context) =>
+    3 * FortalTheme.of(context).scaling.factor;

--- a/packages/remix_fortal/lib/src/recipes/chart.dart
+++ b/packages/remix_fortal/lib/src/recipes/chart.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:mix/mix.dart';
 import 'package:mix_annotations/mix_annotations.dart';
 import 'package:mix_chart/mix_chart.dart';
 import 'package:remix/remix.dart';
@@ -124,7 +125,8 @@ BarChartStyler fortalBarChartStyle({
 /// A positive [centerRadius] renders a donut. Labels are hidden by default so
 /// category names can be presented in a caller-owned legend without forcing
 /// low-contrast text onto arbitrary categorical colors. Generates
-/// [FortalPieChart] through `mix_generator`.
+/// [FortalPieChart] through `mix_generator`. For advanced chart-level geometry,
+/// pass this recipe directly to [PieChart.style] and merge a [PieSliceStyler].
 @MixWidget(target: PieChart.new)
 PieChartStyler fortalPieChartStyle({
   bool highContrast = false,
@@ -137,6 +139,7 @@ PieChartStyler fortalPieChartStyle({
       .centerRadius(centerRadius)
       .centerColor(FortalTokens.colorPanel())
       .sliceSpacing(FortalTokens.borderWidth2())
+      .selectedSliceRadiusOffset(FortalTokens.space2())
       .slice(
         PieSliceStyler()
             .showLabel(showLabels)

--- a/packages/remix_fortal/lib/src/recipes/chart.g.dart
+++ b/packages/remix_fortal/lib/src/recipes/chart.g.dart
@@ -204,7 +204,8 @@ class FortalBarChart extends StatelessWidget {
 /// A positive [centerRadius] renders a donut. Labels are hidden by default so
 /// category names can be presented in a caller-owned legend without forcing
 /// low-contrast text onto arbitrary categorical colors. Generates
-/// [FortalPieChart] through `mix_generator`.
+/// [FortalPieChart] through `mix_generator`. For advanced chart-level geometry,
+/// pass this recipe directly to [PieChart.style] and merge a [PieSliceStyler].
 class FortalPieChart extends StatelessWidget {
   const FortalPieChart({
     super.key,

--- a/packages/remix_fortal/lib/src/recipes/chart.g.dart
+++ b/packages/remix_fortal/lib/src/recipes/chart.g.dart
@@ -1,0 +1,285 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'chart.dart';
+
+// **************************************************************************
+// MixWidgetGenerator
+// **************************************************************************
+
+/// Fortal presentation for a Mix line or area chart.
+///
+/// Generates [FortalLineChart] through `mix_generator`. The plot remains
+/// transparent so callers can compose it inside any Fortal surface.
+class FortalLineChart extends StatelessWidget {
+  const FortalLineChart({
+    super.key,
+    this.highContrast = false,
+    this.showMarkers = false,
+    this.palette,
+    required this.series,
+    this.xAxis,
+    this.yAxis,
+    this.topAxis,
+    this.rightAxis,
+    this.viewport,
+    this.dataTransition = ChartDataTransition.none,
+    this.selectedPoints = const {},
+    this.onPointHover,
+    this.onPointTap,
+    this.onPointLongPress,
+    this.tooltipBuilder,
+    this.hitTestRadius = 10,
+    this.mouseCursorResolver,
+    this.semanticsLabel,
+    this.semanticsValue,
+    this.excludeFromSemantics = false,
+  });
+
+  final bool highContrast;
+
+  final bool showMarkers;
+
+  final List<Color>? palette;
+
+  final List<LineSeries> series;
+
+  final ChartAxis? xAxis;
+
+  final ChartAxis? yAxis;
+
+  final ChartAxis? topAxis;
+
+  final ChartAxis? rightAxis;
+
+  final ChartViewport? viewport;
+
+  final ChartDataTransition dataTransition;
+
+  final Set<LinePointKey> selectedPoints;
+
+  final ValueChanged<LineChartHit?>? onPointHover;
+
+  final ValueChanged<LineChartHit>? onPointTap;
+
+  final ValueChanged<LineChartHit>? onPointLongPress;
+
+  final ChartTooltipBuilder? tooltipBuilder;
+
+  final double hitTestRadius;
+
+  final ChartMouseCursorResolver<LineChartHit>? mouseCursorResolver;
+
+  final String? semanticsLabel;
+
+  final String? semanticsValue;
+
+  final bool excludeFromSemantics;
+
+  @override
+  Widget build(BuildContext context) {
+    return LineChart(
+      key: this.key,
+      style: fortalLineChartStyle(
+        highContrast: this.highContrast,
+        showMarkers: this.showMarkers,
+        palette: this.palette,
+      ),
+      series: this.series,
+      xAxis: this.xAxis,
+      yAxis: this.yAxis,
+      topAxis: this.topAxis,
+      rightAxis: this.rightAxis,
+      viewport: this.viewport,
+      dataTransition: this.dataTransition,
+      selectedPoints: this.selectedPoints,
+      onPointHover: this.onPointHover,
+      onPointTap: this.onPointTap,
+      onPointLongPress: this.onPointLongPress,
+      tooltipBuilder: this.tooltipBuilder,
+      hitTestRadius: this.hitTestRadius,
+      mouseCursorResolver: this.mouseCursorResolver,
+      semanticsLabel: this.semanticsLabel,
+      semanticsValue: this.semanticsValue,
+      excludeFromSemantics: this.excludeFromSemantics,
+    );
+  }
+}
+
+/// Fortal presentation for a Mix grouped, stacked, or floating bar chart.
+///
+/// Generates [FortalBarChart] through `mix_generator`.
+class FortalBarChart extends StatelessWidget {
+  const FortalBarChart({
+    super.key,
+    this.highContrast = false,
+    this.palette,
+    required this.groups,
+    this.xAxis,
+    this.yAxis,
+    this.topAxis,
+    this.rightAxis,
+    this.viewport,
+    this.dataTransition = ChartDataTransition.none,
+    this.selectedItems = const {},
+    this.onBarHover,
+    this.onBarTap,
+    this.onBarLongPress,
+    this.tooltipBuilder,
+    this.hitTestPadding = const EdgeInsets.all(4),
+    this.mouseCursorResolver,
+    this.semanticsLabel,
+    this.semanticsValue,
+    this.excludeFromSemantics = false,
+  });
+
+  final bool highContrast;
+
+  final List<Color>? palette;
+
+  final List<BarGroup> groups;
+
+  final ChartAxis? xAxis;
+
+  final ChartAxis? yAxis;
+
+  final ChartAxis? topAxis;
+
+  final ChartAxis? rightAxis;
+
+  final ChartViewport? viewport;
+
+  final ChartDataTransition dataTransition;
+
+  final Set<BarSelectionKey> selectedItems;
+
+  final ValueChanged<BarChartHit?>? onBarHover;
+
+  final ValueChanged<BarChartHit>? onBarTap;
+
+  final ValueChanged<BarChartHit>? onBarLongPress;
+
+  final ChartTooltipBuilder? tooltipBuilder;
+
+  final EdgeInsets hitTestPadding;
+
+  final ChartMouseCursorResolver<BarChartHit>? mouseCursorResolver;
+
+  final String? semanticsLabel;
+
+  final String? semanticsValue;
+
+  final bool excludeFromSemantics;
+
+  @override
+  Widget build(BuildContext context) {
+    return BarChart(
+      key: this.key,
+      style: fortalBarChartStyle(
+        highContrast: this.highContrast,
+        palette: this.palette,
+      ),
+      groups: this.groups,
+      xAxis: this.xAxis,
+      yAxis: this.yAxis,
+      topAxis: this.topAxis,
+      rightAxis: this.rightAxis,
+      viewport: this.viewport,
+      dataTransition: this.dataTransition,
+      selectedItems: this.selectedItems,
+      onBarHover: this.onBarHover,
+      onBarTap: this.onBarTap,
+      onBarLongPress: this.onBarLongPress,
+      tooltipBuilder: this.tooltipBuilder,
+      hitTestPadding: this.hitTestPadding,
+      mouseCursorResolver: this.mouseCursorResolver,
+      semanticsLabel: this.semanticsLabel,
+      semanticsValue: this.semanticsValue,
+      excludeFromSemantics: this.excludeFromSemantics,
+    );
+  }
+}
+
+/// Fortal presentation for a Mix pie or donut chart.
+///
+/// A positive [centerRadius] renders a donut. Labels are hidden by default so
+/// category names can be presented in a caller-owned legend without forcing
+/// low-contrast text onto arbitrary categorical colors. Generates
+/// [FortalPieChart] through `mix_generator`.
+class FortalPieChart extends StatelessWidget {
+  const FortalPieChart({
+    super.key,
+    this.highContrast = false,
+    this.centerRadius = 0,
+    this.showLabels = false,
+    this.palette,
+    required this.slices,
+    this.dataTransition = ChartDataTransition.none,
+    this.selectedSliceIds = const {},
+    this.onSliceHover,
+    this.onSliceTap,
+    this.onSliceLongPress,
+    this.tooltipBuilder,
+    this.mouseCursorResolver,
+    this.valueFormatter,
+    this.semanticsLabel,
+    this.semanticsValue,
+    this.excludeFromSemantics = false,
+  });
+
+  final bool highContrast;
+
+  final double centerRadius;
+
+  final bool showLabels;
+
+  final List<Color>? palette;
+
+  final List<PieSlice> slices;
+
+  final ChartDataTransition dataTransition;
+
+  final Set<Object> selectedSliceIds;
+
+  final ValueChanged<PieChartHit?>? onSliceHover;
+
+  final ValueChanged<PieChartHit>? onSliceTap;
+
+  final ValueChanged<PieChartHit>? onSliceLongPress;
+
+  final ChartTooltipBuilder? tooltipBuilder;
+
+  final ChartMouseCursorResolver<PieChartHit>? mouseCursorResolver;
+
+  final ChartAxisLabelFormatter? valueFormatter;
+
+  final String? semanticsLabel;
+
+  final String? semanticsValue;
+
+  final bool excludeFromSemantics;
+
+  @override
+  Widget build(BuildContext context) {
+    return PieChart(
+      key: this.key,
+      style: fortalPieChartStyle(
+        highContrast: this.highContrast,
+        centerRadius: this.centerRadius,
+        showLabels: this.showLabels,
+        palette: this.palette,
+      ),
+      slices: this.slices,
+      dataTransition: this.dataTransition,
+      selectedSliceIds: this.selectedSliceIds,
+      onSliceHover: this.onSliceHover,
+      onSliceTap: this.onSliceTap,
+      onSliceLongPress: this.onSliceLongPress,
+      tooltipBuilder: this.tooltipBuilder,
+      mouseCursorResolver: this.mouseCursorResolver,
+      valueFormatter: this.valueFormatter,
+      semanticsLabel: this.semanticsLabel,
+      semanticsValue: this.semanticsValue,
+      excludeFromSemantics: this.excludeFromSemantics,
+    );
+  }
+}

--- a/packages/remix_fortal/pubspec.yaml
+++ b/packages/remix_fortal/pubspec.yaml
@@ -39,7 +39,7 @@ dependencies:
   remix: ^1.0.0-beta.2 # x-release-please-version
   mix: ^2.2.0-beta.4
   mix_annotations: ^2.2.0-beta.1
-  mix_chart: ^0.0.1-beta.0
+  mix_chart: ^0.0.1-beta.1
   naked_ui: ^1.0.0-beta.8
 
 dev_dependencies:

--- a/packages/remix_fortal/pubspec.yaml
+++ b/packages/remix_fortal/pubspec.yaml
@@ -39,6 +39,7 @@ dependencies:
   remix: ^1.0.0-beta.2 # x-release-please-version
   mix: ^2.2.0-beta.4
   mix_annotations: ^2.2.0-beta.1
+  mix_chart: ^0.0.1-beta.0
   naked_ui: ^1.0.0-beta.8
 
 dev_dependencies:

--- a/packages/remix_fortal/test/components/chart/chart_test.dart
+++ b/packages/remix_fortal/test/components/chart/chart_test.dart
@@ -86,6 +86,27 @@ void main() {
 
       expect(resolved.spec.palette, palette);
     });
+
+    testWidgets('pie selection expansion follows Fortal spacing', (
+      tester,
+    ) async {
+      late StyleSpec<PieChartSpec> resolved;
+      late double expectedOffset;
+
+      await tester.pumpWidget(
+        FortalScope(
+          child: Builder(
+            builder: (context) {
+              expectedOffset = MixScope.tokenOf(FortalTokens.space2, context);
+              resolved = fortalPieChartStyle().build(context);
+              return const SizedBox();
+            },
+          ),
+        ),
+      );
+
+      expect(resolved.spec.selectedSliceRadiusOffset, expectedOffset);
+    });
   });
 
   group('generated Fortal chart widgets', () {

--- a/packages/remix_fortal/test/components/chart/chart_test.dart
+++ b/packages/remix_fortal/test/components/chart/chart_test.dart
@@ -1,0 +1,207 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mix_chart/mix_chart.dart';
+import 'package:remix/remix.dart';
+import 'package:remix_fortal/remix_fortal.dart';
+
+void main() {
+  group('Fortal chart recipes', () {
+    testWidgets('resolve the active Fortal theme and contextual palette', (
+      tester,
+    ) async {
+      late StyleSpec<LineChartSpec> resolved;
+      late List<Color> publicPalette;
+
+      await tester.pumpWidget(
+        FortalScope(
+          accent: .orange,
+          brightness: .dark,
+          child: Builder(
+            builder: (context) {
+              publicPalette = resolveFortalChartPalette(context);
+              resolved = fortalLineChartStyle().build(context);
+              return const SizedBox();
+            },
+          ),
+        ),
+      );
+
+      final colors = resolveFortalTokens(
+        const FortalThemeConfig(accent: .orange, brightness: .dark),
+      );
+      final spec = resolved.spec;
+
+      expect(spec.palette, publicPalette);
+      expect(spec.palette!.first, colors.accent.scale.step(9));
+      expect(spec.palette, hasLength(greaterThanOrEqualTo(7)));
+      expect(spec.palette!.toSet(), hasLength(spec.palette!.length));
+      expect(
+        spec.grid!.spec.stroke!.spec.color,
+        colors.gray.scale.alphaStep(5),
+      );
+      expect(spec.tooltip!.spec.backgroundColor, colors.colorPanelTranslucent);
+    });
+
+    testWidgets('high contrast uses the Fortal step-12 palette', (
+      tester,
+    ) async {
+      late StyleSpec<PieChartSpec> resolved;
+
+      await tester.pumpWidget(
+        FortalScope(
+          accent: .indigo,
+          child: Builder(
+            builder: (context) {
+              resolved = fortalPieChartStyle(highContrast: true).build(context);
+              return const SizedBox();
+            },
+          ),
+        ),
+      );
+
+      final colors = resolveFortalTokens(
+        const FortalThemeConfig(accent: .indigo),
+      );
+      expect(resolved.spec.palette!.first, colors.accent.scale.step(12));
+    });
+
+    testWidgets('caller palette overrides the contextual default', (
+      tester,
+    ) async {
+      const palette = [Color(0xFF112233), Color(0xFF445566)];
+      late StyleSpec<BarChartSpec> resolved;
+
+      await tester.pumpWidget(
+        FortalScope(
+          child: Builder(
+            builder: (context) {
+              resolved = fortalBarChartStyle(palette: palette).build(context);
+              return const SizedBox();
+            },
+          ),
+        ),
+      );
+
+      expect(resolved.spec.palette, palette);
+    });
+  });
+
+  group('generated Fortal chart widgets', () {
+    test('forward recipe and chart constructor parameters', () {
+      final line = FortalLineChart(
+        highContrast: true,
+        showMarkers: true,
+        semanticsLabel: 'Revenue',
+        series: [_lineSeries()],
+      );
+      final bar = FortalBarChart(
+        highContrast: true,
+        semanticsLabel: 'Orders',
+        groups: [_barGroup()],
+      );
+      final pie = FortalPieChart(
+        centerRadius: 40,
+        showLabels: true,
+        semanticsLabel: 'Channels',
+        slices: [_pieSlice()],
+      );
+
+      expect(line.highContrast, isTrue);
+      expect(line.showMarkers, isTrue);
+      expect(line.semanticsLabel, 'Revenue');
+      expect(bar.highContrast, isTrue);
+      expect(bar.semanticsLabel, 'Orders');
+      expect(pie.centerRadius, 40);
+      expect(pie.showLabels, isTrue);
+      expect(pie.semanticsLabel, 'Channels');
+    });
+
+    testWidgets('render through the mix_chart widgets', (tester) async {
+      await tester.pumpWidget(
+        FortalScope(
+          child: MaterialApp(
+            home: Column(
+              children: [
+                SizedBox(
+                  width: 360,
+                  height: 180,
+                  child: FortalLineChart(series: [_lineSeries()]),
+                ),
+                SizedBox(
+                  width: 360,
+                  height: 180,
+                  child: FortalBarChart(groups: [_barGroup()]),
+                ),
+                SizedBox(
+                  width: 360,
+                  height: 180,
+                  child: FortalPieChart(slices: [_pieSlice()]),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.byType(FortalLineChart), findsOneWidget);
+      expect(find.byType(FortalBarChart), findsOneWidget);
+      expect(find.byType(FortalPieChart), findsOneWidget);
+      expect(find.byType(LineChart), findsOneWidget);
+      expect(find.byType(BarChart), findsOneWidget);
+      expect(find.byType(PieChart), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+  });
+
+  group('package boundary', () {
+    test('Fortal does not import the private chart renderer', () {
+      final sources = Directory('lib')
+          .listSync(recursive: true)
+          .whereType<File>()
+          .where((file) => file.path.endsWith('.dart'));
+
+      for (final source in sources) {
+        expect(
+          source.readAsStringSync(),
+          isNot(contains('package:fl_chart')),
+          reason: '${source.path} crosses the mix_chart renderer boundary',
+        );
+      }
+    });
+
+    test('mix_chart belongs to Fortal rather than core Remix', () {
+      final fortalPubspec = File('pubspec.yaml').readAsStringSync();
+      final remixPubspec = File('../remix/pubspec.yaml').readAsStringSync();
+
+      expect(
+        fortalPubspec,
+        contains(RegExp(r'^name: remix_fortal$', multiLine: true)),
+      );
+      expect(
+        fortalPubspec,
+        contains(RegExp(r'^  mix_chart:', multiLine: true)),
+      );
+      expect(remixPubspec, isNot(contains('mix_chart:')));
+    });
+  });
+}
+
+LineSeries _lineSeries() => LineSeries(
+  id: 'revenue',
+  label: 'Revenue',
+  points: [
+    ChartPoint(id: 'monday', x: 0, y: 18),
+    ChartPoint(id: 'tuesday', x: 1, y: 31),
+  ],
+);
+
+BarGroup _barGroup() => BarGroup(
+  id: 'q1',
+  label: 'Q1',
+  bars: [BarValue(id: 'actual', label: 'Actual', toY: 42)],
+);
+
+PieSlice _pieSlice() => PieSlice(id: 'mobile', label: 'Mobile', value: 64);

--- a/packages/remix_fortal/test/public_api_test.dart
+++ b/packages/remix_fortal/test/public_api_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mix_chart/mix_chart.dart';
 import 'package:remix/remix.dart';
 import 'package:remix_fortal/remix_fortal.dart';
 
@@ -66,4 +67,35 @@ void main() {
       expect(fortalDataTableStyle(), isA<DataTableStyler>());
     },
   );
+
+  test('Fortal chart wrappers are constructible from the public API', () {
+    final line = FortalLineChart(
+      series: [
+        LineSeries(
+          id: 'revenue',
+          label: 'Revenue',
+          points: [ChartPoint(id: 'monday', x: 0, y: 18)],
+        ),
+      ],
+    );
+    final bar = FortalBarChart(
+      groups: [
+        BarGroup(
+          id: 'q1',
+          label: 'Q1',
+          bars: [BarValue(id: 'actual', label: 'Actual', toY: 42)],
+        ),
+      ],
+    );
+    final pie = FortalPieChart(
+      slices: [PieSlice(id: 'direct', label: 'Direct', value: 64)],
+    );
+
+    expect(line, isA<FortalLineChart>());
+    expect(bar, isA<FortalBarChart>());
+    expect(pie, isA<FortalPieChart>());
+    expect(fortalLineChartStyle(), isA<LineChartStyler>());
+    expect(fortalBarChartStyle(), isA<BarChartStyler>());
+    expect(fortalPieChartStyle(), isA<PieChartStyler>());
+  });
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -452,10 +452,10 @@ packages:
     dependency: transitive
     description:
       name: mix_chart
-      sha256: "3c8d8eee1d843a12e25a28cc6b515e2ef00553d876608b6571d56d11fde1ecee"
+      sha256: fbc284e5626a0021c43f078c55e51570b7dae69d59089302310933d1924bbb91
       url: "https://pub.dev"
     source: hosted
-    version: "0.0.1-beta.0"
+    version: "0.0.1-beta.1"
   mix_generator:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -217,6 +217,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
+  equatable:
+    dependency: transitive
+    description:
+      name: equatable
+      sha256: "3bce007a596ff8b3119c45d68aaef631272537c03d30e5d4534dd24bf4c5eaa2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   fake_async:
     dependency: transitive
     description:
@@ -249,6 +257,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
+  fl_chart:
+    dependency: transitive
+    description:
+      name: fl_chart
+      sha256: b938f77d042cbcd822936a7a359a7235bad8bd72070de1f827efc2cc297ac888
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.0"
   flutter:
     dependency: transitive
     description: flutter
@@ -432,6 +448,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0-beta.1"
+  mix_chart:
+    dependency: transitive
+    description:
+      name: mix_chart
+      sha256: "3c8d8eee1d843a12e25a28cc6b515e2ef00553d876608b6571d56d11fde1ecee"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.1-beta.0"
   mix_generator:
     dependency: transitive
     description:

--- a/skills/using-remix/references/fortal.md
+++ b/skills/using-remix/references/fortal.md
@@ -33,6 +33,10 @@ import 'package:remix_fortal/remix_fortal.dart';
 `remix_fortal` does not re-export `remix`. Import both when a file also uses base
 `Remix*` widgets or `*Styler` types.
 
+Charts also use `mix_chart` data models. Add and import `mix_chart` directly;
+Fortal provides the themed recipes and generated wrappers without re-exporting
+the chart package.
+
 ## Presets and recipes
 
 Each component ships a `fortal<Name>Style(...)` function that returns the
@@ -86,6 +90,9 @@ explicit `<String>`.
 | Callout | `FortalCallout` | `outline`, `surface`, `soft` | `size1`–`size3` |
 | DataList | `FortalDataList` | — | `size1`–`size3` |
 | DataTable | `FortalDataTable<T>` | `surface`, `ghost` | `size1`–`size3` |
+| LineChart | `FortalLineChart` | — | — |
+| BarChart | `FortalBarChart` | — | — |
+| PieChart | `FortalPieChart` | — | — |
 | Progress | `FortalProgress` | `classic`, `surface`, `soft` | `size1`–`size3` (4/8/12 px) |
 | Accordion | `FortalAccordion<T>` | `surface`, `soft` | `size1`–`size3` |
 | Spinner | `FortalSpinner` | — | `size1`–`size3` |


### PR DESCRIPTION
## Description

Adds Fortal-native line, bar, and pie chart recipes backed by `mix_chart`, plus a dedicated dashboard chart gallery and overview analytics.

This follow-up removes the last private renderer assumption from the Remix integration. Upstream [conceptadev/mix#1019](https://github.com/conceptadev/mix/pull/1019) made selected-pie expansion public as `PieChartStyler.selectedSliceRadiusOffset`, and the hosted [`mix_chart 0.0.1-beta.1`](https://pub.dev/packages/mix_chart/versions/0.0.1-beta.1) release now supplies that API without a cross-repository path override.

After this change:

- `fortalPieChartStyle()` tokenizes selected-slice expansion with `FortalTokens.space2()` while keeping its public signature unchanged.
- `LineChart`, `BarChart`, and `PieChart` remain the typed engines; advanced pie geometry composes the Fortal recipe through `PieChart(style: fortalPieChartStyle(...).slice(...))`.
- A shared, dashboard-local `DashboardChartCard` replaces the two private card variants, while `GridBox` owns the overview's fixed-height 3/2/1 responsive composition.
- Repeated pie radii and badge placement live at chart level, percentage legends share one mapping helper, and the empty state keeps the simple `FortalPieChart` wrapper.
- Compact viewport badges use the size-1 Fortal preset with collision-safe tick density.
- Floating bars preserve genuine gains and declines instead of normalizing every range upward.
- The dashboard exposes 12 responsive chart examples covering comparisons, gaps, stacked and floating bars, interaction, badges, and empty states.
- Solid/dashed or filled/outlined patterns preserve meaning without relying on color alone.
- Documentation and public API coverage describe the package boundary: chart models come from `mix_chart`, Fortal owns tokenized presentation, and app composition remains dashboard-local.

## Visual evidence

### Overview — desktop, light theme

<img width="1440" height="1200" alt="Fortal dashboard overview in the light theme with the responsive three-column analytics grid" src="https://github.com/user-attachments/assets/ee9c02c1-dc60-4363-acf2-62a4c98e4cf3" />

### Overview — desktop, dark theme

<img width="1440" height="1200" alt="Fortal dashboard overview in the dark theme with unclipped line, bar, and donut charts" src="https://github.com/user-attachments/assets/c717a5b1-a3b7-4b7f-b007-ff1ffa5cebb0" />

### Donut clearance — compact, light theme

<img width="390" height="844" alt="Fortal chart gallery at the compact breakpoint showing the selected product donut fully contained with its horizontal legend" src="https://github.com/user-attachments/assets/90e2ff8d-bb58-436d-a3bc-464f03b42c26" />

## Validation

- `fvm dart run melos run ci` — passed hosted dependency checks, generated-code drift, docs, Fortal parity, and 2,923 tests.
- `fvm flutter analyze` — passed with no issues.
- `fvm dart format --output=none --set-exit-if-changed ...` — all touched Dart files required no formatting changes.
- Browser verification covered all 12 gallery charts and the overview at 1440×1200 and 390×844 in light and dark themes, including donut selection, compact label clearance, and an empty warning/error console.

## Related work

- [conceptadev/mix#1019](https://github.com/conceptadev/mix/pull/1019) — public selected-slice radius offset (merged).
- [conceptadev/mix#1020](https://github.com/conceptadev/mix/pull/1020) — `mix_chart 0.0.1-beta.1` release (merged and published).

---

## Checklist

- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors.
- [x] I have updated or added relevant documentation (doc comments with `///`).
- [x] I am prepared to follow up on review comments in a timely manner.

## Breaking Change

Does this PR require users of the package to manually update their code?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.
