### PR TITLE
chore(deps): resolve naked_ui 1.0.0-beta.10

### DIFF
--- a/packages/remix/pubspec.yaml
+++ b/packages/remix/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
     sdk: flutter
   mix: ^2.2.0-beta.4
   mix_annotations: ^2.2.0-beta.1
-  naked_ui: ^1.0.0-beta.8
+  naked_ui: ^1.0.0-beta.10
 
 dev_dependencies:
   flutter_test:

--- a/packages/remix_fortal/pubspec.yaml
+++ b/packages/remix_fortal/pubspec.yaml
@@ -40,7 +40,7 @@ dependencies:
   mix: ^2.2.0-beta.4
   mix_annotations: ^2.2.0-beta.1
   mix_chart: ^0.0.1-beta.1
-  naked_ui: ^1.0.0-beta.8
+  naked_ui: ^1.0.0-beta.10
 
 dev_dependencies:
   flutter_test:

--- a/packages/remix_fortal/tool/fortal_parity/check.dart
+++ b/packages/remix_fortal/tool/fortal_parity/check.dart
@@ -4,8 +4,8 @@ import 'dart:typed_data';
 
 const _expectedIntegrity =
     'sha512-I0/h2CRNTpYNB7Mi3xFIvSsQq5a108d7kK8dTO5zp5b9HR5QJXKag6B8tjpz2ITkVYkFdkGk45doNkSr7OxwNw==';
-const _expectedNakedUiVersion = '1.0.0-beta.9';
-const _expectedNakedUiConstraint = '^1.0.0-beta.8';
+const _expectedNakedUiVersion = '1.0.0-beta.10';
+const _expectedNakedUiConstraint = '^1.0.0-beta.10';
 const _expectedMappedFamilies = <String>{
   'avatar',
   'badge',

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -476,10 +476,10 @@ packages:
     dependency: transitive
     description:
       name: naked_ui
-      sha256: "38d42f7512504226d8ceea34bc108edb416dab639c44e6f39a65860f703f534d"
+      sha256: cb6c35fc10cf62142da74b491c0033d53c0e8c4f2a6ef895751c1713e47c41b9
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0-beta.9"
+    version: "1.0.0-beta.10"
   nested:
     dependency: transitive
     description:


### PR DESCRIPTION
Resolves `naked_ui 1.0.0-beta.10`, published today, which adds `NakedAccordion.itemBuilder`.

## Why the floor moves

`^1.0.0-beta.8` would still *admit* beta.10, but it also admits beta.8 and beta.9, neither of which has `itemBuilder`. Once Remix code depends on it, the floor has to name the release that introduces it — so both pubspecs and the two constants in `check.dart` move together. The parity checker enforces all four agreeing.

## Behaviour change to be aware of

beta.10 is not purely additive. `NakedAccordion` now tracks press state whenever the item is enabled, instead of only when `onPressChange` is supplied.

Remix is compatible by accident of an existing workaround — `accordion_widget.dart` passes an always-non-null callback for exactly this reason:

```dart
// Always non-null: NakedAccordion only wires up press detection when
// a callback is supplied, and the panel's pressed styling needs it
// whether or not the caller asked to observe presses.
onPressChange: _handlePressChange,
```

That comment is now obsolete upstream and can go with the mirror removal below.

## Verification

- `remix` 2578 · `remix_fortal` 365 · dashboard 48 · demo 1 — all pass
- `flutter analyze --fatal-infos` clean
- Fortal parity check: *"hosted Naked 1.0.0-beta.10 resolution"*
- Docs validation clean

## What this unblocks (deliberately not in this PR)

`itemBuilder` exists so Remix can delete two mirrors in the accordion:

- `_RemixAccordionStyleState` — an inherited widget mirroring `isExpanded` / `canExpand` / `canCollapse`
- `_statesController` — a `WidgetStatesController` mirroring hover, press, focus, and disabled

I validated against the naked_ui branch before it merged that `NakedAccordionItemState.controllerOf<T>(context)` supplies all of it at the whole-item boundary.

It is a separate PR because it carries one design decision. Remix currently resolves the spec **once** above `NakedAccordion` and threads it into container, trigger, and content. `itemBuilder` receives an **already-built** child, so it cannot pass a spec down — the trigger and the transition would each resolve their own. That trades two mirrors for three resolutions of the same style.

Correctness improves either way, since all three would read one shared controller and cannot diverge — which is the bug class the mirror creates. But it is a structural change to a component that changed in #133 today, and it deserves its own review rather than riding along with a dependency bump.
