### PR TITLE
chore(release): remix 1.0.0-beta.3, remix_fortal 0.1.0-beta.2

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "packages/remix": "1.0.0-beta.2",
-  "packages/remix_fortal": "0.1.0-beta.1"
+  "packages/remix": "1.0.0-beta.3",
+  "packages/remix_fortal": "0.1.0-beta.2"
 }

--- a/packages/remix/CHANGELOG.md
+++ b/packages/remix/CHANGELOG.md
@@ -1,3 +1,31 @@
+## 1.0.0-beta.3
+
+- **BREAKING**: Remove handwritten component styler aliases that duplicate the
+  generated API. Use `color` for component surfaces; explicit child-slot
+  methods such as `labelColor`, `iconColor`, `textColor`, and `contentTextStyle`
+  for component parts; `size(width, height)` for square and fixed sizes; and
+  `wrap(.rotate(...))` for whole-widget rotation.
+- **BREAKING**: Remove `RemixBoxStylerConvenience` and its shorthand methods.
+  Use the canonical compound forms such as `padding(.all(value))`,
+  `margin(.horizontal(value))`, `border(.color(value))`,
+  `borderRadius(.circular(value))`, and `transform(Matrix4.identity())`.
+- **BREAKING**: Remove direct Material usage from the published packages.
+  `remix` no longer imports `package:flutter/material.dart`, ships no Material
+  default icons, and sets `uses-material-design: false`. Hosts on `WidgetsApp`
+  or `CupertinoApp` no longer pull Material in through Remix.
+- **FEAT**: Give `RemixAccordion` a panel container that owns the item's
+  border, radius, fill, and clipping, removing the notched seam between an
+  expanded trigger and its content. `AccordionSpec` gains `container` and
+  `containerEffects`; `trigger` remains the forwarded part.
+- **FIX**: Correct focus-visible state handling.
+- **FIX**: Respect input modality when showing focus rings, so a pointer
+  interaction no longer leaves a keyboard focus ring behind.
+- **FIX**: Make checkbox styles value-comparable.
+- **FIX**: Forward `excludeSemantics` on toggle.
+- Raise the `naked_ui` floor to `^1.0.0-beta.10`, which adds
+  `NakedAccordion.itemBuilder` and tracks accordion press state whenever the
+  item is enabled rather than only when a callback is supplied.
+
 ## 1.0.0-beta.2
 
 - **FEAT**: Lower the supported floor to Dart 3.11 / Flutter 3.41, matching
@@ -108,15 +136,6 @@
   `RemixBoxStylerMixin` are unchanged. Public styler extension names such as
   `RemixCardStylerRemixHelpers` are also unchanged, so explicit extension
   invocation stays source-compatible.
-- **BREAKING**: Remove handwritten component styler aliases that duplicate the
-  generated API. Use `color` for component surfaces; explicit child-slot
-  methods such as `labelColor`, `iconColor`, `textColor`, and `contentTextStyle`
-  for component parts; `size(width, height)` for square and fixed sizes; and
-  `wrap(.rotate(...))` for whole-widget rotation.
-- **BREAKING**: Remove `RemixBoxStylerConvenience` and its shorthand methods.
-  Use the canonical compound forms such as `padding(.all(value))`,
-  `margin(.horizontal(value))`, `border(.color(value))`,
-  `borderRadius(.circular(value))`, and `transform(Matrix4.identity())`.
 - **BREAKING**: Rename Fortal recipe helpers from `fortalXStyler()` to
   `fortalXStyle()` so `@MixWidget` can infer every generated `FortalX` name.
   Remix component styler types such as `ButtonStyler` and

--- a/packages/remix/pubspec.yaml
+++ b/packages/remix/pubspec.yaml
@@ -12,7 +12,7 @@ topics:
   - styling
   - mix
 
-version: 1.0.0-beta.2
+version: 1.0.0-beta.3
 
 # Consumer floor, matching `mix` and `naked_ui`. Intentionally lower than the
 # workspace's own toolchain floor: dev tooling needs a newer SDK than the

--- a/packages/remix_fortal/CHANGELOG.md
+++ b/packages/remix_fortal/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.1.0-beta.1
+## 0.1.0-beta.2
 
 - **FEAT**: Add Fortal-themed line, bar, and pie chart recipes and generated
   widgets backed by `mix_chart`.
@@ -7,6 +7,22 @@
   `center` alignment options, fills up to 600 pixels, and preserves safe
   viewport insets;
   `FortalPopover` has a 480-pixel maximum width.
+- **FEAT**: Complete the five typography families — `FortalText`,
+  `FortalHeading`, `FortalCode`, `FortalKbd`, and `FortalLink` — sharing one
+  nine-step `FortalTextSize` scale and one `FortalTextWeight` enum.
+- **FEAT**: `FortalScope` establishes the Radix theme root's default text run
+  (`text3` at `gray-12`, regular weight), so an unsized `FortalText`,
+  `FortalCode`, `FortalKbd`, or `FortalLink` resolves `1em` the way upstream
+  does. Only the outermost scope does this; a nested scope re-scopes tokens and
+  inherits the closest text style. Under `MaterialApp` or `CupertinoApp` the
+  scope belongs in `builder:`.
+- **FEAT**: Add `FortalCheckboxGroupItem` and share the focus ring.
+- **FEAT**: Add Fortal typography recipes.
+- **FIX**: Restore dialog and popover layout defaults.
+- Raise the `remix` floor to `^1.0.0-beta.3`.
+
+## 0.1.0-beta.1
+
 - Initial release. Fortal — the Radix Themes-inspired preset theme for
   [Remix](https://pub.dev/packages/remix) — now ships as its own package.
   `FortalScope`, `FortalTokens`, the `Fortal*` widgets, and the `fortal*Style()`

--- a/packages/remix_fortal/pubspec.yaml
+++ b/packages/remix_fortal/pubspec.yaml
@@ -15,7 +15,7 @@ topics:
 # Pre-release because every dependency below is itself a pre-release; pub warns
 # when a stable package is built on beta foundations. Graduate to 0.1.0 when
 # remix reaches 1.0.0 stable.
-version: 0.1.0-beta.1
+version: 0.1.0-beta.2
 
 # Consumer floor, matching `remix` and `mix`. See packages/remix/pubspec.yaml.
 environment:
@@ -36,7 +36,7 @@ dependencies:
   # — otherwise pub could resolve a `remix` whose symbols collide with this
   # package. `tool/fortal_parity/check.dart` (_checkRemixHostedPin) fails if the
   # two ever fall out of sync.
-  remix: ^1.0.0-beta.2 # x-release-please-version
+  remix: ^1.0.0-beta.3 # x-release-please-version
   mix: ^2.2.0-beta.4
   mix_annotations: ^2.2.0-beta.1
   mix_chart: ^0.0.1-beta.1


### PR DESCRIPTION
Prepares the next beta of both packages **by hand**, because release-please cannot do it today.

```
remix          1.0.0-beta.2  →  1.0.0-beta.3
remix_fortal   0.1.0-beta.1  →  0.1.0-beta.2
remix floor in remix_fortal  →  ^1.0.0-beta.3   (enforced by the parity checker)
```

## Why not release-please

Two independent blockers, both found by dispatching the workflow:

**1. It produces invalid versions.** The `release-type: dart` pubspec updater misparses a prerelease as a build number. The run wrote this to its branch:

```yaml
packages/remix/pubspec.yaml:         version: 2.0.0-beta.1+-beta.1
packages/remix_fortal/pubspec.yaml:  version: 1.0.0-beta.1+-beta.1
```

`+-beta.1` is not valid build metadata, the beta counter is dropped (remix is on `beta.2`), and its own manifest disagreed with the pubspec it wrote. This is [googleapis/release-please#2400](https://github.com/googleapis/release-please/issues/2400) — open, p3, no workaround published.

**2. It cannot open the PR anyway.**

```
release-please failed: GitHub Actions is not permitted to create or approve pull requests.
```

A repository setting: *Settings → Actions → General → Allow GitHub Actions to create and approve pull requests*. The 2026-08-12 23:47 run failed the same way, so this predates today.

It did push `release-please--branches--main` with the bad versions before failing. **That branch should be deleted** so nobody merges it by hand.

## Changelog correction included

Both changelogs had collected post-release entries under an **already-published** heading, because release-please normally generates those sections and two PRs hand-wrote them instead:

- the styler-alias and `RemixBoxStylerConvenience` removals sat under `remix 1.0.0-beta.2`
- the chart recipes and dialog/popover fixes sat under `remix_fortal 0.1.0-beta.1`

Neither shipped those changes — the published `0.1.0-beta.1` changelog on pub.dev reads "Initial release." only. Those entries move into the sections that will actually carry them, and the remaining commits since each tag are written up.

## Verification

- `dart pub publish --dry-run`: **0 warnings** for both packages, on a clean tree
- `remix` 2578 · `remix_fortal` 365 · dashboard 48 — all pass
- `flutter analyze --fatal-infos` clean
- Fortal parity check passes, including the `remix` floor equality it enforces
- Docs validation clean

## Publishing after merge — order matters

`publish.yml` warns about this in its own header: the two tag-triggered jobs do not order themselves.

1. push `v1.0.0-beta.3` → wait until pub.dev serves `remix 1.0.0-beta.3`
2. then push `remix_fortal-v0.1.0-beta.2`

pub.dev does not verify that a dependency version exists, so the wrong order ships an **uninstallable** `remix_fortal` rather than failing the job.

## Follow-up for the automation

Fixing release-please needs the repo permission enabled **and** a way around #2400 — most likely moving the `version:` fields onto the generic `x-release-please-version` updater already used for the `remix` floor in `remix_fortal/pubspec.yaml`, so the buggy Dart pubspec updater is bypassed.
