### PR TITLE
fix(ci): keep git clean during publish by pre-declaring analysis_options excludes

### DIFF
--- a/packages/remix/analysis_options.yaml
+++ b/packages/remix/analysis_options.yaml
@@ -1,4 +1,15 @@
 analyzer:
+  # Keep this list in sync with Flutter's AnalysisOptionsMigration so
+  # `flutter pub get` does not rewrite this file during publish (dirty git
+  # working tree makes `dart pub publish` fail with exit code 65).
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
   errors:
     non_constant_identifier_names: ignore
 

--- a/packages/remix_fortal/analysis_options.yaml
+++ b/packages/remix_fortal/analysis_options.yaml
@@ -1,4 +1,15 @@
 analyzer:
+  # Keep this list in sync with Flutter's AnalysisOptionsMigration so
+  # `flutter pub get` does not rewrite this file during publish (dirty git
+  # working tree makes `dart pub publish` fail with exit code 65).
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
   errors:
     non_constant_identifier_names: ignore
 


### PR DESCRIPTION
## Problem

The `publish-remix` job fails at the final `dart pub publish` step with **exit code 65**, even though all tests pass:

```
Package validation found the following potential issue:
* 1 checked-in file is modified in git.
  Modified files:
  analysis_options.yaml
```

([failing run](https://github.com/conceptadev/remix/actions/runs/31699195536/job/94449403078))

## Root cause

Earlier in the same job, `flutter pub get` (Flutter 3.47) runs the new `AnalysisOptionsMigration`, which logs:

```
Upgrading analysis_options.yaml to exclude build and platform directories.
```

That migrator **rewrites the checked-in `analysis_options.yaml` in place** unless `analyzer.exclude` already contains all of: `build/**`, `android/**`, `ios/**`, `web/**`, `windows/**`, `macos/**`, `linux/**`. The rewrite dirties the git working tree, so `dart pub publish` aborts.

## Fix

Add the exact `exclude` list the migrator expects to both published packages (`remix`, `remix_fortal`) so the migration is a no-op and the working tree stays clean during publish.

## Verification

- YAML parses correctly and entries match the migrator's required strings exactly.
- `flutter analyze` issue count is unchanged by this edit (verified against baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)