### PR TITLE
feat(remix): forward omitted semantic and behavioral parameters

### DIFF
--- a/docs/components/menu.mdx
+++ b/docs/components/menu.mdx
@@ -375,6 +375,8 @@ RemixMenu<T> remixMenuConstructor<T>({
   bool closeOnClickOutside = true,
   FocusNode? triggerFocusNode,
   OverlayPositionConfig positioning = const OverlayPositionConfig(),
+  String? semanticLabel,
+  bool excludeSemantics = false,
   MenuStyler style = const MenuStyler.create(),
   MenuSpec? styleSpec,
 }) => throw UnimplementedError();
@@ -445,6 +447,14 @@ Optional. Optional focus node for the trigger.
 
 Optional. Overlay positioning configuration.
 
+#### `semanticLabel` → `String?`
+
+Optional. The accessible label for the menu trigger.
+
+#### `excludeSemantics` → `bool`
+
+Optional. Whether to hide the menu trigger from the semantics tree. Defaults to `false`. This applies to the trigger only — the overlay is mounted separately, so an open menu keeps announcing its items.
+
 #### `style` → `MenuStyler`
 
 Optional. The style configuration for the menu.
@@ -502,7 +512,7 @@ Applies widget modifiers such as clipping, opacity, or scaling.
 
 Sets the widget modifier.
 
-#### `call<T>({ ... })`
+#### `call<T>({..., String? semanticLabel, bool excludeSemantics = false})`
 
 Creates a RemixMenu widget with this style applied.
 

--- a/docs/components/progress.mdx
+++ b/docs/components/progress.mdx
@@ -86,6 +86,8 @@ import 'package:remix/remix.dart';
 RemixProgress remixProgressConstructor({
   Key? key,
   required double value,
+  String? semanticsLabel,
+  String? semanticsValue,
   ProgressStyler style = const ProgressStyler.create(),
   ProgressSpec? styleSpec,
 }) => throw UnimplementedError();
@@ -111,6 +113,14 @@ Optional. Controls how one widget replaces another widget in the tree.
 #### `value` → `double`
 
 **Required**. The progress value between 0 and 1.  This value determines how much of the progress bar is filled. A value of 0 means empty, while 1 means completely filled.
+
+#### `semanticsLabel` → `String?`
+
+Optional. The accessible name for a non-decorative progress indicator. When omitted, the progress indicator remains decorative.
+
+#### `semanticsValue` → `String?`
+
+Optional. The accessible progress value used with `semanticsLabel`. When omitted, Remix announces the rounded 0–100 value.
 
 
 ### Style Methods
@@ -179,6 +189,6 @@ Sets a foreground decoration painted on top of the component.
 
 Applies a matrix transformation to the component.
 
-#### `call({Key? key, required double value})`
+#### `call({Key? key, required double value, String? semanticsLabel, String? semanticsValue})`
 
 Creates a `RemixProgress` widget with this style applied.

--- a/docs/components/radio.mdx
+++ b/docs/components/radio.mdx
@@ -190,6 +190,8 @@ RemixRadio<T> remixRadioConstructor<T>({
   MouseCursor? mouseCursor,
   FocusNode? focusNode,
   bool autofocus = false,
+  String? semanticLabel,
+  bool excludeSemantics = false,
   RadioStyler style = const RadioStyler.create(),
   RadioSpec? styleSpec,
 }) => throw UnimplementedError();
@@ -248,6 +250,14 @@ Optional. The focus node for the radio button.
 
 Optional. The mouse cursor to use when hovering over the radio button.
 
+#### `semanticLabel` → `String?`
+
+Optional. The accessible label for this radio button.
+
+#### `excludeSemantics` → `bool`
+
+Optional. Whether to hide the radio button and its visual subtree from the semantics tree. Defaults to `false`.
+
 
 #### `indicator(BoxStyler value)`
 
@@ -297,6 +307,6 @@ Sets a foreground decoration painted on top of the component.
 
 Applies a matrix transformation to the component.
 
-#### `call<T>({required T value, bool enabled = true, bool autofocus = false, bool toggleable = false, FocusNode? focusNode, MouseCursor? mouseCursor})`
+#### `call<T>({Key? key, required T value, bool enabled = true, bool toggleable = false, MouseCursor? mouseCursor, FocusNode? focusNode, bool autofocus = false, String? semanticLabel, bool excludeSemantics = false})`
 
 Creates a `RemixRadio<T>` widget with this style applied.

--- a/docs/components/slider.mdx
+++ b/docs/components/slider.mdx
@@ -119,6 +119,7 @@ class _FortalSliderExampleState extends State<FortalSliderExample> {
 <CodeGroup title="Constructor" defaultLanguage="dart">
 ```dart
 import 'package:flutter/material.dart';
+import 'package:naked_ui/naked_ui.dart';
 import 'package:remix/remix.dart';
 
 RemixSlider remixSliderConstructor({
@@ -134,6 +135,9 @@ RemixSlider remixSliderConstructor({
   FocusNode? focusNode,
   bool autofocus = false,
   int? snapDivisions,
+  String? semanticLabel,
+  NakedSliderSemanticFormatterCallback? semanticFormatterCallback,
+  bool excludeSemantics = false,
   SliderStyler style = const SliderStyler.create(),
   SliderSpec? styleSpec,
 }) => throw UnimplementedError();
@@ -199,6 +203,18 @@ Optional. Whether the slider should automatically request focus when it is creat
 #### `snapDivisions` → `int?`
 
 Optional. Optional snapping divisions for interaction only (no visual ticks). When provided, the slider snaps to these discrete steps but does not render any division marks on the track.
+
+#### `semanticLabel` → `String?`
+
+Optional. The accessible label for the slider's single thumb.
+
+#### `semanticFormatterCallback` → `NakedSliderSemanticFormatterCallback?`
+
+Optional. Formats the semantic value for the slider's single thumb. Remix forwards it to Naked as a one-element formatter list.
+
+#### `excludeSemantics` → `bool`
+
+Optional. Whether to hide the slider from the semantics tree. Defaults to `false`.
 
 
 ### Style Methods
@@ -299,6 +315,6 @@ Sets style variants.
 
 Sets the widget modifier.
 
-#### `call({ ... })`
+#### `call({Key? key, required double value, ValueChanged<double>? onChanged, ValueChanged<double>? onChangeStart, ValueChanged<double>? onChangeEnd, double min = 0.0, double max = 1.0, bool enabled = true, bool enableFeedback = true, FocusNode? focusNode, bool autofocus = false, int? snapDivisions, String? semanticLabel, NakedSliderSemanticFormatterCallback? semanticFormatterCallback, bool excludeSemantics = false})`
 
 Creates a RemixSlider widget with this style applied.

--- a/docs/components/spinner.mdx
+++ b/docs/components/spinner.mdx
@@ -94,6 +94,8 @@ import 'package:remix/remix.dart';
 
 RemixSpinner remixSpinnerConstructor({
   Key? key,
+  String? semanticsLabel,
+  String? semanticsValue,
   SpinnerStyler style = const SpinnerStyler.create(),
   SpinnerSpec? styleSpec,
 }) => throw UnimplementedError();
@@ -115,6 +117,14 @@ Optional. A pre-resolved style spec that bypasses style resolution. Useful for p
 #### `key` → `Key?`
 
 Optional. Controls how one widget replaces another widget in the tree.
+
+#### `semanticsLabel` → `String?`
+
+Optional. The accessible name for a non-decorative loading spinner. When omitted, the spinner remains decorative.
+
+#### `semanticsValue` → `String?`
+
+Optional. Status text announced with `semanticsLabel`.
 
 
 ### Style Methods
@@ -151,6 +161,6 @@ Configures implicit animation for style transitions.
 
 Applies widget modifiers such as clipping, opacity, or scaling.
 
-#### `call()`
+#### `call({Key? key, String? semanticsLabel, String? semanticsValue})`
 
 Creates a `RemixSpinner` widget with this style applied.

--- a/docs/components/switch.mdx
+++ b/docs/components/switch.mdx
@@ -139,6 +139,7 @@ RemixSwitch remixSwitchConstructor({
   FocusNode? focusNode,
   bool autofocus = false,
   String? semanticLabel,
+  bool excludeSemantics = false,
   MouseCursor mouseCursor = SystemMouseCursors.click,
   SwitchStyler style = const SwitchStyler.create(),
   SwitchSpec? styleSpec,
@@ -189,6 +190,10 @@ Optional. Whether the switch should automatically request focus when it is creat
 #### `semanticLabel` → `String?`
 
 Optional. The semantic label for the switch.
+
+#### `excludeSemantics` → `bool`
+
+Optional. Whether to hide the switch and its visual subtree from the semantics tree. Defaults to `false`.
 
 #### `mouseCursor` → `MouseCursor`
 
@@ -261,6 +266,6 @@ Sets a foreground decoration painted on top of the component.
 
 Applies a matrix transformation to the component.
 
-#### `call({ ... })`
+#### `call({..., String? semanticLabel, bool excludeSemantics = false, ...})`
 
 Creates a `RemixSwitch` widget with this style applied.

--- a/docs/components/tabs.mdx
+++ b/docs/components/tabs.mdx
@@ -187,6 +187,7 @@ RemixTabs remixTabsConstructor({
   String? selectedTabId,
   ValueChanged<String>? onChanged,
   Axis orientation = Axis.horizontal,
+  NakedTabActivationMode activationMode = NakedTabActivationMode.automatic,
   bool enabled = true,
   VoidCallback? onEscapePressed,
 }) => throw UnimplementedError();
@@ -225,6 +226,7 @@ RemixTabView remixTabViewConstructor({
   Key? key,
   required String tabId,
   required Widget child,
+  bool maintainState = true,
   TabViewStyler style = const TabViewStyler.create(),
   TabViewSpec? styleSpec,
 }) => throw UnimplementedError();
@@ -259,6 +261,10 @@ Optional. Called when the selected tab changes.
 
 Optional. The tab list orientation.
 
+#### `activationMode` → `NakedTabActivationMode`
+
+Optional. Whether moving focus automatically selects the focused tab. Defaults to `NakedTabActivationMode.automatic`; use `manual` when selection should require explicit activation.
+
 #### `enabled` → `bool`
 
 Optional. Whether the tabs are enabled.
@@ -272,6 +278,10 @@ Optional. Called when Escape is pressed while a tab has focus.
 `RemixTabBar`, `RemixTab`, and `RemixTabView` each accept their matching
 `Remix*Styler` through `style` and an optional raw `Remix*Spec` through
 `styleSpec`. A raw spec bypasses fluent style resolution.
+
+#### `maintainState` → `bool`
+
+Optional on `RemixTabView`. Whether the panel keeps its state while hidden. Defaults to `true`.
 
 
 ### Tab Bar Style Methods
@@ -554,6 +564,6 @@ Sets custom tab view variants.
 
 Applies widget modifiers to the tab view.
 
-#### `call({Key? key, required String tabId, required Widget child})`
+#### `call({Key? key, required String tabId, required Widget child, bool maintainState = true})`
 
 Creates a `RemixTabView` widget with this style applied.

--- a/packages/remix/lib/src/components/menu/menu_style.dart
+++ b/packages/remix/lib/src/components/menu/menu_style.dart
@@ -34,6 +34,8 @@ extension RemixMenuStylerRemixHelpers on MenuStyler {
     bool closeOnClickOutside = true,
     FocusNode? triggerFocusNode,
     OverlayPositionConfig positioning = const OverlayPositionConfig(),
+    String? semanticLabel,
+    bool excludeSemantics = false,
   }) {
     return RemixMenu(
       key: key,
@@ -51,6 +53,8 @@ extension RemixMenuStylerRemixHelpers on MenuStyler {
       closeOnClickOutside: closeOnClickOutside,
       triggerFocusNode: triggerFocusNode,
       positioning: positioning,
+      semanticLabel: semanticLabel,
+      excludeSemantics: excludeSemantics,
       style: this,
     );
   }

--- a/packages/remix/lib/src/components/menu/menu_widget.dart
+++ b/packages/remix/lib/src/components/menu/menu_widget.dart
@@ -342,6 +342,8 @@ class RemixMenu<T> extends StatefulWidget {
     this.closeOnClickOutside = true,
     this.triggerFocusNode,
     this.positioning = const OverlayPositionConfig(),
+    this.semanticLabel,
+    this.excludeSemantics = false,
     this.style = const MenuStyler.create(),
     this.styleSpec,
   });
@@ -387,6 +389,16 @@ class RemixMenu<T> extends StatefulWidget {
 
   /// Overlay positioning configuration.
   final OverlayPositionConfig positioning;
+
+  /// The semantic label for the menu trigger.
+  final String? semanticLabel;
+
+  /// Whether to hide the menu trigger from the semantic tree.
+  ///
+  /// Naked applies this to the trigger only. The overlay content is mounted
+  /// into the ambient [Overlay], a sibling subtree that `ExcludeSemantics`
+  /// cannot reach, so an open menu keeps announcing its items.
+  final bool excludeSemantics;
 
   /// The style configuration for the menu.
   final MenuStyler style;
@@ -457,6 +469,8 @@ class _RemixMenuState<T> extends State<RemixMenu<T>> {
       closeOnClickOutside: widget.closeOnClickOutside,
       triggerFocusNode: widget.triggerFocusNode,
       positioning: widget.positioning,
+      semanticLabel: widget.semanticLabel,
+      excludeSemantics: widget.excludeSemantics,
       // Render trigger from RemixMenuTrigger data
       builder: (context, state, _) {
         return RemixStyleSpecBuilder<MenuSpec>(

--- a/packages/remix/lib/src/components/progress/progress_style.dart
+++ b/packages/remix/lib/src/components/progress/progress_style.dart
@@ -24,7 +24,18 @@ extension RemixProgressStylerRemixHelpers on ProgressStyler {
   }
 
   /// Creates a [RemixProgress] widget with this style applied.
-  RemixProgress call({Key? key, required double value}) {
-    return RemixProgress(key: key, value: value, style: this);
+  RemixProgress call({
+    Key? key,
+    required double value,
+    String? semanticsLabel,
+    String? semanticsValue,
+  }) {
+    return RemixProgress(
+      key: key,
+      value: value,
+      semanticsLabel: semanticsLabel,
+      semanticsValue: semanticsValue,
+      style: this,
+    );
   }
 }

--- a/packages/remix/lib/src/components/radio/radio_style.dart
+++ b/packages/remix/lib/src/components/radio/radio_style.dart
@@ -11,6 +11,8 @@ extension RemixRadioStylerRemixHelpers on RadioStyler {
     MouseCursor? mouseCursor,
     FocusNode? focusNode,
     bool autofocus = false,
+    String? semanticLabel,
+    bool excludeSemantics = false,
   }) {
     return RemixRadio(
       key: key,
@@ -20,6 +22,8 @@ extension RemixRadioStylerRemixHelpers on RadioStyler {
       mouseCursor: mouseCursor,
       focusNode: focusNode,
       autofocus: autofocus,
+      semanticLabel: semanticLabel,
+      excludeSemantics: excludeSemantics,
       style: this,
     );
   }

--- a/packages/remix/lib/src/components/radio/radio_widget.dart
+++ b/packages/remix/lib/src/components/radio/radio_widget.dart
@@ -39,6 +39,8 @@ class RemixRadio<T> extends StatelessWidget {
     this.mouseCursor,
     this.focusNode,
     this.autofocus = false,
+    this.semanticLabel,
+    this.excludeSemantics = false,
     this.style = const RadioStyler.create(),
     this.styleSpec,
   });
@@ -66,6 +68,12 @@ class RemixRadio<T> extends StatelessWidget {
 
   /// The mouse cursor to use when hovering over the radio button.
   final MouseCursor? mouseCursor;
+
+  /// The semantic label for the radio button.
+  final String? semanticLabel;
+
+  /// Whether to hide the radio button and its visual subtree from semantics.
+  final bool excludeSemantics;
 
   @override
   Widget build(BuildContext context) {
@@ -110,6 +118,8 @@ class RemixRadio<T> extends StatelessWidget {
       focusNode: focusNode,
       autofocus: autofocus,
       toggleable: toggleable,
+      semanticLabel: semanticLabel,
+      excludeSemantics: excludeSemantics,
       builder: (context, _, __) {
         return RemixStyleSpecBuilder<RadioSpec>(
           style: style,

--- a/packages/remix/lib/src/components/slider/slider_style.dart
+++ b/packages/remix/lib/src/components/slider/slider_style.dart
@@ -64,6 +64,9 @@ extension RemixSliderStylerRemixHelpers on SliderStyler {
     FocusNode? focusNode,
     bool autofocus = false,
     int? snapDivisions,
+    String? semanticLabel,
+    NakedSliderSemanticFormatterCallback? semanticFormatterCallback,
+    bool excludeSemantics = false,
   }) {
     return RemixSlider(
       key: key,
@@ -78,6 +81,9 @@ extension RemixSliderStylerRemixHelpers on SliderStyler {
       focusNode: focusNode,
       autofocus: autofocus,
       snapDivisions: snapDivisions,
+      semanticLabel: semanticLabel,
+      semanticFormatterCallback: semanticFormatterCallback,
+      excludeSemantics: excludeSemantics,
       style: this,
     );
   }

--- a/packages/remix/lib/src/components/slider/slider_widget.dart
+++ b/packages/remix/lib/src/components/slider/slider_widget.dart
@@ -30,6 +30,9 @@ class RemixSlider extends StatelessWidget {
     this.focusNode,
     this.autofocus = false,
     this.snapDivisions,
+    this.semanticLabel,
+    this.semanticFormatterCallback,
+    this.excludeSemantics = false,
     this.style = const SliderStyler.create(),
     this.styleSpec,
   }) : assert(min <= max, 'Slider min must be less than or equal to max'),
@@ -86,6 +89,15 @@ class RemixSlider extends StatelessWidget {
   /// The focus node for the slider.
   final FocusNode? focusNode;
 
+  /// The semantic label for the slider's single thumb.
+  final String? semanticLabel;
+
+  /// Formats the semantic value for the slider's single thumb.
+  final NakedSliderSemanticFormatterCallback? semanticFormatterCallback;
+
+  /// Whether to hide the slider from the semantic tree.
+  final bool excludeSemantics;
+
   double get _effectiveStep {
     final divisions = snapDivisions;
     if (divisions != null) return (max - min) / divisions;
@@ -113,6 +125,11 @@ class RemixSlider extends StatelessWidget {
       enableFeedback: enableFeedback,
       focusNodes: focusNode == null ? null : [focusNode],
       autofocusThumbIndex: autofocus ? 0 : null,
+      semanticLabels: semanticLabel == null ? null : [semanticLabel],
+      semanticFormatterCallbacks: semanticFormatterCallback == null
+          ? null
+          : [semanticFormatterCallback],
+      excludeSemantics: excludeSemantics,
       builder: (context, state, _) {
         return RemixStyleSpecBuilder<SliderSpec>(
           style: style,

--- a/packages/remix/lib/src/components/spinner/spinner_style.dart
+++ b/packages/remix/lib/src/components/spinner/spinner_style.dart
@@ -5,7 +5,16 @@ part of 'spinner.dart';
 /// Use this class to customize spinner size, stroke widths, colors, duration,
 /// and Mix variants.
 extension RemixSpinnerStylerRemixHelpers on SpinnerStyler {
-  RemixSpinner call({Key? key}) {
-    return RemixSpinner(key: key, style: this);
+  RemixSpinner call({
+    Key? key,
+    String? semanticsLabel,
+    String? semanticsValue,
+  }) {
+    return RemixSpinner(
+      key: key,
+      semanticsLabel: semanticsLabel,
+      semanticsValue: semanticsValue,
+      style: this,
+    );
   }
 }

--- a/packages/remix/lib/src/components/switch/switch_style.dart
+++ b/packages/remix/lib/src/components/switch/switch_style.dart
@@ -42,6 +42,7 @@ extension RemixSwitchStylerRemixHelpers on SwitchStyler {
     FocusNode? focusNode,
     bool autofocus = false,
     String? semanticLabel,
+    bool excludeSemantics = false,
     MouseCursor mouseCursor = SystemMouseCursors.click,
   }) {
     return RemixSwitch(
@@ -53,6 +54,7 @@ extension RemixSwitchStylerRemixHelpers on SwitchStyler {
       focusNode: focusNode,
       autofocus: autofocus,
       semanticLabel: semanticLabel,
+      excludeSemantics: excludeSemantics,
       mouseCursor: mouseCursor,
       style: this,
     );

--- a/packages/remix/lib/src/components/switch/switch_widget.dart
+++ b/packages/remix/lib/src/components/switch/switch_widget.dart
@@ -24,6 +24,7 @@ class RemixSwitch extends StatelessWidget {
     this.focusNode,
     this.autofocus = false,
     this.semanticLabel,
+    this.excludeSemantics = false,
     this.mouseCursor = SystemMouseCursors.click,
     this.style = const SwitchStyler.create(),
     this.styleSpec,
@@ -61,6 +62,9 @@ class RemixSwitch extends StatelessWidget {
   /// The semantic label for the switch.
   final String? semanticLabel;
 
+  /// Whether to hide the switch and its visual subtree from semantics.
+  final bool excludeSemantics;
+
   /// Cursor when hovering over the switch.
   final MouseCursor mouseCursor;
 
@@ -86,6 +90,7 @@ class RemixSwitch extends StatelessWidget {
       autofocus: autofocus,
       semanticLabel: semanticLabel,
       asSwitch: true,
+      excludeSemantics: excludeSemantics,
       builder: (context, state, _) {
         return RemixStyleSpecBuilder<SwitchSpec>(
           style: _buildStyle(),

--- a/packages/remix/lib/src/components/tabs/tabs_style.dart
+++ b/packages/remix/lib/src/components/tabs/tabs_style.dart
@@ -16,8 +16,19 @@ extension RemixTabBarStylerRemixHelpers on TabBarStyler {
 /// tab.
 extension RemixTabViewStylerRemixHelpers on TabViewStyler {
   /// Creates a [RemixTabView] widget with this style applied.
-  RemixTabView call({Key? key, required String tabId, required Widget child}) {
-    return RemixTabView(key: key, tabId: tabId, style: this, child: child);
+  RemixTabView call({
+    Key? key,
+    required String tabId,
+    required Widget child,
+    bool maintainState = true,
+  }) {
+    return RemixTabView(
+      key: key,
+      tabId: tabId,
+      maintainState: maintainState,
+      style: this,
+      child: child,
+    );
   }
 }
 

--- a/packages/remix/lib/src/components/tabs/tabs_widget.dart
+++ b/packages/remix/lib/src/components/tabs/tabs_widget.dart
@@ -38,6 +38,7 @@ class RemixTabs extends StatelessWidget {
     this.selectedTabId,
     this.onChanged,
     this.orientation = .horizontal,
+    this.activationMode = NakedTabActivationMode.automatic,
     this.enabled = true,
     this.onEscapePressed,
   }) : assert(
@@ -63,6 +64,9 @@ class RemixTabs extends StatelessWidget {
   /// The tab list orientation.
   final Axis orientation;
 
+  /// Whether moving focus also selects the focused tab.
+  final NakedTabActivationMode activationMode;
+
   /// Called when Escape is pressed while a tab has focus.
   final VoidCallback? onEscapePressed;
 
@@ -73,6 +77,7 @@ class RemixTabs extends StatelessWidget {
       selectedTabId: selectedTabId,
       onChanged: onChanged,
       orientation: orientation,
+      activationMode: activationMode,
       enabled: enabled,
       onEscapePressed: onEscapePressed,
       child: child,
@@ -240,6 +245,7 @@ class RemixTabView extends StatelessWidget {
     super.key,
     required this.tabId,
     required this.child,
+    this.maintainState = true,
     this.style = const TabViewStyler.create(),
     this.styleSpec,
   });
@@ -249,6 +255,9 @@ class RemixTabView extends StatelessWidget {
 
   /// The content to show when this tab is selected.
   final Widget child;
+
+  /// Whether to maintain the content's state while this tab is hidden.
+  final bool maintainState;
 
   /// Style applied to the tab view container.
   final TabViewStyler style;
@@ -262,6 +271,7 @@ class RemixTabView extends StatelessWidget {
   Widget build(BuildContext context) {
     return NakedTabView(
       tabId: tabId,
+      maintainState: maintainState,
       child: RemixStyleSpecBuilder<TabViewSpec>(
         style: style,
         styleSpec: styleSpec,

--- a/packages/remix/test/components/semantic_behavior_forwarding_test.dart
+++ b/packages/remix/test/components/semantic_behavior_forwarding_test.dart
@@ -1,0 +1,289 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:naked_ui/naked_ui.dart';
+import 'package:remix/remix.dart';
+
+import '../helpers/test_helpers.dart';
+
+void main() {
+  group('semantic and behavioral parameter forwarding', () {
+    test('ProgressStyler.call forwards semantic inputs and defaults', () {
+      final style = ProgressStyler();
+      final defaultProgress = style.call(value: 0.25);
+      final labeledProgress = style.call(
+        value: 0.5,
+        semanticsLabel: 'Upload progress',
+        semanticsValue: '50%',
+      );
+
+      expect(defaultProgress.semanticsLabel, isNull);
+      expect(defaultProgress.semanticsValue, isNull);
+      expect(labeledProgress.semanticsLabel, 'Upload progress');
+      expect(labeledProgress.semanticsValue, '50%');
+      expect(labeledProgress.style, same(style));
+    });
+
+    test('SpinnerStyler.call forwards semantic inputs and defaults', () {
+      final style = SpinnerStyler();
+      final defaultSpinner = style.call();
+      final labeledSpinner = style.call(
+        semanticsLabel: 'Loading account',
+        semanticsValue: 'Connecting',
+      );
+
+      expect(defaultSpinner.semanticsLabel, isNull);
+      expect(defaultSpinner.semanticsValue, isNull);
+      expect(labeledSpinner.semanticsLabel, 'Loading account');
+      expect(labeledSpinner.semanticsValue, 'Connecting');
+      expect(labeledSpinner.style, same(style));
+    });
+
+    testWidgets('RemixRadio and RadioStyler.call forward semantics', (
+      tester,
+    ) async {
+      final defaultRadio = RadioStyler().call<String>(value: 'default');
+
+      expect(defaultRadio.semanticLabel, isNull);
+      expect(defaultRadio.excludeSemantics, isFalse);
+
+      await tester.pumpRemixApp(
+        RemixRadioGroup<String>(
+          groupValue: 'default',
+          onChanged: (_) {},
+          child: defaultRadio,
+        ),
+      );
+
+      var nakedRadio = tester.widget<NakedRadio<String>>(
+        find.byType(NakedRadio<String>),
+      );
+      expect(nakedRadio.semanticLabel, isNull);
+      expect(nakedRadio.excludeSemantics, isFalse);
+
+      final labeledRadio = RadioStyler().call<String>(
+        value: 'labeled',
+        semanticLabel: 'Preferred option',
+        excludeSemantics: true,
+      );
+
+      expect(labeledRadio.semanticLabel, 'Preferred option');
+      expect(labeledRadio.excludeSemantics, isTrue);
+
+      await tester.pumpRemixApp(
+        RemixRadioGroup<String>(
+          groupValue: 'labeled',
+          onChanged: (_) {},
+          child: labeledRadio,
+        ),
+      );
+
+      nakedRadio = tester.widget<NakedRadio<String>>(
+        find.byType(NakedRadio<String>),
+      );
+      expect(nakedRadio.semanticLabel, 'Preferred option');
+      expect(nakedRadio.excludeSemantics, isTrue);
+    });
+
+    testWidgets(
+      'RemixSlider and SliderStyler.call map scalar semantics to one thumb',
+      (tester) async {
+        final defaultSlider = SliderStyler().call(value: 0.25);
+
+        expect(defaultSlider.semanticLabel, isNull);
+        expect(defaultSlider.semanticFormatterCallback, isNull);
+        expect(defaultSlider.excludeSemantics, isFalse);
+
+        await tester.pumpRemixApp(defaultSlider);
+
+        var nakedSlider = tester.widget<NakedSlider>(find.byType(NakedSlider));
+        expect(nakedSlider.semanticLabels, isNull);
+        expect(nakedSlider.semanticFormatterCallbacks, isNull);
+        expect(nakedSlider.excludeSemantics, isFalse);
+
+        String formatter(double value) => '${value.round()} percent';
+
+        final labeledSlider = SliderStyler().call(
+          value: 0.5,
+          semanticLabel: 'Volume',
+          semanticFormatterCallback: formatter,
+          excludeSemantics: true,
+        );
+
+        expect(labeledSlider.semanticLabel, 'Volume');
+        expect(labeledSlider.semanticFormatterCallback, same(formatter));
+        expect(labeledSlider.excludeSemantics, isTrue);
+
+        await tester.pumpRemixApp(labeledSlider);
+
+        nakedSlider = tester.widget<NakedSlider>(find.byType(NakedSlider));
+        expect(nakedSlider.semanticLabels, <String?>['Volume']);
+        expect(nakedSlider.semanticFormatterCallbacks, hasLength(1));
+        expect(nakedSlider.semanticFormatterCallbacks!.single, same(formatter));
+        expect(
+          nakedSlider.semanticFormatterCallbacks!.single!(42),
+          '42 percent',
+        );
+        expect(nakedSlider.excludeSemantics, isTrue);
+      },
+    );
+
+    testWidgets('RemixTabs forwards activation mode and its default', (
+      tester,
+    ) async {
+      await tester.pumpRemixApp(
+        const RemixTabs(selectedTabId: 'one', child: SizedBox()),
+      );
+
+      var nakedTabs = tester.widget<NakedTabs>(find.byType(NakedTabs));
+      expect(nakedTabs.activationMode, NakedTabActivationMode.automatic);
+
+      await tester.pumpRemixApp(
+        const RemixTabs(
+          selectedTabId: 'one',
+          activationMode: NakedTabActivationMode.manual,
+          child: SizedBox(),
+        ),
+      );
+
+      nakedTabs = tester.widget<NakedTabs>(find.byType(NakedTabs));
+      expect(nakedTabs.activationMode, NakedTabActivationMode.manual);
+    });
+
+    testWidgets('RemixTabView and TabViewStyler.call forward maintainState', (
+      tester,
+    ) async {
+      final defaultView = TabViewStyler().call(
+        tabId: 'one',
+        child: const SizedBox(),
+      );
+
+      expect(defaultView.maintainState, isTrue);
+
+      await tester.pumpRemixApp(
+        RemixTabs(selectedTabId: 'one', child: defaultView),
+      );
+
+      var nakedView = tester.widget<NakedTabView>(find.byType(NakedTabView));
+      expect(nakedView.maintainState, isTrue);
+
+      final disposableView = TabViewStyler().call(
+        tabId: 'one',
+        maintainState: false,
+        child: const SizedBox(),
+      );
+
+      expect(disposableView.maintainState, isFalse);
+
+      await tester.pumpRemixApp(
+        RemixTabs(selectedTabId: 'one', child: disposableView),
+      );
+
+      nakedView = tester.widget<NakedTabView>(find.byType(NakedTabView));
+      expect(nakedView.maintainState, isFalse);
+    });
+
+    testWidgets('RemixMenu and MenuStyler.call forward semantics', (
+      tester,
+    ) async {
+      final defaultMenu = MenuStyler().call<String>(
+        trigger: const RemixMenuTrigger(label: 'Open'),
+        items: const [RemixMenuItem(value: 'item', label: 'Item')],
+      );
+
+      expect(defaultMenu.semanticLabel, isNull);
+      expect(defaultMenu.excludeSemantics, isFalse);
+
+      await tester.pumpRemixApp(defaultMenu);
+
+      var nakedMenu = tester.widget<NakedMenu<String>>(
+        find.byType(NakedMenu<String>),
+      );
+      expect(nakedMenu.semanticLabel, isNull);
+      expect(nakedMenu.excludeSemantics, isFalse);
+
+      final labeledMenu = MenuStyler().call<String>(
+        trigger: const RemixMenuTrigger(label: 'Open'),
+        items: const [RemixMenuItem(value: 'item', label: 'Item')],
+        semanticLabel: 'Account actions',
+        excludeSemantics: true,
+      );
+
+      expect(labeledMenu.semanticLabel, 'Account actions');
+      expect(labeledMenu.excludeSemantics, isTrue);
+
+      await tester.pumpRemixApp(labeledMenu);
+
+      nakedMenu = tester.widget<NakedMenu<String>>(
+        find.byType(NakedMenu<String>),
+      );
+      expect(nakedMenu.semanticLabel, 'Account actions');
+      expect(nakedMenu.excludeSemantics, isTrue);
+    });
+
+    // Pins the documented scope of RemixMenu.excludeSemantics. Naked wraps only
+    // the trigger in ExcludeSemantics; the overlay is mounted into the ambient
+    // Overlay, so item semantics survive. Without this, the doc comment on
+    // RemixMenu.excludeSemantics is an unverifiable claim.
+    testWidgets(
+      'RemixMenu excludeSemantics covers the trigger, not the items',
+      (tester) async {
+        final semantics = tester.ensureSemantics();
+        final controller = MenuController();
+
+        await tester.pumpRemixApp(
+          RemixMenu<String>(
+            trigger: const RemixMenuTrigger(label: 'Options'),
+            items: const [RemixMenuItem(value: 'copy', label: 'Copy')],
+            controller: controller,
+            semanticLabel: 'Account actions',
+            excludeSemantics: true,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        controller.open();
+        await tester.pumpAndSettle();
+
+        final triggerCount = find
+            .bySemanticsLabel('Account actions')
+            .evaluate()
+            .length;
+        final itemCount = find.bySemanticsLabel('Copy').evaluate().length;
+        semantics.dispose();
+
+        expect(triggerCount, 0, reason: 'trigger semantics are excluded');
+        expect(
+          itemCount,
+          1,
+          reason: 'overlay items stay in the semantics tree',
+        );
+      },
+    );
+
+    testWidgets('RemixSwitch and SwitchStyler.call forward excludeSemantics', (
+      tester,
+    ) async {
+      final defaultSwitch = SwitchStyler().call(selected: false);
+
+      expect(defaultSwitch.excludeSemantics, isFalse);
+
+      await tester.pumpRemixApp(defaultSwitch);
+
+      var nakedToggle = tester.widget<NakedToggle>(find.byType(NakedToggle));
+      expect(nakedToggle.excludeSemantics, isFalse);
+
+      final excludedSwitch = SwitchStyler().call(
+        selected: true,
+        semanticLabel: 'Notifications',
+        excludeSemantics: true,
+      );
+
+      expect(excludedSwitch.excludeSemantics, isTrue);
+
+      await tester.pumpRemixApp(excludedSwitch);
+
+      nakedToggle = tester.widget<NakedToggle>(find.byType(NakedToggle));
+      expect(nakedToggle.excludeSemantics, isTrue);
+    });
+  });
+}

--- a/packages/remix_fortal/lib/src/recipes/menu.g.dart
+++ b/packages/remix_fortal/lib/src/recipes/menu.g.dart
@@ -27,6 +27,8 @@ class FortalMenu<T> extends StatelessWidget {
     this.closeOnClickOutside = true,
     this.triggerFocusNode,
     this.positioning = const OverlayPositionConfig(),
+    this.semanticLabel,
+    this.excludeSemantics = false,
   });
 
   const FortalMenu.solid({
@@ -47,6 +49,8 @@ class FortalMenu<T> extends StatelessWidget {
     this.closeOnClickOutside = true,
     this.triggerFocusNode,
     this.positioning = const OverlayPositionConfig(),
+    this.semanticLabel,
+    this.excludeSemantics = false,
   }) : variant = FortalMenuVariant.solid;
 
   const FortalMenu.soft({
@@ -67,6 +71,8 @@ class FortalMenu<T> extends StatelessWidget {
     this.closeOnClickOutside = true,
     this.triggerFocusNode,
     this.positioning = const OverlayPositionConfig(),
+    this.semanticLabel,
+    this.excludeSemantics = false,
   }) : variant = FortalMenuVariant.soft;
 
   final FortalMenuVariant variant;
@@ -103,6 +109,10 @@ class FortalMenu<T> extends StatelessWidget {
 
   final OverlayPositionConfig positioning;
 
+  final String? semanticLabel;
+
+  final bool excludeSemantics;
+
   @override
   Widget build(BuildContext context) {
     return RemixMenu<T>(
@@ -126,6 +136,8 @@ class FortalMenu<T> extends StatelessWidget {
       closeOnClickOutside: this.closeOnClickOutside,
       triggerFocusNode: this.triggerFocusNode,
       positioning: this.positioning,
+      semanticLabel: this.semanticLabel,
+      excludeSemantics: this.excludeSemantics,
     );
   }
 }

--- a/packages/remix_fortal/lib/src/recipes/radio.g.dart
+++ b/packages/remix_fortal/lib/src/recipes/radio.g.dart
@@ -19,6 +19,8 @@ class FortalRadio<T> extends StatelessWidget {
     this.mouseCursor,
     this.focusNode,
     this.autofocus = false,
+    this.semanticLabel,
+    this.excludeSemantics = false,
   });
 
   /// Raised treatment with Radix's classic shadow and gradient layers.
@@ -32,6 +34,8 @@ class FortalRadio<T> extends StatelessWidget {
     this.mouseCursor,
     this.focusNode,
     this.autofocus = false,
+    this.semanticLabel,
+    this.excludeSemantics = false,
   }) : variant = FortalRadioVariant.classic;
 
   /// Surface treatment with neutral border.
@@ -45,6 +49,8 @@ class FortalRadio<T> extends StatelessWidget {
     this.mouseCursor,
     this.focusNode,
     this.autofocus = false,
+    this.semanticLabel,
+    this.excludeSemantics = false,
   }) : variant = FortalRadioVariant.surface;
 
   /// Soft accent treatment.
@@ -58,6 +64,8 @@ class FortalRadio<T> extends StatelessWidget {
     this.mouseCursor,
     this.focusNode,
     this.autofocus = false,
+    this.semanticLabel,
+    this.excludeSemantics = false,
   }) : variant = FortalRadioVariant.soft;
 
   final FortalRadioVariant variant;
@@ -78,6 +86,10 @@ class FortalRadio<T> extends StatelessWidget {
 
   final bool autofocus;
 
+  final String? semanticLabel;
+
+  final bool excludeSemantics;
+
   @override
   Widget build(BuildContext context) {
     return RemixRadio<T>(
@@ -93,6 +105,8 @@ class FortalRadio<T> extends StatelessWidget {
       mouseCursor: this.mouseCursor,
       focusNode: this.focusNode,
       autofocus: this.autofocus,
+      semanticLabel: this.semanticLabel,
+      excludeSemantics: this.excludeSemantics,
     );
   }
 }

--- a/packages/remix_fortal/lib/src/recipes/slider.dart
+++ b/packages/remix_fortal/lib/src/recipes/slider.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/widgets.dart';
 import 'package:mix_annotations/mix_annotations.dart';
+import 'package:naked_ui/naked_ui.dart';
 import 'package:remix/remix.dart';
 
 import '../fortal/fortal.dart';

--- a/packages/remix_fortal/lib/src/recipes/slider.g.dart
+++ b/packages/remix_fortal/lib/src/recipes/slider.g.dart
@@ -24,6 +24,9 @@ class FortalSlider extends StatelessWidget {
     this.focusNode,
     this.autofocus = false,
     this.snapDivisions,
+    this.semanticLabel,
+    this.semanticFormatterCallback,
+    this.excludeSemantics = false,
   });
 
   const FortalSlider.classic({
@@ -41,6 +44,9 @@ class FortalSlider extends StatelessWidget {
     this.focusNode,
     this.autofocus = false,
     this.snapDivisions,
+    this.semanticLabel,
+    this.semanticFormatterCallback,
+    this.excludeSemantics = false,
   }) : variant = FortalSliderVariant.classic;
 
   const FortalSlider.surface({
@@ -58,6 +64,9 @@ class FortalSlider extends StatelessWidget {
     this.focusNode,
     this.autofocus = false,
     this.snapDivisions,
+    this.semanticLabel,
+    this.semanticFormatterCallback,
+    this.excludeSemantics = false,
   }) : variant = FortalSliderVariant.surface;
 
   const FortalSlider.soft({
@@ -75,6 +84,9 @@ class FortalSlider extends StatelessWidget {
     this.focusNode,
     this.autofocus = false,
     this.snapDivisions,
+    this.semanticLabel,
+    this.semanticFormatterCallback,
+    this.excludeSemantics = false,
   }) : variant = FortalSliderVariant.soft;
 
   final FortalSliderVariant variant;
@@ -105,6 +117,12 @@ class FortalSlider extends StatelessWidget {
 
   final int? snapDivisions;
 
+  final String? semanticLabel;
+
+  final NakedSliderSemanticFormatterCallback? semanticFormatterCallback;
+
+  final bool excludeSemantics;
+
   @override
   Widget build(BuildContext context) {
     return RemixSlider(
@@ -125,6 +143,9 @@ class FortalSlider extends StatelessWidget {
       focusNode: this.focusNode,
       autofocus: this.autofocus,
       snapDivisions: this.snapDivisions,
+      semanticLabel: this.semanticLabel,
+      semanticFormatterCallback: this.semanticFormatterCallback,
+      excludeSemantics: this.excludeSemantics,
     );
   }
 }

--- a/packages/remix_fortal/lib/src/recipes/switch.g.dart
+++ b/packages/remix_fortal/lib/src/recipes/switch.g.dart
@@ -20,6 +20,7 @@ class FortalSwitch extends StatelessWidget {
     this.focusNode,
     this.autofocus = false,
     this.semanticLabel,
+    this.excludeSemantics = false,
     this.mouseCursor = SystemMouseCursors.click,
   });
 
@@ -35,6 +36,7 @@ class FortalSwitch extends StatelessWidget {
     this.focusNode,
     this.autofocus = false,
     this.semanticLabel,
+    this.excludeSemantics = false,
     this.mouseCursor = SystemMouseCursors.click,
   }) : variant = FortalSwitchVariant.classic;
 
@@ -50,6 +52,7 @@ class FortalSwitch extends StatelessWidget {
     this.focusNode,
     this.autofocus = false,
     this.semanticLabel,
+    this.excludeSemantics = false,
     this.mouseCursor = SystemMouseCursors.click,
   }) : variant = FortalSwitchVariant.surface;
 
@@ -65,6 +68,7 @@ class FortalSwitch extends StatelessWidget {
     this.focusNode,
     this.autofocus = false,
     this.semanticLabel,
+    this.excludeSemantics = false,
     this.mouseCursor = SystemMouseCursors.click,
   }) : variant = FortalSwitchVariant.soft;
 
@@ -88,6 +92,8 @@ class FortalSwitch extends StatelessWidget {
 
   final String? semanticLabel;
 
+  final bool excludeSemantics;
+
   final MouseCursor mouseCursor;
 
   @override
@@ -106,6 +112,7 @@ class FortalSwitch extends StatelessWidget {
       focusNode: this.focusNode,
       autofocus: this.autofocus,
       semanticLabel: this.semanticLabel,
+      excludeSemantics: this.excludeSemantics,
       mouseCursor: this.mouseCursor,
     );
   }

--- a/packages/remix_fortal/lib/src/recipes/tabs.g.dart
+++ b/packages/remix_fortal/lib/src/recipes/tabs.g.dart
@@ -27,11 +27,18 @@ class FortalTabBar extends StatelessWidget {
 
 /// Fortal-themed preset for [RemixTabView].
 class FortalTabView extends StatelessWidget {
-  const FortalTabView({super.key, required this.tabId, required this.child});
+  const FortalTabView({
+    super.key,
+    required this.tabId,
+    required this.child,
+    this.maintainState = true,
+  });
 
   final String tabId;
 
   final Widget child;
+
+  final bool maintainState;
 
   @override
   Widget build(BuildContext context) {
@@ -40,6 +47,7 @@ class FortalTabView extends StatelessWidget {
       style: fortalTabViewStyle(),
       tabId: this.tabId,
       child: this.child,
+      maintainState: this.maintainState,
     );
   }
 }


### PR DESCRIPTION
## Description

Several Remix wrappers and `Styler.call(...)` helpers accepted less than the primitive underneath them, so consumers could not reach configuration that was already implemented one layer down. This closes the eight gaps audited in #141.

**Widgets gain the parameters their Naked primitive already supports.** `RemixRadio` and `RemixMenu` gain `semanticLabel`/`excludeSemantics`; `RemixSwitch` gains `excludeSemantics` (matching the `RemixToggle` precedent from #119, same primitive, same spelling); `RemixSlider` gains `semanticLabel`/`semanticFormatterCallback`/`excludeSemantics`; `RemixTabs` gains `activationMode`; `RemixTabView` gains `maintainState`.

**`Styler.call(...)` helpers stop dropping arguments the widget already took.** `ProgressStyler` and `SpinnerStyler` now pass the `semanticsLabel`/`semanticsValue` added in #90 — previously the fluent entry point silently discarded them, so `ProgressStyler().call(value: v)` could never produce a non-decorative progress bar. The radio, slider, menu, switch, and tab-view helpers pass their new parameters through.

**`RemixSlider` stays scalar.** Naked's multi-thumb API asserts one entry per value, and Remix always builds `values: [value]`, so the label and formatter are forwarded as one-element lists rather than widening the public API to lists that can only ever hold one item.

### Old vs new behavior

No existing caller changes behavior. Every new default is the value the Naked primitive already defaulted to:

| Parameter | Remix default | Naked default |
|---|---|---|
| `semanticLabel`, `semanticFormatterCallback` | `null` | `null` |
| `excludeSemantics` | `false` | `false` |
| `RemixTabs.activationMode` | `.automatic` | `.automatic` |
| `RemixTabView.maintainState` | `true` | `true` |

`activationMode` and `maintainState` are the only two that were previously omitted rather than absent — they now pass explicitly what was already implicit.

### One doc correction found while writing the tests

`RemixMenu.excludeSemantics` is documented as **trigger-scoped**, not menu-wide. `NakedMenu` wraps only the trigger in `ExcludeSemantics`; the item list is mounted into the ambient `Overlay` through `RawMenuAnchor`, a sibling subtree that `ExcludeSemantics` cannot reach. Setting it on an openable menu therefore hides the trigger and leaves the items announced with `SemanticsRole.menu` — the opposite of "hides the menu". This matches how `RemixPopover` already documents the same anchor. A test pins that scope so the doc comment is a checked claim rather than an assertion.

### Generated files

The Fortal wrappers are **regenerated, not hand-edited**. Verified with the build cache and every `lib/**/*.g.dart` deleted from disk before rebuilding: the from-scratch output is byte-identical, and `tool/check_generated.dart` reports clean generation for both packages (29 Fortal + 27 Remix artifacts). `slider.dart` gains a direct `naked_ui` import because `remix.dart` re-exports only the four overlay symbols, so the part file cannot otherwise resolve `NakedSliderSemanticFormatterCallback`.

## Related Issues

Closes #141.

## Verification

- `flutter analyze packages/remix packages/remix_fortal` — no issues
- `packages/remix`: 2587 tests pass; `packages/remix_fortal`: 365 tests pass
- `dart format --set-exit-if-changed` — clean
- `tool/validate_docs.dart` — passes (33 MDX files, 123 analyzable Dart examples)
- `tool/check_generated.dart` — byte-for-byte in both packages

---

## Checklist

- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors.
- [x] I have updated or added relevant documentation (doc comments with `///`).
- [x] I am prepared to follow up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

All new parameters are optional with defaults equal to the previously implicit behavior.
