### PR TITLE
feat(remix)!: customizable Select trigger indicator icons

### DIFF
--- a/docs/components/select.mdx
+++ b/docs/components/select.mdx
@@ -13,6 +13,36 @@ A dropdown select component for choosing from a list of options.
 - **Settings**: Enable users to choose configuration values
 - **Data entry**: Provide structured input options in forms
 
+## Anatomy
+
+The select trigger is a fixed horizontal row with four visual slots:
+
+- **`container`** — layout, fill, border, effects, and spacing for the trigger.
+- **`icon`** — an optional content icon before the label or placeholder.
+- **`label` / `placeholder`** — the selected item label or empty-state text.
+- **`indicator`** — the affordance that communicates collapsed or expanded
+  state. It is styled separately from `icon`.
+
+Customize the indicator glyph for either state through `RemixSelectTrigger`:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:remix/remix.dart';
+
+void main() {
+  RemixSelectTrigger(
+    placeholder: 'Select an option',
+    icon: Icons.language,
+    collapsedIcon: Icons.add,
+    expandedIcon: Icons.remove,
+  );
+}
+```
+
+Each state falls back independently. A null `collapsedIcon` uses the built-in
+downward chevron, while a null `expandedIcon` uses the built-in upward chevron.
+Those defaults are internal vector paths and do not require Material icons.
+
 ## Basic implementation
 
 <CodeGroup title="Basic implementation" defaultLanguage="dart">
@@ -198,6 +228,10 @@ Optional. Controls how one widget replaces another widget in the tree.
 
 **Required**. The trigger data that defines the select's button.
 
+`RemixSelectTrigger` requires a `placeholder` and optionally accepts a leading
+content `icon`, `collapsedIcon`, and `expandedIcon`. Omitted state icons fall
+back independently to the built-in indicator for that state.
+
 #### `items` → `List<RemixSelectItem<T>>`
 
 **Required**. The list of selectable items.
@@ -303,7 +337,21 @@ Sets trigger label styling.
 
 #### `icon(IconStyler value)`
 
-Sets trigger icon styling.
+Styles the optional trigger content icon.
+
+#### `indicator(IconStyler value)`
+
+Styles the collapsed/expanded indicator independently from the content icon.
+
+#### `indicatorOpacity(double value)`
+
+Sets the opacity of the collapsed/expanded indicator.
+
+<Warning>
+  `chevron` and `chevronOpacity` were renamed to `indicator` and
+  `indicatorOpacity`. The indicator may now use any caller-provided glyph, so
+  the semantic name is the only supported spelling.
+</Warning>
 
 #### `alignment(Alignment value)`
 

--- a/packages/remix/lib/src/components/select/select.g.dart
+++ b/packages/remix/lib/src/components/select/select.g.dart
@@ -100,9 +100,9 @@ mixin _$SelectTriggerSpec implements Spec<SelectTriggerSpec>, Diagnosticable {
   StyleSpec<TextSpec> get label;
   StyleSpec<TextSpec> get placeholder;
   StyleSpec<IconSpec> get icon;
-  StyleSpec<IconSpec> get chevron;
+  StyleSpec<IconSpec> get indicator;
   RemixBoxEffectsSpec? get containerEffects;
-  double? get chevronOpacity;
+  double? get indicatorOpacity;
   double? get placeholderOpacity;
 
   @override
@@ -114,9 +114,9 @@ mixin _$SelectTriggerSpec implements Spec<SelectTriggerSpec>, Diagnosticable {
     StyleSpec<TextSpec>? label,
     StyleSpec<TextSpec>? placeholder,
     StyleSpec<IconSpec>? icon,
-    StyleSpec<IconSpec>? chevron,
+    StyleSpec<IconSpec>? indicator,
     RemixBoxEffectsSpec? containerEffects,
-    double? chevronOpacity,
+    double? indicatorOpacity,
     double? placeholderOpacity,
   }) {
     return SelectTriggerSpec(
@@ -124,9 +124,9 @@ mixin _$SelectTriggerSpec implements Spec<SelectTriggerSpec>, Diagnosticable {
       label: label ?? this.label,
       placeholder: placeholder ?? this.placeholder,
       icon: icon ?? this.icon,
-      chevron: chevron ?? this.chevron,
+      indicator: indicator ?? this.indicator,
       containerEffects: containerEffects ?? this.containerEffects,
-      chevronOpacity: chevronOpacity ?? this.chevronOpacity,
+      indicatorOpacity: indicatorOpacity ?? this.indicatorOpacity,
       placeholderOpacity: placeholderOpacity ?? this.placeholderOpacity,
     );
   }
@@ -138,13 +138,17 @@ mixin _$SelectTriggerSpec implements Spec<SelectTriggerSpec>, Diagnosticable {
       label: label.lerp(other?.label, t),
       placeholder: placeholder.lerp(other?.placeholder, t),
       icon: icon.lerp(other?.icon, t),
-      chevron: chevron.lerp(other?.chevron, t),
+      indicator: indicator.lerp(other?.indicator, t),
       containerEffects: MixOps.lerpSnap(
         containerEffects,
         other?.containerEffects,
         t,
       ),
-      chevronOpacity: MixOps.lerp(chevronOpacity, other?.chevronOpacity, t),
+      indicatorOpacity: MixOps.lerp(
+        indicatorOpacity,
+        other?.indicatorOpacity,
+        t,
+      ),
       placeholderOpacity: MixOps.lerp(
         placeholderOpacity,
         other?.placeholderOpacity,
@@ -159,9 +163,9 @@ mixin _$SelectTriggerSpec implements Spec<SelectTriggerSpec>, Diagnosticable {
     label,
     placeholder,
     icon,
-    chevron,
+    indicator,
     containerEffects,
-    chevronOpacity,
+    indicatorOpacity,
     placeholderOpacity,
   ];
 
@@ -209,9 +213,9 @@ mixin _$SelectTriggerSpec implements Spec<SelectTriggerSpec>, Diagnosticable {
       ..add(DiagnosticsProperty('label', label))
       ..add(DiagnosticsProperty('placeholder', placeholder))
       ..add(DiagnosticsProperty('icon', icon))
-      ..add(DiagnosticsProperty('chevron', chevron))
+      ..add(DiagnosticsProperty('indicator', indicator))
       ..add(DiagnosticsProperty('containerEffects', containerEffects))
-      ..add(DoubleProperty('chevronOpacity', chevronOpacity))
+      ..add(DoubleProperty('indicatorOpacity', indicatorOpacity))
       ..add(DoubleProperty('placeholderOpacity', placeholderOpacity));
   }
 }
@@ -1016,9 +1020,9 @@ class SelectTriggerStyler
   final Prop<StyleSpec<TextSpec>>? $label;
   final Prop<StyleSpec<TextSpec>>? $placeholder;
   final Prop<StyleSpec<IconSpec>>? $icon;
-  final Prop<StyleSpec<IconSpec>>? $chevron;
+  final Prop<StyleSpec<IconSpec>>? $indicator;
   final Prop<RemixBoxEffectsSpec>? $containerEffects;
-  final Prop<double>? $chevronOpacity;
+  final Prop<double>? $indicatorOpacity;
   final Prop<double>? $placeholderOpacity;
 
   const SelectTriggerStyler.create({
@@ -1026,9 +1030,9 @@ class SelectTriggerStyler
     Prop<StyleSpec<TextSpec>>? label,
     Prop<StyleSpec<TextSpec>>? placeholder,
     Prop<StyleSpec<IconSpec>>? icon,
-    Prop<StyleSpec<IconSpec>>? chevron,
+    Prop<StyleSpec<IconSpec>>? indicator,
     Prop<RemixBoxEffectsSpec>? containerEffects,
-    Prop<double>? chevronOpacity,
+    Prop<double>? indicatorOpacity,
     Prop<double>? placeholderOpacity,
     super.variants,
     super.modifier,
@@ -1037,9 +1041,9 @@ class SelectTriggerStyler
        $label = label,
        $placeholder = placeholder,
        $icon = icon,
-       $chevron = chevron,
+       $indicator = indicator,
        $containerEffects = containerEffects,
-       $chevronOpacity = chevronOpacity,
+       $indicatorOpacity = indicatorOpacity,
        $placeholderOpacity = placeholderOpacity;
 
   SelectTriggerStyler({
@@ -1047,9 +1051,9 @@ class SelectTriggerStyler
     TextStyler? label,
     TextStyler? placeholder,
     IconStyler? icon,
-    IconStyler? chevron,
+    IconStyler? indicator,
     RemixBoxEffectsMix? containerEffects,
-    double? chevronOpacity,
+    double? indicatorOpacity,
     double? placeholderOpacity,
     AnimationConfig? animation,
     WidgetModifierConfig? modifier,
@@ -1059,9 +1063,9 @@ class SelectTriggerStyler
          label: Prop.maybeMix(label),
          placeholder: Prop.maybeMix(placeholder),
          icon: Prop.maybeMix(icon),
-         chevron: Prop.maybeMix(chevron),
+         indicator: Prop.maybeMix(indicator),
          containerEffects: Prop.maybeMix(containerEffects),
-         chevronOpacity: Prop.maybe(chevronOpacity),
+         indicatorOpacity: Prop.maybe(indicatorOpacity),
          placeholderOpacity: Prop.maybe(placeholderOpacity),
          variants: variants,
          modifier: modifier,
@@ -1076,12 +1080,12 @@ class SelectTriggerStyler
       SelectTriggerStyler().placeholder(value);
   factory SelectTriggerStyler.icon(IconStyler value) =>
       SelectTriggerStyler().icon(value);
-  factory SelectTriggerStyler.chevron(IconStyler value) =>
-      SelectTriggerStyler().chevron(value);
+  factory SelectTriggerStyler.indicator(IconStyler value) =>
+      SelectTriggerStyler().indicator(value);
   factory SelectTriggerStyler.containerEffects(RemixBoxEffectsMix value) =>
       SelectTriggerStyler().containerEffects(value);
-  factory SelectTriggerStyler.chevronOpacity(double value) =>
-      SelectTriggerStyler().chevronOpacity(value);
+  factory SelectTriggerStyler.indicatorOpacity(double value) =>
+      SelectTriggerStyler().indicatorOpacity(value);
   factory SelectTriggerStyler.placeholderOpacity(double value) =>
       SelectTriggerStyler().placeholderOpacity(value);
   factory SelectTriggerStyler.color(Color value) =>
@@ -1639,9 +1643,9 @@ class SelectTriggerStyler
     return merge(SelectTriggerStyler(icon: value));
   }
 
-  /// Sets the chevron.
-  SelectTriggerStyler chevron(IconStyler value) {
-    return merge(SelectTriggerStyler(chevron: value));
+  /// Sets the indicator.
+  SelectTriggerStyler indicator(IconStyler value) {
+    return merge(SelectTriggerStyler(indicator: value));
   }
 
   /// Sets the containerEffects.
@@ -1649,9 +1653,9 @@ class SelectTriggerStyler
     return merge(SelectTriggerStyler(containerEffects: value));
   }
 
-  /// Sets the chevronOpacity.
-  SelectTriggerStyler chevronOpacity(double value) {
-    return merge(SelectTriggerStyler(chevronOpacity: value));
+  /// Sets the indicatorOpacity.
+  SelectTriggerStyler indicatorOpacity(double value) {
+    return merge(SelectTriggerStyler(indicatorOpacity: value));
   }
 
   /// Sets the placeholderOpacity.
@@ -1690,12 +1694,15 @@ class SelectTriggerStyler
       label: MixOps.merge($label, other?.$label),
       placeholder: MixOps.merge($placeholder, other?.$placeholder),
       icon: MixOps.merge($icon, other?.$icon),
-      chevron: MixOps.merge($chevron, other?.$chevron),
+      indicator: MixOps.merge($indicator, other?.$indicator),
       containerEffects: MixOps.merge(
         $containerEffects,
         other?.$containerEffects,
       ),
-      chevronOpacity: MixOps.merge($chevronOpacity, other?.$chevronOpacity),
+      indicatorOpacity: MixOps.merge(
+        $indicatorOpacity,
+        other?.$indicatorOpacity,
+      ),
       placeholderOpacity: MixOps.merge(
         $placeholderOpacity,
         other?.$placeholderOpacity,
@@ -1714,9 +1721,9 @@ class SelectTriggerStyler
       label: MixOps.resolve(context, $label),
       placeholder: MixOps.resolve(context, $placeholder),
       icon: MixOps.resolve(context, $icon),
-      chevron: MixOps.resolve(context, $chevron),
+      indicator: MixOps.resolve(context, $indicator),
       containerEffects: MixOps.resolve(context, $containerEffects),
-      chevronOpacity: MixOps.resolve(context, $chevronOpacity),
+      indicatorOpacity: MixOps.resolve(context, $indicatorOpacity),
       placeholderOpacity: MixOps.resolve(context, $placeholderOpacity),
     );
 
@@ -1735,9 +1742,9 @@ class SelectTriggerStyler
       ..add(DiagnosticsProperty('label', $label))
       ..add(DiagnosticsProperty('placeholder', $placeholder))
       ..add(DiagnosticsProperty('icon', $icon))
-      ..add(DiagnosticsProperty('chevron', $chevron))
+      ..add(DiagnosticsProperty('indicator', $indicator))
       ..add(DiagnosticsProperty('containerEffects', $containerEffects))
-      ..add(DiagnosticsProperty('chevronOpacity', $chevronOpacity))
+      ..add(DiagnosticsProperty('indicatorOpacity', $indicatorOpacity))
       ..add(DiagnosticsProperty('placeholderOpacity', $placeholderOpacity));
   }
 
@@ -1747,9 +1754,9 @@ class SelectTriggerStyler
     $label,
     $placeholder,
     $icon,
-    $chevron,
+    $indicator,
     $containerEffects,
-    $chevronOpacity,
+    $indicatorOpacity,
     $placeholderOpacity,
     $animation,
     $modifier,

--- a/packages/remix/lib/src/components/select/select_spec.dart
+++ b/packages/remix/lib/src/components/select/select_spec.dart
@@ -44,13 +44,17 @@ class SelectTriggerSpec with _$SelectTriggerSpec {
   final StyleSpec<TextSpec> placeholder;
   @override
   final StyleSpec<IconSpec> icon;
+
+  /// Style for the collapsed/expanded trigger affordance.
   @override
-  final StyleSpec<IconSpec> chevron;
+  final StyleSpec<IconSpec> indicator;
   @override
   @MixableField(setterType: RemixBoxEffectsMix)
   final RemixBoxEffectsSpec? containerEffects;
+
+  /// Opacity applied to the collapsed/expanded trigger affordance.
   @override
-  final double? chevronOpacity;
+  final double? indicatorOpacity;
   @override
   final double? placeholderOpacity;
 
@@ -59,15 +63,15 @@ class SelectTriggerSpec with _$SelectTriggerSpec {
     StyleSpec<TextSpec>? label,
     StyleSpec<TextSpec>? placeholder,
     StyleSpec<IconSpec>? icon,
-    StyleSpec<IconSpec>? chevron,
+    StyleSpec<IconSpec>? indicator,
     this.containerEffects,
-    this.chevronOpacity,
+    this.indicatorOpacity,
     this.placeholderOpacity,
   }) : container = container ?? const StyleSpec(spec: FlexBoxSpec()),
        label = label ?? const StyleSpec(spec: TextSpec()),
        placeholder = placeholder ?? const StyleSpec(spec: TextSpec()),
        icon = icon ?? const StyleSpec(spec: IconSpec()),
-       chevron = chevron ?? const StyleSpec(spec: IconSpec());
+       indicator = indicator ?? const StyleSpec(spec: IconSpec());
 
   // Deliberate: route effects through lerpNullable so shadows/blends animate;
   // the generator's default snap-lerps unrecognized spec types.

--- a/packages/remix/lib/src/components/select/select_widget.dart
+++ b/packages/remix/lib/src/components/select/select_widget.dart
@@ -12,11 +12,25 @@ class RemixSelectTrigger {
   /// Placeholder text to display when no value is selected.
   final String placeholder;
 
-  /// Optional icon to display before the label/placeholder.
-  /// When provided, icon appears in leading position (before text).
+  /// Optional content icon to display before the label/placeholder.
   final IconData? icon;
 
-  const RemixSelectTrigger({required this.placeholder, this.icon});
+  /// Optional indicator icon to display while the select is collapsed.
+  ///
+  /// When null, the default downward chevron is displayed.
+  final IconData? collapsedIcon;
+
+  /// Optional indicator icon to display while the select is expanded.
+  ///
+  /// When null, the default upward chevron is displayed.
+  final IconData? expandedIcon;
+
+  const RemixSelectTrigger({
+    required this.placeholder,
+    this.icon,
+    this.collapsedIcon,
+    this.expandedIcon,
+  });
 }
 
 /// Data class representing a selectable option.
@@ -376,6 +390,10 @@ class _RemixSelectTriggerWidget extends StatelessWidget {
     return StyleSpecBuilder<SelectTriggerSpec>(
       styleSpec: styleSpec,
       builder: (context, spec) {
+        final indicatorIcon = isOpen
+            ? trigger.expandedIcon
+            : trigger.collapsedIcon;
+
         return RemixFlexBoxWithEffects(
           styleSpec: spec.container,
           direction: Axis.horizontal,
@@ -393,16 +411,22 @@ class _RemixSelectTriggerWidget extends StatelessWidget {
                 ),
               ),
             ),
-            Transform.rotate(
-              angle: isOpen ? math.pi : 0,
-              child: Opacity(
-                opacity: spec.chevronOpacity ?? 1,
-                child: RemixPathIcon(
-                  key: const ValueKey('fortal-select-chevron'),
-                  glyph: RemixPathGlyph.chevronDown,
-                  styleSpec: spec.chevron,
-                ),
-              ),
+            Opacity(
+              opacity: spec.indicatorOpacity ?? 1,
+              child: indicatorIcon == null
+                  ? Transform.rotate(
+                      angle: isOpen ? math.pi : 0,
+                      child: RemixPathIcon(
+                        key: const ValueKey('remix-select-indicator'),
+                        glyph: RemixPathGlyph.chevronDown,
+                        styleSpec: spec.indicator,
+                      ),
+                    )
+                  : StyledIcon(
+                      key: const ValueKey('remix-select-indicator'),
+                      icon: indicatorIcon,
+                      styleSpec: spec.indicator,
+                    ),
             ),
           ],
         );

--- a/packages/remix/test/components/select/select_spec_test.dart
+++ b/packages/remix/test/components/select/select_spec_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:remix/remix.dart';
 
@@ -181,34 +182,46 @@ void main() {
         expect(spec.container, isA<StyleSpec<FlexBoxSpec>>());
         expect(spec.label, isA<StyleSpec<TextSpec>>());
         expect(spec.icon, isA<StyleSpec<IconSpec>>());
+        expect(spec.indicator, isA<StyleSpec<IconSpec>>());
       });
 
       test('creates spec with provided parameters', () {
         final container = StyleSpec(spec: FlexBoxSpec());
         final label = StyleSpec(spec: TextSpec());
         final icon = StyleSpec(spec: IconSpec());
+        final indicator = StyleSpec(spec: IconSpec());
 
         final spec = SelectTriggerSpec(
           container: container,
           label: label,
           icon: icon,
+          indicator: indicator,
+          indicatorOpacity: 0.5,
         );
 
         expect(spec.container, equals(container));
         expect(spec.label, equals(label));
         expect(spec.icon, equals(icon));
+        expect(spec.indicator, equals(indicator));
+        expect(spec.indicatorOpacity, 0.5);
       });
     });
 
     group('copyWith', () {
       test('returns new instance with updated properties', () {
         const originalSpec = SelectTriggerSpec();
-        final newContainer = StyleSpec(spec: FlexBoxSpec());
+        final newIndicator = StyleSpec(
+          spec: IconSpec(color: const Color(0xFF0000FF), size: 18),
+        );
 
-        final updatedSpec = originalSpec.copyWith(container: newContainer);
+        final updatedSpec = originalSpec.copyWith(
+          indicator: newIndicator,
+          indicatorOpacity: 0.5,
+        );
 
         expect(updatedSpec, isNot(same(originalSpec)));
-        expect(updatedSpec.container, equals(newContainer));
+        expect(updatedSpec.indicator, equals(newIndicator));
+        expect(updatedSpec.indicatorOpacity, 0.5);
       });
 
       test('preserves immutability - original spec unchanged', () {
@@ -236,30 +249,36 @@ void main() {
 
       test('interpolates between two specs at t=0.0', () {
         final spec1 = SelectTriggerSpec(
-          container: StyleSpec(spec: FlexBoxSpec()),
+          indicator: StyleSpec(spec: IconSpec(color: const Color(0xFF0000FF))),
+          indicatorOpacity: 0,
         );
         final spec2 = SelectTriggerSpec(
-          container: StyleSpec(spec: FlexBoxSpec()),
+          indicator: StyleSpec(spec: IconSpec(color: const Color(0xFFFF0000))),
+          indicatorOpacity: 1,
         );
 
         final result = spec1.lerp(spec2, 0.0);
 
         expect(result, isNot(same(spec1)));
-        expect(result.container, equals(spec1.container));
+        expect(result.indicator, equals(spec1.indicator));
+        expect(result.indicatorOpacity, spec1.indicatorOpacity);
       });
 
       test('interpolates between two specs at t=1.0', () {
         final spec1 = SelectTriggerSpec(
-          container: StyleSpec(spec: FlexBoxSpec()),
+          indicator: StyleSpec(spec: IconSpec(color: const Color(0xFF0000FF))),
+          indicatorOpacity: 0,
         );
         final spec2 = SelectTriggerSpec(
-          container: StyleSpec(spec: FlexBoxSpec()),
+          indicator: StyleSpec(spec: IconSpec(color: const Color(0xFFFF0000))),
+          indicatorOpacity: 1,
         );
 
         final result = spec1.lerp(spec2, 1.0);
 
         expect(result, isNot(same(spec2)));
-        expect(result.container, equals(spec2.container));
+        expect(result.indicator, equals(spec2.indicator));
+        expect(result.indicatorOpacity, spec2.indicatorOpacity);
       });
     });
 
@@ -274,14 +293,7 @@ void main() {
 
       test('two specs with different properties are not equal', () {
         const spec1 = SelectTriggerSpec();
-        final spec2 = SelectTriggerSpec(
-          container: StyleSpec(
-            spec: FlexBoxSpec(),
-            animation: AnimationConfig.linear(
-              const Duration(milliseconds: 100),
-            ),
-          ),
-        );
+        const spec2 = SelectTriggerSpec(indicatorOpacity: 0.5);
 
         expect(spec1, isNot(equals(spec2)));
       });
@@ -293,16 +305,20 @@ void main() {
         expect(spec.props, contains(spec.container));
         expect(spec.props, contains(spec.label));
         expect(spec.props, contains(spec.icon));
+        expect(spec.props, contains(spec.indicator));
+        expect(spec.props, contains(spec.indicatorOpacity));
       });
     });
 
     group('Diagnostic Support', () {
       test('debugFillProperties works without throwing', () {
-        const spec = SelectTriggerSpec();
+        const spec = SelectTriggerSpec(indicatorOpacity: 0.5);
+        final properties = DiagnosticPropertiesBuilder();
 
+        expect(() => spec.debugFillProperties(properties), returnsNormally);
         expect(
-          () => spec.debugFillProperties(DiagnosticPropertiesBuilder()),
-          returnsNormally,
+          properties.properties.map((property) => property.name),
+          containsAll(['indicator', 'indicatorOpacity']),
         );
       });
 

--- a/packages/remix/test/components/select/select_style_test.dart
+++ b/packages/remix/test/components/select/select_style_test.dart
@@ -266,12 +266,15 @@ void main() {
         final container = Prop.maybeMix(FlexBoxStyler());
         final label = Prop.maybeMix(TextStyler());
         final icon = Prop.maybeMix(IconStyler());
+        final indicator = Prop.maybeMix(IconStyler());
         final variants = <VariantStyle<SelectTriggerSpec>>[];
 
         final style = SelectTriggerStyler.create(
           container: container,
           label: label,
           icon: icon,
+          indicator: indicator,
+          indicatorOpacity: Prop.maybe(0.5),
           variants: variants,
         );
 
@@ -279,6 +282,8 @@ void main() {
         expect(style.$container, equals(container));
         expect(style.$label, equals(label));
         expect(style.$icon, equals(icon));
+        expect(style.$indicator, equals(indicator));
+        expect(style.$indicatorOpacity, Prop.maybe(0.5));
         expect(style.$variants, equals(variants));
       });
     });
@@ -310,6 +315,34 @@ void main() {
             style.$icon,
             equals(Prop.maybeMix(IconStyler(color: Colors.red))),
           );
+        },
+      );
+
+      styleMethodTest(
+        'indicator',
+        initial: SelectTriggerStyler(),
+        modify: (style) => style.indicator(IconStyler(color: Colors.blue)),
+        expect: (style) {
+          expect(
+            style.$indicator,
+            equals(Prop.maybeMix(IconStyler(color: Colors.blue))),
+          );
+          expect(
+            style,
+            equals(
+              SelectTriggerStyler.indicator(IconStyler(color: Colors.blue)),
+            ),
+          );
+        },
+      );
+
+      styleMethodTest(
+        'indicatorOpacity',
+        initial: SelectTriggerStyler(),
+        modify: (style) => style.indicatorOpacity(0.5),
+        expect: (style) {
+          expect(style.$indicatorOpacity, Prop.maybe(0.5));
+          expect(style, equals(SelectTriggerStyler.indicatorOpacity(0.5)));
         },
       );
 
@@ -398,7 +431,9 @@ void main() {
       testWidgets('resolve method returns StyleSpec', (
         WidgetTester tester,
       ) async {
-        final style = SelectTriggerStyler();
+        final style = SelectTriggerStyler()
+            .indicator(IconStyler(color: Colors.blue, size: 18))
+            .indicatorOpacity(0.5);
 
         await tester.pumpWidget(
           MaterialApp(
@@ -411,6 +446,10 @@ void main() {
                 expect(spec.spec.container, isA<StyleSpec<FlexBoxSpec>>());
                 expect(spec.spec.label, isA<StyleSpec<TextSpec>>());
                 expect(spec.spec.icon, isA<StyleSpec<IconSpec>>());
+                expect(spec.spec.indicator, isA<StyleSpec<IconSpec>>());
+                expect(spec.spec.indicator.spec.color, Colors.blue);
+                expect(spec.spec.indicator.spec.size, 18);
+                expect(spec.spec.indicatorOpacity, 0.5);
 
                 return Container();
               },
@@ -426,6 +465,27 @@ void main() {
 
         expect(mergedStyle, equals(originalStyle));
       });
+
+      test('merge combines indicator properties', () {
+        final indicator = IconStyler(color: Colors.blue, size: 18);
+        final style = SelectTriggerStyler(indicator: indicator);
+        final other = SelectTriggerStyler(indicatorOpacity: 0.5);
+
+        final merged = style.merge(other);
+
+        expect(merged.$indicator, equals(Prop.maybeMix(indicator)));
+        expect(merged.$indicatorOpacity, equals(Prop.maybe(0.5)));
+      });
+
+      test('props list contains indicator properties', () {
+        final style = SelectTriggerStyler(
+          indicator: IconStyler(color: Colors.blue),
+          indicatorOpacity: 0.5,
+        );
+
+        expect(style.props, contains(style.$indicator));
+        expect(style.props, contains(style.$indicatorOpacity));
+      });
     });
 
     group('Equality', () {
@@ -438,11 +498,11 @@ void main() {
       });
 
       test('styles with different properties are not equal', () {
-        final style1 = SelectTriggerStyler().label(
-          TextStyler(style: TextStyleMix(color: Colors.blue)),
+        final style1 = SelectTriggerStyler().indicator(
+          IconStyler(color: Colors.blue),
         );
-        final style2 = SelectTriggerStyler().label(
-          TextStyler(style: TextStyleMix(color: Colors.red)),
+        final style2 = SelectTriggerStyler().indicator(
+          IconStyler(color: Colors.red),
         );
 
         expect(style1, isNot(equals(style2)));

--- a/packages/remix/test/components/select/select_widget_test.dart
+++ b/packages/remix/test/components/select/select_widget_test.dart
@@ -56,7 +56,7 @@ void main() {
         expect(find.byIcon(Icons.star), findsOneWidget);
       });
 
-      testWidgets('shows dropdown chevron', (tester) async {
+      testWidgets('shows the default select indicator', (tester) async {
         await tester.pumpRemixApp(
           RemixSelect<String>(
             trigger: const RemixSelectTrigger(placeholder: 'Select'),
@@ -66,9 +66,98 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(
-          find.byKey(const ValueKey('fortal-select-chevron')),
+          find.byKey(const ValueKey('remix-select-indicator')),
           findsOneWidget,
         );
+      });
+
+      testWidgets(
+        'renders custom indicator icons for collapsed and expanded states',
+        (tester) async {
+          await tester.pumpRemixApp(
+            RemixSelect<String>(
+              trigger: const RemixSelectTrigger(
+                placeholder: 'Select',
+                collapsedIcon: Icons.add,
+                expandedIcon: Icons.remove,
+              ),
+              items: const [RemixSelectItem(value: 'a', label: 'Option A')],
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          expect(find.byIcon(Icons.add), findsOneWidget);
+          expect(find.byIcon(Icons.remove), findsNothing);
+          expect(
+            find.ancestor(
+              of: find.byIcon(Icons.add),
+              matching: find.byType(Transform),
+            ),
+            findsNothing,
+          );
+
+          await tester.tap(find.byType(RemixSelect<String>));
+          await tester.pumpAndSettle();
+
+          expect(find.byIcon(Icons.add), findsNothing);
+          expect(find.byIcon(Icons.remove), findsOneWidget);
+          expect(
+            find.ancestor(
+              of: find.byIcon(Icons.remove),
+              matching: find.byType(Transform),
+            ),
+            findsNothing,
+          );
+        },
+      );
+
+      testWidgets('falls back to the collapsed indicator independently', (
+        tester,
+      ) async {
+        await tester.pumpRemixApp(
+          RemixSelect<String>(
+            trigger: const RemixSelectTrigger(
+              placeholder: 'Select',
+              expandedIcon: Icons.remove,
+            ),
+            items: const [RemixSelectItem(value: 'a', label: 'Option A')],
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final indicator = find.byKey(const ValueKey('remix-select-indicator'));
+        expect(tester.widget(indicator), isNot(isA<StyledIcon>()));
+
+        await tester.tap(find.byType(RemixSelect<String>));
+        await tester.pumpAndSettle();
+
+        expect(find.byIcon(Icons.remove), findsOneWidget);
+        expect(tester.widget(indicator), isA<StyledIcon>());
+      });
+
+      testWidgets('falls back to the expanded indicator independently', (
+        tester,
+      ) async {
+        await tester.pumpRemixApp(
+          RemixSelect<String>(
+            trigger: const RemixSelectTrigger(
+              placeholder: 'Select',
+              collapsedIcon: Icons.add,
+            ),
+            items: const [RemixSelectItem(value: 'a', label: 'Option A')],
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final indicator = find.byKey(const ValueKey('remix-select-indicator'));
+        expect(find.byIcon(Icons.add), findsOneWidget);
+        expect(tester.widget(indicator), isA<StyledIcon>());
+
+        await tester.tap(find.byType(RemixSelect<String>));
+        await tester.pumpAndSettle();
+
+        expect(find.byIcon(Icons.add), findsNothing);
+        expect(tester.widget(indicator), isNot(isA<StyledIcon>()));
       });
     });
 
@@ -181,7 +270,7 @@ void main() {
         expect(find.text('Option B'), findsOneWidget);
       });
 
-      testWidgets('rotates the chevron when opened', (tester) async {
+      testWidgets('rotates the default indicator when opened', (tester) async {
         await tester.pumpRemixApp(
           RemixSelect<String>(
             trigger: const RemixSelectTrigger(placeholder: 'Select'),
@@ -190,9 +279,9 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        final chevron = find.byKey(const ValueKey('fortal-select-chevron'));
+        final indicator = find.byKey(const ValueKey('remix-select-indicator'));
         final transformFinder = find.ancestor(
-          of: chevron,
+          of: indicator,
           matching: find.byType(Transform),
         );
         final closedTransform = tester
@@ -401,6 +490,35 @@ void main() {
           find.byType(RemixSelect<String>),
         );
         expect(select.mouseCursor, SystemMouseCursors.help);
+      });
+
+      testWidgets('styles the content icon and indicator independently', (
+        tester,
+      ) async {
+        await tester.pumpRemixApp(
+          RemixSelect<String>(
+            trigger: const RemixSelectTrigger(
+              placeholder: 'Select',
+              icon: Icons.star,
+              collapsedIcon: Icons.add,
+            ),
+            items: const [RemixSelectItem(value: 'a', label: 'Option A')],
+            style: SelectStyler().trigger(
+              SelectTriggerStyler()
+                  .icon(IconStyler(color: Colors.red, size: 17))
+                  .indicator(IconStyler(color: Colors.blue, size: 23)),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final contentIcon = tester.widget<Icon>(find.byIcon(Icons.star));
+        final indicator = tester.widget<Icon>(find.byIcon(Icons.add));
+
+        expect(contentIcon.color, Colors.red);
+        expect(contentIcon.size, 17);
+        expect(indicator.color, Colors.blue);
+        expect(indicator.size, 23);
       });
 
       testWidgets('item styling uses the typed select-option controller', (

--- a/packages/remix_fortal/lib/src/recipes/select.dart
+++ b/packages/remix_fortal/lib/src/recipes/select.dart
@@ -47,7 +47,7 @@ SelectTriggerStyler _fortalSelectTriggerStyler(
         _fortalSelectTriggerText(size, color: FortalTokens.grayA10()),
       )
       .icon(.color(FortalTokens.gray12()))
-      .chevron(.color(FortalTokens.gray12()).size(size == .size3 ? 11 : 9))
+      .indicator(.color(FortalTokens.gray12()).size(size == .size3 ? 11 : 9))
       .onFocusVisible(
         .containerEffects(
           RemixBoxEffectsMix.overContent(_fortalSelectFocusRing()),
@@ -135,7 +135,7 @@ RemixBoxEffectLayerMix _fortalSelectFocusRing() {
 
 SelectTriggerStyler _fortalSelectSurfaceTrigger(SelectTriggerStyler base) {
   return base
-      .chevronOpacity(0.9)
+      .indicatorOpacity(0.9)
       .color(FortalTokens.colorSurface())
       .containerEffects(
         RemixBoxEffectsMix.behindContent(
@@ -160,7 +160,7 @@ SelectTriggerStyler _fortalSelectSurfaceTrigger(SelectTriggerStyler base) {
         .color(FortalTokens.grayA2())
             .label(.color(FortalTokens.grayA11()))
             .icon(.color(FortalTokens.grayA9()))
-            .chevron(.color(FortalTokens.grayA9()))
+            .indicator(.color(FortalTokens.grayA9()))
             .containerEffects(
               RemixBoxEffectsMix.behindContent(
                 fortalInsetSurface(strokes: [FortalTokens.grayA6()]),
@@ -175,14 +175,14 @@ SelectTriggerStyler _fortalSelectSoftTrigger(SelectTriggerStyler base) {
       .placeholder(.color(FortalTokens.accent12()))
       .placeholderOpacity(0.6)
       .icon(.color(FortalTokens.accent12()))
-      .chevron(.color(FortalTokens.accent12()))
+      .indicator(.color(FortalTokens.accent12()))
       .color(FortalTokens.accentA3())
       .onHovered(.color(FortalTokens.accentA4()))
       .onSelected(.color(FortalTokens.accentA4()))
       .onDisabled(
         .label(.color(FortalTokens.grayA11()))
             .icon(.color(FortalTokens.grayA9()))
-            .chevron(.color(FortalTokens.grayA9()))
+            .indicator(.color(FortalTokens.grayA9()))
             .color(FortalTokens.grayA3()),
       );
 }
@@ -193,14 +193,14 @@ SelectTriggerStyler _fortalSelectGhostTrigger(SelectTriggerStyler base) {
       .placeholder(.color(FortalTokens.accent12()))
       .placeholderOpacity(0.6)
       .icon(.color(FortalTokens.accent12()))
-      .chevron(.color(FortalTokens.accent12()))
+      .indicator(.color(FortalTokens.accent12()))
       .color(const Color(0x00000000))
       .onHovered(.color(FortalTokens.accentA3()))
       .onSelected(.color(FortalTokens.accentA3()))
       .onDisabled(
         .label(.color(FortalTokens.grayA11()))
             .icon(.color(FortalTokens.grayA9()))
-            .chevron(.color(FortalTokens.grayA9()))
+            .indicator(.color(FortalTokens.grayA9()))
             .color(const Color(0x00000000)),
       );
 }

--- a/packages/remix_fortal/test/components/select/select_fortal_parity_test.dart
+++ b/packages/remix_fortal/test/components/select/select_fortal_parity_test.dart
@@ -1,6 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:remix/remix.dart';
+// Deliberate: RemixPathIcon/RemixPathGlyph stay unexported, but this suite
+// pins the *glyph* the trigger draws, not just that some widget sits under the
+// indicator key. Exporting them to satisfy a test would widen the public API
+// for no consumer, so the private import is the cheaper coupling. If that file
+// moves, retarget this import rather than weakening the assertion.
+import 'package:remix/src/utilities/remix_path_icon.dart';
 import 'package:remix_fortal/remix_fortal.dart';
 
 import '../../helpers/test_helpers.dart';
@@ -54,7 +60,7 @@ void main() {
               double triggerPadding,
               double gap,
               double triggerRadius,
-              double chevron,
+              double triggerIndicatorSize,
               double contentPadding,
               double contentRadius,
               double itemHeight,
@@ -72,7 +78,7 @@ void main() {
               triggerPadding: 8,
               gap: 4,
               triggerRadius: 3,
-              chevron: 9,
+              triggerIndicatorSize: 9,
               contentPadding: 4,
               contentRadius: 6,
               itemHeight: 24,
@@ -89,7 +95,7 @@ void main() {
               triggerPadding: 12,
               gap: 6,
               triggerRadius: 4,
-              chevron: 9,
+              triggerIndicatorSize: 9,
               contentPadding: 8,
               contentRadius: 8,
               itemHeight: 32,
@@ -106,7 +112,7 @@ void main() {
               triggerPadding: 16,
               gap: 8,
               triggerRadius: 6,
-              chevron: 11,
+              triggerIndicatorSize: 11,
               contentPadding: 8,
               contentRadius: 8,
               itemHeight: 32,
@@ -135,7 +141,7 @@ void main() {
         );
         expect(trigger.container.spec.flex!.spec.spacing, expected.gap);
         expect(_radius(triggerBox), expected.triggerRadius);
-        expect(trigger.chevron.spec.size, expected.chevron);
+        expect(trigger.indicator.spec.size, expected.triggerIndicatorSize);
 
         expect(
           content.container.spec.padding,
@@ -178,7 +184,7 @@ void main() {
       expect(item.indicator.spec.constraints!.minWidth, closeTo(22, 1e-9));
       expect(item.icon.spec.size, closeTo(8.8, 1e-9));
       expect(item.text.spec.style!.fontSize, closeTo(13.2, 1e-9));
-      expect(spec.trigger.spec.chevron.spec.size, 9);
+      expect(spec.trigger.spec.indicator.spec.size, 9);
     });
 
     testWidgets('full radius promotes only the trigger to a pill', (
@@ -242,7 +248,8 @@ void main() {
         disabledHover.trigger.spec.label.spec.style!.color,
         tokens.grayA11,
       );
-      expect(disabledHover.trigger.spec.chevron.spec.color, tokens.grayA9);
+      expect(idle.trigger.spec.indicatorOpacity, 0.9);
+      expect(disabledHover.trigger.spec.indicator.spec.color, tokens.grayA9);
     });
 
     testWidgets('focus ring straddles the trigger edge with solid focus8', (
@@ -306,7 +313,7 @@ void main() {
     );
   });
 
-  testWidgets('uses the pinned Radix chevron and thick-check vector paths', (
+  testWidgets('uses the pinned Radix indicator and thick-check vector paths', (
     tester,
   ) async {
     await tester.pumpWidget(
@@ -324,7 +331,14 @@ void main() {
       ),
     );
 
-    expect(find.byKey(const ValueKey('fortal-select-chevron')), findsOneWidget);
+    final triggerIndicator = find.byKey(
+      const ValueKey('remix-select-indicator'),
+    );
+    expect(triggerIndicator, findsOneWidget);
+    expect(
+      tester.widget<RemixPathIcon>(triggerIndicator).glyph,
+      RemixPathGlyph.chevronDown,
+    );
     expect(find.byIcon(Icons.keyboard_arrow_down), findsNothing);
 
     await tester.tap(find.byType(RemixSelect<String>));

--- a/skills/using-remix/references/forms.md
+++ b/skills/using-remix/references/forms.md
@@ -222,7 +222,9 @@ Fortal preset: `FortalTextArea` — `variant` (`classic|surface|soft`), `size`
 `RemixSelectTrigger` and `RemixSelectItem<T>` are **data classes**, not
 widgets:
 
-- **RemixSelectTrigger**: `placeholder` (required), `icon` (optional).
+- **RemixSelectTrigger**: `placeholder` (required), `icon` (optional content
+  icon), `collapsedIcon` / `expandedIcon` (optional indicator glyphs; each
+  falls back independently to the built-in chevron for that state).
 - **RemixSelectItem\<T\>**: `value` (required), `label` (required),
   `enabled` (default true), `style` (a `SelectMenuItemStyler`),
   `semanticLabel`.

--- a/tool/validate_docs.dart
+++ b/tool/validate_docs.dart
@@ -28,6 +28,13 @@ final _retiredApis = <(RegExp, String)>[
     RegExp(r'\bentries\s*:'),
     'renamed Menu/Select collection argument; use items',
   ),
+  // Narrow on purpose: the slot spellings always end in `(` or `:`, so the
+  // pinned `RemixPathGlyph.chevronDown` / `FortalIcons.chevron*` glyph names
+  // and prose about the chevron the indicator draws stay legal.
+  (
+    RegExp(r'\bchevron(?:Opacity)?\s*[(:]|\$chevron(?:Opacity)?\b'),
+    'renamed Select trigger indicator slot; use indicator/indicatorOpacity',
+  ),
   (
     RegExp(
       r'\b(?:RemixPaintShadow(?:Kind|Mix|ListToken)?|RemixSurface(?:Layer|Effects)?(?:Spec|Mix)?|remixSurface(?:Box|FlexBox))\b',


### PR DESCRIPTION
## Description

`RemixSelect`'s trigger affordance was a hardcoded chevron with no public API to change it. This adds `collapsedIcon` and `expandedIcon` to `RemixSelectTrigger`, so callers can supply their own glyph for either state:

```dart
RemixSelectTrigger(
  placeholder: 'Select an option',
  icon: Icons.language,
  collapsedIcon: Icons.add,
  expandedIcon: Icons.remove,
);
```

Each state falls back independently. A null `collapsedIcon` keeps the built-in downward chevron; a null `expandedIcon` keeps the built-in upward one. Those defaults are the pinned Radix vector paths, so the Material-free default is unchanged and existing call sites render identically.

**Old behavior:** the trigger always drew `RemixPathGlyph.chevronDown`, rotated 180° when open. **New behavior:** same, unless a caller supplies a glyph for that state, in which case it renders unrotated.

Because the slot is no longer guaranteed to contain a chevron, `SelectTriggerSpec.chevron` / `chevronOpacity` are renamed to `indicator` / `indicatorOpacity`, and the same rename applies across `SelectTriggerStyler`. This is a hard cutoff with no aliases. A `@Deprecated` extension was considered and rejected on evidence: it can restore the instance methods and spec getters, but the analyzer rejects it for the dot-shorthand factory form (`.chevron(...)` → `dot_shorthand_undefined_member`) and for constructor named arguments (`undefined_named_parameter`). The Fortal recipes in this repo use the dot-shorthand spelling, so a shim would cover roughly half the real call sites while implying a smooth migration.

`tool/validate_docs.dart` gains a retired-API guard for the old spellings, matching how the previous `entries:` → `items` rename was enforced. It anchors on the trailing `(` or `:` so the pinned `RemixPathGlyph.chevronDown` / `FortalIcons.chevron*` glyph names and prose about the chevron stay legal.

**Migration:** `.chevron(...)` → `.indicator(...)`, `.chevronOpacity(...)` → `.indicatorOpacity(...)`.

## Related Issues

Closes #53

Note that #53's third acceptance criterion asked for no breaking change, and this PR makes one. Rendered output and defaults are unchanged; the break is confined to the two styler/spec member names. The issue's premise is also partly stale against current `main` — it describes `Icons.keyboard_arrow_up/down` sharing `spec.icon`, but the trailing slot had already been split out as `chevron` and moved to a vector path. The remaining gap it identified, no way to customize the glyph, is what this PR closes.

---

## Checklist

- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors.
- [x] I have updated or added relevant documentation (doc comments with `///`).
- [x] I am prepared to follow up on review comments in a timely manner.

## Breaking Change

Does this PR require users of the package to manually update their code?

- [x] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

## Validation

Rebased onto `main` after #142 and #144 landed. Both touched Select, and #142 added a `Styling` test adjacent to mine; the conflict was resolved by keeping both tests, and both are confirmed running. Results below are from the rebased branch.

- `dart analyze .` (workspace including apps and `tool/`) — no issues found
- `flutter test` in `packages/remix` — 2599 passed
- `flutter test` in `packages/remix_fortal` — 365 passed
- `tool/check_generated.dart` — 27 generated artifacts reproduced byte-for-byte
- `tool/validate_docs.dart` — passed; guard verified to reject all five retired spellings and to leave the legal `chevron*` glyph names untouched
- `tool/fortal_parity/check.dart` — 30 mapped families, no undocumented approximations
- `tool/check_material_independence.dart` — passed
