### PR TITLE
chore(release): remix 1.0.0-beta.4, remix_fortal 0.1.0-beta.3

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "packages/remix": "1.0.0-beta.3",
-  "packages/remix_fortal": "0.1.0-beta.2"
+  "packages/remix": "1.0.0-beta.4",
+  "packages/remix_fortal": "0.1.0-beta.3"
 }

--- a/packages/remix/CHANGELOG.md
+++ b/packages/remix/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 1.0.0-beta.4
+
+- **BREAKING**: `RemixSelectTrigger` gains `collapsedIcon` and `expandedIcon`,
+  replacing the hardcoded trigger chevron. Each state falls back independently,
+  so a trigger that only sets one keeps the default for the other.
+- **FEAT**: Forward semantic and behavioral parameters that the underlying Naked
+  primitives already supported. `RemixRadio` and `RemixMenu` gain
+  `semanticLabel` and `excludeSemantics`, `RemixSwitch` gains
+  `excludeSemantics`, and the matching `Styler.call(...)` helpers accept the
+  same values, closing eight audited gaps.
+- **FIX**: Add `mouseCursor` to `RemixSelect` and `SelectStyler.call`, defaulting
+  to `SystemMouseCursors.click` and forwarding it to `NakedSelect`, so a
+  disabled trigger keeps the basic cursor.
+
 ## 1.0.0-beta.3
 
 - **BREAKING**: Remove handwritten component styler aliases that duplicate the

--- a/packages/remix/pubspec.yaml
+++ b/packages/remix/pubspec.yaml
@@ -12,7 +12,7 @@ topics:
   - styling
   - mix
 
-version: 1.0.0-beta.3
+version: 1.0.0-beta.4
 
 # Consumer floor, matching `mix` and `naked_ui`. Intentionally lower than the
 # workspace's own toolchain floor: dev tooling needs a newer SDK than the

--- a/packages/remix_fortal/CHANGELOG.md
+++ b/packages/remix_fortal/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.1.0-beta.3
+
+- **FEAT**: Regenerate the Fortal Select wrappers for the new trigger indicator
+  icons and `mouseCursor`, so `FortalSelect` exposes `collapsedIcon`,
+  `expandedIcon`, and a cursor alongside the base component.
+- Raise the `remix` floor to `^1.0.0-beta.4`.
+
 ## 0.1.0-beta.2
 
 - **FEAT**: Add Fortal-themed line, bar, and pie chart recipes and generated

--- a/packages/remix_fortal/pubspec.yaml
+++ b/packages/remix_fortal/pubspec.yaml
@@ -15,7 +15,7 @@ topics:
 # Pre-release because every dependency below is itself a pre-release; pub warns
 # when a stable package is built on beta foundations. Graduate to 0.1.0 when
 # remix reaches 1.0.0 stable.
-version: 0.1.0-beta.2
+version: 0.1.0-beta.3
 
 # Consumer floor, matching `remix` and `mix`. See packages/remix/pubspec.yaml.
 environment:
@@ -36,7 +36,7 @@ dependencies:
   # — otherwise pub could resolve a `remix` whose symbols collide with this
   # package. `tool/fortal_parity/check.dart` (_checkRemixHostedPin) fails if the
   # two ever fall out of sync.
-  remix: ^1.0.0-beta.3 # x-release-please-version
+  remix: ^1.0.0-beta.4 # x-release-please-version
   mix: ^2.2.0-beta.4
   mix_annotations: ^2.2.0-beta.1
   mix_chart: ^0.0.1-beta.1


### PR DESCRIPTION
```
remix          1.0.0-beta.3  →  1.0.0-beta.4
remix_fortal   0.1.0-beta.2  →  0.1.0-beta.3
remix floor in remix_fortal  →  ^1.0.0-beta.4   (enforced by the parity checker)
```

## What landed since the last beta

Three pull requests, each closing a tracked issue:

| PR | Closes | |
|---|---|---|
| #145 | #53 | **BREAKING** — `RemixSelectTrigger` gains `collapsedIcon` / `expandedIcon`, replacing the hardcoded chevron |
| #144 | #141 | Forwards eight audited semantic/behavioral parameters the Naked primitives already supported |
| #142 | #60 | `mouseCursor` on `RemixSelect` and `SelectStyler.call`, defaulting to `SystemMouseCursors.click` |

`remix_fortal` moves with them because its Select wrappers regenerate to expose the same parameters.

The breaking change leads the `remix` section: a trigger no longer paints a fixed chevron, and each icon state falls back independently so a trigger that sets only one keeps the default for the other.

## Still written by hand

Same two blockers as the previous release, neither resolved:

- **release-please misparses Dart prereleases.** `release-type: dart` treats the prerelease as build metadata and emitted `2.0.0-beta.1+-beta.1` last time — invalid, and it dropped the beta counter. [googleapis/release-please#2400](https://github.com/googleapis/release-please/issues/2400), open.
- **The action cannot open its PR.** *Settings → Actions → General → Allow GitHub Actions to create and approve pull requests* is off.

Worth fixing before this becomes the habit. The likely route is moving the `version:` fields onto the generic `x-release-please-version` updater already used for the `remix` floor in `remix_fortal/pubspec.yaml`, which bypasses the buggy Dart pubspec updater.

## Verification

- `dart pub publish --dry-run`: **0 warnings** for both packages, on a clean tree
- `remix` 2599 · `remix_fortal` 365 · dashboard 48 — all pass
- `flutter analyze --fatal-infos` clean
- Fortal parity check passes, including the `remix` floor equality it enforces
- Docs validation clean

## Publishing after merge — order still matters

`publish.yml` warns about this in its own header; the two tag-triggered jobs do not order themselves.

1. push `v1.0.0-beta.4` → wait until pub.dev serves `remix 1.0.0-beta.4`
2. then push `remix_fortal-v0.1.0-beta.3`

pub.dev does not verify that a dependency version exists, so the wrong order ships an uninstallable `remix_fortal` rather than failing the job.

The `analysis_options.yaml` dirty-tree failure that blocked the last release is fixed by #140 and should not recur.
