### PR TITLE
refactor(fortal)!: default unsized typography from tokens, not ambient text

### DIFF
--- a/apps/dashboard/lib/main.dart
+++ b/apps/dashboard/lib/main.dart
@@ -58,14 +58,11 @@ class _DashboardAppState extends State<DashboardApp>
         themeAnimationDuration: Duration.zero,
         // FortalScope goes *below* MaterialApp and *above* the Navigator.
         //
-        // MaterialApp always hands WidgetsApp its "put your text in a Material"
-        // fallback style, which WidgetsApp installs as a DefaultTextStyle
-        // around everything beneath it — so a scope placed above MaterialApp
-        // would have its root text run overridden. `builder` wraps the whole
-        // Navigator, so this placement still reaches pushed routes and raw
-        // Overlay entries such as the toast with Fortal's root fallback.
-        // A nearer DefaultTextStyle (for example from a Material surface) can
-        // still override it through Flutter's normal inheritance.
+        // MaterialApp installs its fallback DefaultTextStyle below its widget
+        // tree, so a scope placed above it would be overridden. `builder` wraps
+        // the whole Navigator, so this placement reaches pushed routes and raw
+        // Overlay entries such as the toast. A nearer DefaultTextStyle retains
+        // its normal priority through Flutter's inheritance.
         builder: (context, child) => FortalScope(
           key: const ValueKey('dashboard-fortal-scope'),
           accent: _settings.accentColor,

--- a/apps/dashboard/lib/pages/gallery/gallery_navigation_page.dart
+++ b/apps/dashboard/lib/pages/gallery/gallery_navigation_page.dart
@@ -80,14 +80,14 @@ class _TabsDemoState extends State<_TabsDemo> {
           tabId: 'overview',
           child: const Padding(
             padding: EdgeInsets.all(8),
-            child: Text('Overview content'),
+            child: FortalText('Overview content'),
           ),
         ),
         FortalTabView(
           tabId: 'activity',
           child: const Padding(
             padding: EdgeInsets.all(8),
-            child: Text('Activity content'),
+            child: FortalText('Activity content'),
           ),
         ),
       ],
@@ -125,7 +125,7 @@ class _AccordionDemoState extends State<_AccordionDemo> {
           size: widget.size,
           value: 'details',
           title: 'What is Fortal?',
-          child: const Text(
+          child: const FortalText(
             'A Radix-inspired theme and component system for Flutter.',
           ),
         ),
@@ -134,7 +134,7 @@ class _AccordionDemoState extends State<_AccordionDemo> {
           size: widget.size,
           value: 'tokens',
           title: 'Does it support tokens?',
-          child: const Text(
+          child: const FortalText(
             'Every recipe resolves through the active Mix scope.',
           ),
         ),

--- a/apps/dashboard/lib/pages/gallery/gallery_overlays_page.dart
+++ b/apps/dashboard/lib/pages/gallery/gallery_overlays_page.dart
@@ -84,8 +84,8 @@ class _GalleryOverlaysPageState extends State<GalleryOverlaysPage> {
                       crossAxisAlignment: .start,
                       spacing: 8,
                       children: [
-                        Text('Quick note'),
-                        Text(
+                        FortalText('Quick note'),
+                        FortalText(
                           'Popover content inherits the active Fortal scope.',
                         ),
                       ],

--- a/apps/dashboard/lib/pages/gallery/gallery_typography_page.dart
+++ b/apps/dashboard/lib/pages/gallery/gallery_typography_page.dart
@@ -188,7 +188,7 @@ class GalleryTypographyPage extends StatelessWidget {
             runSpacing: 12,
             crossAxisAlignment: WrapCrossAlignment.center,
             children: const [
-              FortalText('Inherited', size: .size3),
+              FortalText('Neutral', size: .size3),
               FortalText('Accent', size: .size3, accent: true),
               FortalText(
                 'Accent high contrast',

--- a/apps/dashboard/lib/shell/dashboard_shell.dart
+++ b/apps/dashboard/lib/shell/dashboard_shell.dart
@@ -11,7 +11,6 @@ import '../pages/gallery/gallery_typography_page.dart';
 import '../pages/orders_page.dart';
 import '../pages/overview_page.dart';
 import '../pages/settings_page.dart';
-import '../widgets/typography.dart';
 import 'dashboard_page.dart';
 import 'sidebar.dart';
 import 'top_bar.dart';
@@ -56,44 +55,34 @@ class _DashboardShellState extends State<DashboardShell> {
     return Scaffold(
       key: _scaffoldKey,
       backgroundColor: Colors.transparent,
-      // Scaffold and Drawer are the two Material surfaces in this app, and each
-      // installs its own DefaultTextStyle below FortalScope's root run.
       drawer: compact
           ? Drawer(
               width: 256,
               semanticLabel: 'Dashboard navigation',
-              child: DashboardSurfaceTone(
-                child: Sidebar(selected: _selected, onSelected: _select),
-              ),
+              child: Sidebar(selected: _selected, onSelected: _select),
             )
           : null,
-      body: DashboardSurfaceTone(
-        child: Row(
-          children: [
-            if (!compact) Sidebar(selected: _selected, onSelected: _select),
-            Expanded(
-              child: Column(
-                children: [
-                  TopBar(
-                    page: _selected,
-                    onMenuPressed: compact
-                        ? () => _scaffoldKey.currentState?.openDrawer()
-                        : null,
-                    onSearchChanged: (value) => setState(
-                      () => _searchQuery = value.trim().toLowerCase(),
-                    ),
-                  ),
-                  Expanded(
-                    child: IndexedStack(
-                      index: _selected.index,
-                      children: pages,
-                    ),
-                  ),
-                ],
-              ),
+      body: Row(
+        children: [
+          if (!compact) Sidebar(selected: _selected, onSelected: _select),
+          Expanded(
+            child: Column(
+              children: [
+                TopBar(
+                  page: _selected,
+                  onMenuPressed: compact
+                      ? () => _scaffoldKey.currentState?.openDrawer()
+                      : null,
+                  onSearchChanged: (value) =>
+                      setState(() => _searchQuery = value.trim().toLowerCase()),
+                ),
+                Expanded(
+                  child: IndexedStack(index: _selected.index, children: pages),
+                ),
+              ],
             ),
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }

--- a/apps/dashboard/lib/widgets/typography.dart
+++ b/apps/dashboard/lib/widgets/typography.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/widgets.dart';
 import 'package:remix/remix.dart';
 import 'package:remix_fortal/remix_fortal.dart';
 
@@ -36,30 +35,6 @@ TextStyler dashboardText(
   FortalTextWeight? weight,
   TextTone tone = TextTone.strong,
 }) => fortalTextStyle(size: size, weight: weight).color(tone._color());
-
-/// Restores Fortal's neutral foreground under a Material surface.
-///
-/// `FortalScope` establishes the Radix root run at `gray12`, but `Scaffold`
-/// and `Drawer` each install their own `DefaultTextStyle` below it, coloured
-/// from Material's `colorScheme.onSurface`. Anything inheriting its colour —
-/// every unsized [FortalText] and [FortalHeading] — would take Material's
-/// foreground instead of the active gray scale.
-///
-/// This re-asserts the scale once per Material surface rather than at each
-/// call site: Fortal models neutral tone as inherited context, so the fix
-/// belongs at the boundary that broke the inheritance. [dashboardText]'s
-/// explicit tones still override it, and both follow live theme changes.
-class DashboardSurfaceTone extends StatelessWidget {
-  const DashboardSurfaceTone({super.key, required this.child});
-
-  final Widget child;
-
-  @override
-  Widget build(BuildContext context) => DefaultTextStyle.merge(
-    style: TextStyle(color: MixScope.tokenOf(TextTone.strong._color, context)),
-    child: child,
-  );
-}
 
 /// Single-line [dashboardText] that ellipsizes, for text sharing a row with a
 /// fixed-width neighbour.

--- a/apps/dashboard/test/app_smoke_test.dart
+++ b/apps/dashboard/test/app_smoke_test.dart
@@ -344,7 +344,11 @@ void main() {
       ),
     );
     expect(content, findsOneWidget);
-    expect(tester.getSize(content).height, lessThan(120));
+    final title = find.text('Quick note');
+    final body = find.text('Popover content inherits the active Fortal scope.');
+    final expectedHeight =
+        tester.getSize(title).height + 8 + tester.getSize(body).height;
+    expect(tester.getSize(content).height, expectedHeight);
   });
 
   testWidgets('dashboard action popovers shrink-wrap their actions', (

--- a/docs/fortal.mdx
+++ b/docs/fortal.mdx
@@ -60,17 +60,18 @@ that overlay and route content inherits the tokens.
 
 ## Scope placement
 
-The **outermost** `FortalScope` carries more than tokens: it also establishes
-the Radix theme root's default text run — `text3` (16px, 1.5 line height, 0
-letter spacing) at `gray-12`, regular weight, with no pinned font family. That
-mirrors `.radix-themes` upstream, and it is what an unsized `FortalText`,
-`FortalCode`, `FortalKbd`, or `FortalLink` measures its `1em` against when no
-closer `DefaultTextStyle` is present.
+The **outermost** `FortalScope` provides the design tokens and establishes a
+courtesy `DefaultTextStyle` for bare Flutter `Text`: the Radix theme root run —
+`text3` (16px, 1.5 line height, 0 letter spacing) at `gray-12`, regular weight,
+with no pinned font family. This is analogous to Material's `bodyMedium`; it is
+not the source of a Fortal typography run. Unsized `FortalText`, `FortalCode`,
+`FortalKbd`, and `FortalLink` resolve their documented defaults directly from
+the active scope's tokens.
 
-A **nested** scope only re-scopes tokens. It inherits the closest text style in
-effect rather than restating the root run, so re-scoping a subtree for a
-different accent or scaling never resizes or recolors the text already running
-through it.
+A **nested** scope re-scopes tokens without restating the courtesy bare-`Text`
+run. Fortal typography re-resolves against those nested tokens, so gray or
+scaling changes apply to the subtree, while ordinary Flutter text keeps its
+nearest inherited style.
 
 Where the outermost scope goes therefore depends on your host:
 
@@ -102,17 +103,19 @@ app. A scope placed above `MaterialApp` still supplies tokens, but its root text
 run is overridden. `builder:` sits below that style and above the `Navigator`,
 so pushed routes and raw `Overlay` entries receive the Fortal fallback.
 
-The root run is a fallback, and it follows Flutter's normal text-style cascade.
-A nearer `DefaultTextStyle` wins, and widgets such as `Material` and `Scaffold`
-commonly install one. Unsized Fortal typography inside those surfaces
-intentionally inherits that local run. Pass an explicit
-`size: FortalTextSize.size3` when a component must remain at the exact Radix
-root size regardless of its host.
+The root run is only a fallback for bare Flutter `Text`, and it follows
+Flutter's normal text-style cascade. A nearer `DefaultTextStyle`, including one
+installed by `Material` or `Scaffold`, wins for that bare text. Fortal
+typography does not inherit it: omitted sizes use the `text3` token, and an
+explicit `size:` selects another token size. Transparent, non-accent
+`FortalCode.ghost` is the deliberate exception for foreground only, so it can
+blend into surrounding text without inheriting that run's metrics.
 
 <Warning>
-  If text inside a hand-rolled `OverlayEntry` renders red and monospace with a
-  yellow double underline, the scope is above `MaterialApp` rather than inside
-  `builder:`. That is Flutter's "put your text in a Material" fallback style.
+  If bare Flutter `Text` inside a hand-rolled `OverlayEntry` renders red and
+  monospace with a yellow double underline, the scope is above `MaterialApp`
+  rather than inside `builder:`. That is Flutter's "put your text in a
+  Material" fallback style; Fortal typography pins its own token run.
 </Warning>
 
 ## Customizing Fortal Styles

--- a/docs/fortal/typography.mdx
+++ b/docs/fortal/typography.mdx
@@ -32,28 +32,28 @@ tokens is the equivalent there.
 | `FortalKbd` | One keyboard key or shortcut | `keyboardKey`, inert |
 | `FortalLink` | Text that navigates | `link` **only** while enabled and given an `onPressed` |
 
-`FortalText` and `FortalCode` leave `size` and `weight` null by default so an
-omitted size inherits the ambient `DefaultTextStyle`, matching a Radix `Text`
-with no size prop rendering at `1em`. `FortalHeading` defaults to size 6 and
-bold because Radix Heading does.
+`FortalText`, `FortalCode`, `FortalKbd`, and `FortalLink` keep nullable public
+`size` fields, but an omitted size resolves the active scope's `text3` token
+rather than the ambient `DefaultTextStyle`. `FortalText` also defaults to the
+regular weight token and neutral `gray-12`; `FortalHeading` defaults to size 6,
+bold, and neutral `gray-12`.
 
-At the scope boundary, that `1em` is defined by the outermost `FortalScope`,
-which establishes the Radix theme root's text run — `text3` (16px, 1.5 line
-height) at `gray-12`, regular weight. With no closer `DefaultTextStyle`, an
-unsized `FortalCode` therefore resolves `0.95 × 0.95 × 16px`, exactly as
-upstream does. Under `MaterialApp` or `CupertinoApp` the scope belongs in
-`builder:` so the fallback reaches routes and raw overlays; see
-[scope placement](/fortal#scope-placement).
+This deliberately differs from Radix CSS, where an unsized `Text` renders at
+the surrounding `1em`. Fortal keeps the upstream Code and Kbd adjustments but
+anchors them to tokens: an unsized soft Code resolves
+`0.95 × 0.95 × text3`, and an unsized Kbd resolves `0.75 × text3`. Pass an
+explicit `size:` to select another token size.
 
-A nearer `DefaultTextStyle` still wins by design. In particular, `Material`
-and `Scaffold` commonly establish a local run. Unsized Fortal widgets inherit
-that run just as Radix text inherits a nearer CSS font size. Specify
-`size: FortalTextSize.size3` when exact root sizing is required inside one of
-those surfaces.
+The outermost `FortalScope` still establishes the Radix root run as a courtesy
+`DefaultTextStyle` for bare Flutter `Text`. Under `MaterialApp` or
+`CupertinoApp`, put the scope in `builder:` so that fallback reaches routes and
+raw overlays; see [scope placement](/fortal#scope-placement). A nearer
+`DefaultTextStyle` can replace the run for bare text, but never changes Fortal
+typography metrics.
 
-A nested `FortalScope` is not a new root: it re-scopes tokens and inherits the
-closest text style, so re-theming a subtree for a different accent or scaling
-leaves the surrounding `1em` intact.
+A nested `FortalScope` re-scopes tokens without restating the courtesy
+bare-`Text` run. Fortal typography re-resolves against the nested gray and
+scaling tokens, while ordinary Flutter text keeps its nearest inherited style.
 
 ## Basic implementation
 
@@ -111,10 +111,11 @@ Every family accepts the same scale and flow controls.
 `truncate` deliberately wins over `softWrap`: it forces exactly one ellipsized
 line, which is what a table cell or a row with a fixed-width neighbour needs.
 
-Colour is opt-in. `accent: true` takes the surrounding `FortalScope` accent at
-`accent-a11`, and `highContrast: true` promotes it to `accent-12`. Leaving
-`accent` false preserves the inherited foreground, so `highContrast` alone does
-nothing — the same gate Radix puts behind `[data-accent-color]`.
+`FortalText` and `FortalHeading` use neutral `gray-12` unless `accent: true`
+takes the surrounding `FortalScope` accent at `accent-a11`; adding
+`highContrast: true` promotes it to `accent-12`. `highContrast` alone leaves
+the neutral color unchanged — the same gate Radix puts behind
+`[data-accent-color]`.
 
 `FortalKbd` is the exception: it pins its own regular weight, line box, and
 `gray-12` foreground so a key cap never follows the surrounding copy.
@@ -151,7 +152,7 @@ class TypographyVariantsExample extends StatelessWidget {
 
 `FortalCode.ghost` is transparent and inherits the ambient foreground unless you
 pass `accent: true`; the other three variants always paint their own accent
-roles.
+roles. A foreground composed onto the recipe overrides that ambient fallback.
 
 ## Headings and semantic level
 

--- a/packages/remix_fortal/README.md
+++ b/packages/remix_fortal/README.md
@@ -51,10 +51,13 @@ class MyApp extends StatelessWidget {
 ```
 
 `FortalScope` is a `MixScope`. The outermost one also establishes the Radix
-theme root's default text run — `text3` at `gray-12` — which is what an unsized
-`FortalText`, `FortalCode`, `FortalKbd`, or `FortalLink` measures `1em` against
-when no closer `DefaultTextStyle` is present. A nested scope only re-scopes
-tokens; it inherits the closest text style rather than restating the root run.
+theme root's `text3` at `gray-12` run as a courtesy `DefaultTextStyle` for bare
+Flutter `Text`. Fortal typography does not depend on that inherited run:
+unsized `FortalText`, `FortalCode`, `FortalKbd`, and `FortalLink` resolve their
+documented defaults directly from the active scope's tokens. A nested scope
+re-scopes those tokens without restating the courtesy bare-`Text` run. The one
+deliberate foreground exception is transparent, non-accent `FortalCode.ghost`,
+which blends with its surrounding text unless explicitly restyled.
 
 Place it above your app widget so that overlay and route content inherits the
 tokens — **except** under `MaterialApp` or `CupertinoApp`, which install their
@@ -72,9 +75,12 @@ final app = MaterialApp(
 ```
 
 This is a fallback, not a forced global style. A nearer `DefaultTextStyle`,
-including one installed by `Material` or `Scaffold`, still wins. Use an
-explicit `size: FortalTextSize.size3` when exact 16px Radix root sizing is
-required inside such a surface.
+including one installed by `Material` or `Scaffold`, still wins for bare
+Flutter `Text`. Fortal typography ignores that ambient run for token metrics
+and default roles: an omitted size uses `text3`, while an explicit `size:`
+selects another token size. This is a deliberate deviation from Radix's
+ambient CSS `1em` behavior. The sole ambient field retained by Fortal
+typography is the foreground of transparent, non-accent `FortalCode.ghost`.
 
 ## Customizing Fortal styles
 

--- a/packages/remix_fortal/lib/src/fortal/fortal_theme.dart
+++ b/packages/remix_fortal/lib/src/fortal/fortal_theme.dart
@@ -1378,7 +1378,7 @@ Map<MixToken, Object> _buildFortalScopeTokens(FortalThemeData theme) {
   return allTokens;
 }
 
-/// Establishes the Radix theme root's default text run.
+/// Establishes a courtesy default text run for bare [Text] descendants.
 ///
 /// `.radix-themes` is not only a token carrier upstream: `color.css` sets
 /// `color: var(--gray-12)` in the same rule as the `data-has-background` fill,
@@ -1387,12 +1387,10 @@ Map<MixToken, Object> _buildFortalScopeTokens(FortalThemeData theme) {
 /// `--default-font-weight`. Those resolve to exactly [FortalTokens.text3] plus
 /// [FortalTokens.gray12] at regular weight.
 ///
-/// Without this fallback, "inherits the ambient `DefaultTextStyle`" — the
-/// documented behaviour of an unsized [FortalText], [FortalCode], [FortalKbd],
-/// or [FortalLink] — means "inherits whatever the outer host happens to
-/// supply", so the em-relative geometry of Code, Kbd, and Link is measured
-/// against that host instead of Radix's 16px root. A nearer descendant
-/// `DefaultTextStyle` still wins through Flutter's normal inheritance.
+/// Fortal text recipes resolve and pin their own runs. This fallback keeps
+/// deliberately bare [Text] descendants aligned with Radix's root typography
+/// and neutral foreground. A nearer descendant `DefaultTextStyle` still wins
+/// through Flutter's normal inheritance.
 ///
 /// Only the outermost [FortalScope] installs this. A nested scope re-scopes
 /// tokens for its subtree and nothing more: upstream, `.radix-themes` inside

--- a/packages/remix_fortal/lib/src/recipes/accordion.dart
+++ b/packages/remix_fortal/lib/src/recipes/accordion.dart
@@ -122,10 +122,10 @@ AccordionStyler _fortalAccordionSoftStyler([
 BorderSideMix _fortalAccordionBorderSide(Color color) =>
     BorderSideMix(color: color, width: FortalTokens.borderWidth1());
 
-/// Pins accordion content to the 14px type-scale step (`text2`) regardless
-/// of accordion size, so content never renders larger than its own
-/// trigger's title (measured 14/15/16px at size1/size2/size3). [color]
-/// supplies the variant's own content tint.
+/// Pins bare [Text] accordion content to the 14px type-scale step (`text2`)
+/// regardless of accordion size, so content never renders larger than its own
+/// trigger's title (measured 14/15/16px at size1/size2/size3). Fortal text
+/// children pin their own run. [color] supplies the variant's own content tint.
 WidgetModifierConfig _fortalAccordionContentTypography(Color color) =>
     WidgetModifierConfig.defaultTextStyle(
       style: FortalTokens.text2.mix(),

--- a/packages/remix_fortal/lib/src/recipes/code.dart
+++ b/packages/remix_fortal/lib/src/recipes/code.dart
@@ -12,8 +12,9 @@ enum FortalCodeVariant { solid, soft, outline, ghost }
 /// Fortal-themed inline code on the Radix nine-step scale.
 ///
 /// Geometry is em-relative to the resolved font size, so this recipe takes a
-/// [context]: an explicit [size] resolves its text token, and an omitted one
-/// inherits the ambient `DefaultTextStyle` exactly as Radix's `1em` does.
+/// [context]. An omitted [size] anchors to the root `text3` token — not the
+/// ambient `DefaultTextStyle` — while keeping upstream's separate unsized
+/// factors, so a host text run cannot change Code's geometry.
 BadgeStyler fortalCodeStyle(
   BuildContext context, {
   FortalTextSize? size,
@@ -24,17 +25,15 @@ BadgeStyler fortalCodeStyle(
   bool accent = false,
   bool highContrast = false,
 }) {
-  final base = size == null
-      ? DefaultTextStyle.of(context).style
-      : fortalResolveTextToken(context, size);
-  final baseFontSize = fortalResolvedFontSize(base);
+  final base = fortalResolveTextToken(context, size ?? FortalTextSize.size3);
+  final baseFontSize = base.fontSize!;
 
   // Radix nests two adjustments: --code-font-size-adjust is 0.95, and
   // --code-variant-font-size-adjust multiplies it by 0.95 again for every
   // variant except ghost, which keeps the outer value.
   final decorated = variant != FortalCodeVariant.ghost;
   final fontSize = baseFontSize * (decorated ? 0.95 * 0.95 : 0.95);
-  // An explicit size keeps its token's absolute line box; the inherited path
+  // An explicit size keeps its token's absolute line box; the unsized path
   // uses the pinned unitless 1.25.
   final lineHeight = size == null
       ? 1.25
@@ -52,7 +51,8 @@ BadgeStyler fortalCodeStyle(
       ])
       .fontSize(fontSize)
       .height(lineHeight)
-      .letterSpacing(letterSpacing);
+      .letterSpacing(letterSpacing)
+      .inherit(false);
   if (weight != null) {
     textStyle = textStyle.fontWeight(fortalTextWeightToken(weight)());
   }
@@ -84,8 +84,22 @@ BadgeStyler fortalCodeStyle(
       foreground = highContrast ? accent12 : accentA11;
     case .ghost:
       // Ghost is transparent and inherits the ambient colour unless the caller
-      // opts into the local accent.
-      if (accent) foreground = highContrast ? accent12 : accentA11;
+      // opts into the local accent. Apply only that intended ambient field
+      // after Mix composition so an explicit recipe colour or foreground can
+      // override it without creating an invalid Flutter TextStyle.
+      if (accent) {
+        foreground = highContrast ? accent12 : accentA11;
+      } else {
+        textStyle = textStyle.merge(
+          TextStyler.create(
+            style: Prop<TextStyle>.directives([
+              _AmbientCodeForegroundDirective(
+                DefaultTextStyle.of(context).style,
+              ),
+            ]),
+          ),
+        );
+      }
   }
   if (foreground != null) textStyle = textStyle.color(foreground);
 
@@ -134,6 +148,61 @@ BadgeStyler fortalCodeStyle(
 
   return style;
 }
+
+final class _AmbientCodeForegroundDirective extends Directive<TextStyle> {
+  _AmbientCodeForegroundDirective(TextStyle ambient)
+    : color = ambient.color,
+      foreground = ambient.foreground;
+
+  final Color? color;
+  final Paint? foreground;
+
+  @override
+  String get key => 'fortal_code_ambient_foreground';
+
+  @override
+  TextStyle apply(TextStyle style) {
+    final hasAmbientFallback = _ambientCodeForegroundFallbacks[style] ?? false;
+    if (!hasAmbientFallback &&
+        (style.color != null || style.foreground != null)) {
+      return style;
+    }
+    if (color == null && foreground == null) return style;
+
+    late final TextStyle result;
+    if (foreground case final paint?) {
+      result = style.copyWith(foreground: paint);
+    } else if (style.foreground != null) {
+      // Mix concatenates directives when recipes merge. If an earlier fallback
+      // supplied a Paint, copyWith cannot clear it in favour of a Color. Keep
+      // the equivalent Paint representation so the later recipe still wins
+      // without producing an invalid TextStyle(color:, foreground:).
+      result = style.copyWith(foreground: Paint()..color = color!);
+    } else {
+      result = style.copyWith(color: color);
+    }
+
+    // Expando keeps provenance out of TextStyle's visual and diagnostic
+    // fields, works with assertions disabled, and does not retain resolved
+    // styles after Mix finishes applying the directive list.
+    _ambientCodeForegroundFallbacks[result] = true;
+    return result;
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is _AmbientCodeForegroundDirective &&
+          other.color == color &&
+          other.foreground == foreground;
+
+  @override
+  int get hashCode => Object.hash(color, foreground);
+}
+
+final _ambientCodeForegroundFallbacks = Expando<bool>(
+  'fortal_code_ambient_foreground',
+);
 
 /// Token-backed standalone code text with the Radix Code variants.
 ///

--- a/packages/remix_fortal/lib/src/recipes/heading.dart
+++ b/packages/remix_fortal/lib/src/recipes/heading.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/widgets.dart';
 import 'package:remix/remix.dart';
 
+import '../fortal/fortal.dart';
 import 'typography_shared.dart';
 
 /// Fortal-themed heading style on the Radix nine-step scale.
@@ -37,9 +38,12 @@ TextStyler fortalHeadingStyle({
   var style = TextStyler(
     style: fortalTextSizeToken(size).mix(),
   ).height(lineHeight).fontWeight(fortalTextWeightToken(weight)());
-  if (accent) {
-    style = fortalAccentForeground(style, highContrast: highContrast);
-  }
+  // Neutral headings pin `gray12` from the tokens rather than inheriting the
+  // ambient foreground, matching fortalTextStyle's token-default contract.
+  style = accent
+      ? fortalAccentForeground(style, highContrast: highContrast)
+      : style.color(FortalTokens.gray12());
+  style = style.inherit(false);
 
   return fortalApplyTextFlow(
     style,

--- a/packages/remix_fortal/lib/src/recipes/kbd.dart
+++ b/packages/remix_fortal/lib/src/recipes/kbd.dart
@@ -11,26 +11,25 @@ enum FortalKbdVariant { classic, soft }
 ///
 /// Like Code, the geometry is em-relative to the resolved font size, so this
 /// recipe takes a [context]. Radix uses two different type-scale factors: an
-/// explicit size multiplies its token by `0.8`, while an inherited one uses the
-/// unsized `0.75em`.
+/// explicit size multiplies its token by `0.8`, while an omitted one keeps
+/// upstream's unsized `0.75em` — anchored to the root `text3` token rather
+/// than the ambient `DefaultTextStyle`, so a host text run cannot resize the
+/// key cap.
 BadgeStyler fortalKbdStyle(
   BuildContext context, {
   FortalTextSize? size,
   FortalKbdVariant variant = .classic,
 }) {
-  final base = size == null
-      ? DefaultTextStyle.of(context).style
-      : fortalResolveTextToken(context, size);
-  final fontSize = fortalResolvedFontSize(base) * (size == null ? 0.75 : 0.8);
+  final base = fortalResolveTextToken(context, size ?? FortalTextSize.size3);
+  final fontSize = base.fontSize! * (size == null ? 0.75 : 0.8);
   // Upstream `--letter-spacing-N` is em-relative, so an explicit size resolves
   // it against Kbd's own `0.8em` rather than the token's own font size. The
-  // inherited path keeps Flutter's absolute inheritance instead: an ambient
-  // DefaultTextStyle carries a resolved letter spacing with no em intent left
-  // to rescale.
+  // unsized path keeps the token's letter spacing unscaled, matching the
+  // resolved value upstream's `0.75em` run would carry.
   final letterSpacing = (base.letterSpacing ?? 0) * (size == null ? 1 : 0.8);
 
-  // Kbd pins its own weight and line box regardless of the inherited style, so
-  // it stays a key cap rather than following surrounding copy.
+  // Kbd pins its own weight and line box regardless of the surrounding style,
+  // so it stays a key cap rather than following surrounding copy.
   final textStyle = TextStyler()
       .fontSize(fontSize)
       .fontWeight(FortalTokens.fontWeightRegular())
@@ -40,7 +39,8 @@ BadgeStyler fortalKbdStyle(
       .textAlign(TextAlign.center)
       .softWrap(false)
       .maxLines(1)
-      .color(FortalTokens.gray12());
+      .color(FortalTokens.gray12())
+      .inherit(false);
 
   var style = BadgeStyler()
       .label(textStyle)

--- a/packages/remix_fortal/lib/src/recipes/link.dart
+++ b/packages/remix_fortal/lib/src/recipes/link.dart
@@ -76,17 +76,22 @@ LinkStyler _fortalLinkStateStyle(
     TextStyler(),
     highContrast: highContrast,
   );
-  if (size != null) {
-    textStyle = textStyle.style(fortalTextSizeToken(size).mix());
-  }
+  // An omitted size anchors to the root `text3` token rather than the ambient
+  // `DefaultTextStyle`, so a host text run cannot change the link's metrics or
+  // its em-relative underline geometry.
+  textStyle = textStyle.style(
+    fortalTextSizeToken(size ?? FortalTextSize.size3).mix(),
+  );
   if (weight != null) {
     textStyle = textStyle.fontWeight(fortalTextWeightToken(weight)());
   }
+  textStyle = textStyle.inherit(false);
 
-  final effectiveText = size == null
-      ? DefaultTextStyle.of(context).style
-      : fortalResolveTextToken(context, size);
-  final fontSize = fortalResolvedFontSize(effectiveText);
+  final effectiveText = fortalResolveTextToken(
+    context,
+    size ?? FortalTextSize.size3,
+  );
+  final fontSize = effectiveText.fontSize!;
 
   // Every upstream underline rule is gated behind `:where(:any-link, button)`,
   // so a link with no callback stays plain accent-coloured text. A focus-visible
@@ -227,7 +232,7 @@ class FortalLink extends StatelessWidget {
         softWrap: softWrap,
         truncate: truncate,
         highContrast: highContrast,
-        actionable: onPressed != null,
+        actionable: enabled && onPressed != null,
       ),
     );
   }

--- a/packages/remix_fortal/lib/src/recipes/text.dart
+++ b/packages/remix_fortal/lib/src/recipes/text.dart
@@ -9,10 +9,14 @@ part 'text.g.dart';
 
 /// Fortal-themed body text on the Radix nine-step scale.
 ///
-/// Omitted [size] and [weight] inherit the ambient `DefaultTextStyle`, matching
-/// Radix, where Text without a size prop renders at the inherited `1em`.
-/// Set [accent] to take the surrounding [FortalScope]'s accent colour; leaving
-/// it false preserves the inherited foreground.
+/// Omitted [size] and [weight] resolve to the Radix root run (`text3`,
+/// regular) from the active [FortalScope]'s tokens rather than the ambient
+/// `DefaultTextStyle`. This deliberately deviates from Radix's CSS `1em`
+/// inheritance: a token default cannot be silently replaced by a host-installed
+/// text run (a `Material` surface, or a host with no run at all), which keeps
+/// Fortal text a function of the theme alone. Set [accent] to take the
+/// surrounding [FortalScope]'s accent colour; leaving it false uses the
+/// neutral `gray12` foreground.
 @MixWidget()
 TextStyler fortalTextStyle({
   FortalTextSize? size,
@@ -23,14 +27,16 @@ TextStyler fortalTextStyle({
   bool accent = false,
   bool highContrast = false,
 }) {
-  var style = TextStyler();
-  if (size != null) style = style.style(fortalTextSizeToken(size).mix());
-  if (weight != null) {
-    style = style.fontWeight(fortalTextWeightToken(weight)());
-  }
-  if (accent) {
-    style = fortalAccentForeground(style, highContrast: highContrast);
-  }
+  var style = TextStyler().style(
+    fortalTextSizeToken(size ?? FortalTextSize.size3).mix(),
+  );
+  style = style.fontWeight(
+    fortalTextWeightToken(weight ?? FortalTextWeight.regular)(),
+  );
+  style = accent
+      ? fortalAccentForeground(style, highContrast: highContrast)
+      : style.color(FortalTokens.gray12());
+  style = style.inherit(false);
 
   return fortalApplyTextFlow(
     style,

--- a/packages/remix_fortal/lib/src/recipes/text.g.dart
+++ b/packages/remix_fortal/lib/src/recipes/text.g.dart
@@ -8,10 +8,14 @@ part of 'text.dart';
 
 /// Fortal-themed body text on the Radix nine-step scale.
 ///
-/// Omitted [size] and [weight] inherit the ambient `DefaultTextStyle`, matching
-/// Radix, where Text without a size prop renders at the inherited `1em`.
-/// Set [accent] to take the surrounding [FortalScope]'s accent colour; leaving
-/// it false preserves the inherited foreground.
+/// Omitted [size] and [weight] resolve to the Radix root run (`text3`,
+/// regular) from the active [FortalScope]'s tokens rather than the ambient
+/// `DefaultTextStyle`. This deliberately deviates from Radix's CSS `1em`
+/// inheritance: a token default cannot be silently replaced by a host-installed
+/// text run (a `Material` surface, or a host with no run at all), which keeps
+/// Fortal text a function of the theme alone. Set [accent] to take the
+/// surrounding [FortalScope]'s accent colour; leaving it false uses the
+/// neutral `gray12` foreground.
 class FortalText extends StatelessWidget {
   const FortalText(
     this.text, {

--- a/packages/remix_fortal/lib/src/recipes/typography_shared.dart
+++ b/packages/remix_fortal/lib/src/recipes/typography_shared.dart
@@ -72,12 +72,6 @@ TextStyle fortalResolveTextToken(BuildContext context, FortalTextSize size) =>
 Color fortalResolveColor(BuildContext context, ColorToken token) =>
     MixScope.tokenOf(token, context);
 
-/// Falls back to what Flutter actually paints when the ambient style omits a
-/// size. `DefaultTextStyle.fallback().style.fontSize` is null, so reading it
-/// with `!` always throws rather than supplying a default.
-double fortalResolvedFontSize(TextStyle style) =>
-    style.fontSize ?? kDefaultFontSize;
-
 /// Derived from the resolved `radius1` rather than duplicating the Fortal
 /// radius enum table, so theme radius and scaling changes flow through.
 double fortalRadiusFactor(BuildContext context) {

--- a/packages/remix_fortal/reference/radix_themes_3_3_0/coverage_evidence.json
+++ b/packages/remix_fortal/reference/radix_themes_3_3_0/coverage_evidence.json
@@ -7,12 +7,12 @@
     },
     {
       "test": "test/fortal/fortal_theme_resolution_test.dart",
-      "case": "unsized typography measures 1em against the root, not the host",
+      "case": "root scope keeps a courtesy DefaultTextStyle for bare Text",
       "covers": ["state:rootTextStyle"]
     },
     {
       "test": "test/fortal/fortal_theme_resolution_test.dart",
-      "case": "a nested scope preserves the nearest text style",
+      "case": "a nested scope reanchors unsized typography to its tokens",
       "covers": ["state:rootTextStyle", "state:nestedInherit"]
     },
     {
@@ -1053,7 +1053,7 @@
     },
     {
       "test": "test/components/typography/typography_test.dart",
-      "case": "code applies the nested Radix font-size adjustments",
+      "case": "code applies nested factors to the text3 token",
       "covers": ["enum:variant.soft", "enum:variant.ghost", "state:idle"]
     },
     {
@@ -1076,6 +1076,16 @@
       "test": "test/components/typography/typography_test.dart",
       "case": "ghost gains the accent foreground only when opted in",
       "covers": ["enum:variant.ghost", "state:accent"]
+    },
+    {
+      "test": "test/components/typography/typography_test.dart",
+      "case": "ghost preserves ambient Paint until a composed color overrides it",
+      "covers": ["enum:variant.ghost", "state:idle"]
+    },
+    {
+      "test": "test/components/typography/typography_test.dart",
+      "case": "later merged ghost recipe replaces the ambient fallback",
+      "covers": ["enum:variant.ghost", "state:idle"]
     },
     {
       "test": "test/components/typography/typography_test.dart",
@@ -1112,7 +1122,7 @@
     },
     {
       "test": "test/components/typography/typography_test.dart",
-      "case": "kbd uses distinct unsized and explicit type factors",
+      "case": "kbd applies distinct unsized and explicit token factors",
       "covers": ["state:idle"]
     },
     {
@@ -1200,6 +1210,15 @@
       "test": "test/components/typography/typography_test.dart",
       "case": "disabled link cannot focus or activate",
       "covers": ["state:disabled"]
+    },
+    {
+      "test": "test/components/typography/typography_test.dart",
+      "case": "disabled links never underline even with a callback",
+      "covers": [
+        "enum:underline.auto",
+        "enum:underline.always",
+        "state:disabled"
+      ]
     },
     {
       "test": "test/components/typography/typography_test.dart",

--- a/packages/remix_fortal/reference/radix_themes_3_3_0/manifest.json
+++ b/packages/remix_fortal/reference/radix_themes_3_3_0/manifest.json
@@ -3895,7 +3895,7 @@
         ".rt-high-contrast"
       ],
       "flutterExceptions": [
-        "An omitted size renders at the ambient DefaultTextStyle, matching an unsized Radix Text at 1em; only an explicit size resolves a token.",
+        "An omitted size and weight resolve the text3 and regular tokens, and neutral text resolves gray-12, rather than inheriting the ambient DefaultTextStyle. This deliberately differs from an unsized Radix Text rendering at 1em; an explicit size selects another token.",
         "The `as` element choice and `asChild` map to Flutter widget composition; FortalText always renders exactly one Text node.",
         "Radix `wrap` covers pretty and balance line breaking; Flutter exposes no equivalent line breaker, so the recipe maps only the wrap/nowrap pair onto softWrap and folds truncate into one ellipsized line.",
         "CSS leading trim has no Flutter primitive, so the token line box is painted untrimmed.",
@@ -4082,6 +4082,7 @@
       "flutterExceptions": [
         "Radix `as` selects an h1\u2013h6 element that carries the visual and the semantic level together; Flutter splits them, so headingLevel drives a Semantics header node while size stays purely visual.",
         "`--heading-font-size-adjust` is 1, so headings reuse the raw token size and differ from body text only in the pinned line box.",
+        "A neutral FortalHeading resolves gray-12 rather than inheriting the ambient foreground; accent is an explicit opt-in.",
         "Radix `wrap` covers pretty and balance line breaking; Flutter exposes no equivalent line breaker, so the recipe maps only the wrap/nowrap pair onto softWrap and folds truncate into one ellipsized line.",
         "CSS leading trim has no Flutter primitive, so the token line box is painted untrimmed."
       ],
@@ -4279,8 +4280,9 @@
       ],
       "flutterExceptions": [
         "Radix renders Code as an inline element inside a text run; RemixBadge paints a standalone box, so a Code inside a wrapped sentence is a sibling widget rather than an inline span.",
-        "`--code-font-weight: inherit` becomes an optional weight argument because a Flutter TextStyler cannot inherit one property in isolation.",
-        "Ghost inherits the ambient foreground unless the caller opts into the local accent, matching the upstream `[data-accent-color]` gate.",
+        "An omitted size anchors the upstream Code factors to the text3 token rather than the ambient 1em run.",
+        "`--code-font-weight: inherit` becomes an optional weight argument. When omitted, the non-inheriting Flutter TextStyle leaves weight unset and therefore uses the engine's regular weight rather than the ambient weight.",
+        "Ghost uses the ambient foreground as a post-composition fallback unless the caller opts into the local accent, matching the upstream `[data-accent-color]` gate while allowing an explicit recipe foreground to win.",
         "The Link-nested hover, solid high-contrast hover filter, and ::selection rules need an actionable ancestor FortalCode never has.",
         "Radix `wrap` covers pretty and balance line breaking; Flutter exposes no equivalent line breaker, so the recipe maps only the wrap/nowrap pair onto softWrap and folds truncate into one ellipsized line.",
         "CSS leading trim has no Flutter primitive, so the token line box is painted untrimmed."
@@ -4442,8 +4444,8 @@
         ".rt-variant-soft"
       ],
       "flutterExceptions": [
-        "Radix uses two type-scale factors: an explicit size multiplies its token by 0.8, while an unsized Kbd renders at 0.75em of the ambient style. Because `--letter-spacing-N` is an em, an explicit size also re-resolves its letter spacing against Kbd's own 0.8 font size.",
-        "The inherited path keeps Flutter absolute letter-spacing inheritance: an ambient DefaultTextStyle carries a resolved value with no em intent left to rescale.",
+        "Radix uses two type-scale factors: an explicit size multiplies its token by 0.8, while an unsized Kbd renders at 0.75em. Fortal keeps those factors but anchors an omitted size to the text3 token rather than the ambient DefaultTextStyle. Because `--letter-spacing-N` is an em, an explicit size also re-resolves its letter spacing against Kbd's own 0.8 font size.",
+        "The unsized path keeps the text3 token's resolved letter spacing instead of inheriting the ambient DefaultTextStyle's absolute value.",
         "`vertical-align: text-top` positions the cap inside a surrounding text run; a standalone Flutter box has no inline baseline to align against.",
         "The hover, open, active, and focus-visible rules apply only when Kbd is nested in an anchor or button, which FortalKbd never is.",
         "Kbd publishes one native keyboardKey Semantics node and no tap action, because it is inert upstream."
@@ -4602,6 +4604,8 @@
       ],
       "flutterExceptions": [
         "Every upstream underline rule is gated behind `:where(:any-link, button)`, so a FortalLink with no onPressed is disabled exactly as `enabled: false` is: it keeps the accent colour but gives up its underline, focus stop, link role, and activation.",
+        "An omitted size resolves the text3 token rather than inheriting the ambient 1em run.",
+        "An omitted weight stays unset on a non-inheriting Flutter TextStyle and therefore uses the engine's regular weight rather than the ambient weight.",
         "`text-underline-offset` has no Flutter TextStyle equivalent, so the underline sits at the font's own offset.",
         "Flutter reads decorationThickness as a multiple of the font underline thickness rather than a CSS length, so the pinned `min(2px, max(1px, 0.05em))` ramp lands as a 1x\u20132x stroke.",
         "The decoration colour approximates Radix `color-mix(in oklab, \u2026)` with an sRGB Color.lerp.",

--- a/packages/remix_fortal/test/components/typography/typography_test.dart
+++ b/packages/remix_fortal/test/components/typography/typography_test.dart
@@ -1,6 +1,7 @@
 import 'dart:ui' show PointerDeviceKind, Tristate;
 
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:naked_ui/naked_ui.dart';
@@ -57,25 +58,25 @@ void main() {
       expect(style.fontWeight, FontWeight.w700);
     });
 
-    testWidgets('code applies the nested Radix font-size adjustments', (
+    testWidgets('code applies nested factors to the text3 token', (
       tester,
     ) async {
       await _pump(
         tester,
         const Column(
           children: [
-            FortalCode.soft('ambient'),
+            FortalCode.soft('unsized'),
             FortalCode.soft('explicit', size: FortalTextSize.size2),
             FortalCode.ghost('ghost', size: FortalTextSize.size2),
           ],
         ),
       );
 
-      final ambient = _text(tester, 'ambient').style!;
-      expect(ambient.fontSize, closeTo(20 * 0.95 * 0.95, 1e-9));
-      expect(ambient.height, 1.25);
-      expect(ambient.letterSpacing, closeTo(2 - 0.007 * 18.05, 1e-9));
-      expect(ambient.fontFamily, 'Menlo');
+      final unsized = _text(tester, 'unsized').style!;
+      expect(unsized.fontSize, closeTo(16 * 0.95 * 0.95, 1e-9));
+      expect(unsized.height, 1.25);
+      expect(unsized.letterSpacing, closeTo(-0.007 * 14.44, 1e-9));
+      expect(unsized.fontFamily, 'Menlo');
 
       final explicit = _text(tester, 'explicit').style!;
       expect(explicit.fontSize, closeTo(14 * 0.95 * 0.95, 1e-9));
@@ -85,20 +86,23 @@ void main() {
       expect(_text(tester, 'ghost').style!.fontSize, closeTo(14 * 0.95, 1e-9));
     });
 
-    testWidgets('kbd uses distinct unsized and explicit type factors', (
+    testWidgets('kbd applies distinct unsized and explicit token factors', (
       tester,
     ) async {
       await _pump(
         tester,
         const Column(
           children: [
-            FortalKbd.soft('ambient'),
+            FortalKbd.soft('unsized'),
             FortalKbd.soft('explicit', size: FortalTextSize.size2),
           ],
         ),
       );
 
-      expect(_text(tester, 'ambient').style?.fontSize, 15);
+      expect(
+        _text(tester, 'unsized').style?.fontSize,
+        closeTo(16 * 0.75, 1e-9),
+      );
       final explicit = _text(tester, 'explicit').style!;
       expect(explicit.fontSize, closeTo(11.2, 1e-9));
       expect(explicit.height, 1.7);
@@ -125,10 +129,10 @@ void main() {
         );
       }
 
-      // The inherited path keeps Flutter's absolute letter-spacing
-      // inheritance; there is no em intent left to rescale.
-      await _pump(tester, const FortalKbd.soft('inherited'));
-      expect(_text(tester, 'inherited').style?.letterSpacing, 2);
+      // The unsized path remains anchored to text3, whose letter spacing is
+      // zero, instead of inheriting the hostile run's 2px spacing.
+      await _pump(tester, const FortalKbd.soft('unsized'));
+      expect(_text(tester, 'unsized').style?.letterSpacing, 0);
     });
 
     testWidgets('code letter spacing adds the pinned -0.007em to the token', (
@@ -207,31 +211,235 @@ void main() {
   });
 
   group('regressions', () {
-    testWidgets('em geometry survives an ambient style with no fontSize', (
+    testWidgets(
+      'token-default typography isolates every hostile ambient field',
+      (tester) async {
+        final gray12 = await _resolveToken(tester, FortalTokens.gray12);
+        final accentA11 = await _resolveToken(tester, FortalTokens.accentA11);
+        final samples = Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const FortalText('body copy'),
+            const FortalHeading('section heading'),
+            const FortalCode.soft('soft code'),
+            const FortalCode.ghost('ghost code'),
+            const FortalKbd.soft('command key'),
+            const FortalLink('inert link'),
+            FortalLink('actionable link', onPressed: _noop),
+          ],
+        );
+        const labels = [
+          'body copy',
+          'section heading',
+          'soft code',
+          'ghost code',
+          'command key',
+          'inert link',
+          'actionable link',
+        ];
+
+        await _pump(tester, samples, ambient: const TextStyle());
+        final baselineSizes = {
+          for (final label in labels) label: tester.getSize(find.text(label)),
+        };
+
+        await _pump(
+          tester,
+          samples,
+          ambient: const TextStyle(
+            color: Colors.green,
+            backgroundColor: Colors.yellow,
+            fontFamily: 'Hostile family',
+            fontSize: 20,
+            fontWeight: FontWeight.w900,
+            fontStyle: FontStyle.italic,
+            height: 2,
+            letterSpacing: 2,
+            wordSpacing: 13,
+            decoration: TextDecoration.lineThrough,
+            shadows: [Shadow(color: Colors.red, blurRadius: 3)],
+          ),
+        );
+
+        for (final entry in baselineSizes.entries) {
+          expect(
+            tester.getSize(find.text(entry.key)),
+            entry.value,
+            reason: entry.key,
+          );
+        }
+
+        final expected = <String, (double, Color)>{
+          'body copy': (16, gray12),
+          'section heading': (24, gray12),
+          'soft code': (16 * 0.95 * 0.95, accentA11),
+          'ghost code': (16 * 0.95, Colors.green),
+          'command key': (16 * 0.75, gray12),
+          'inert link': (16, accentA11),
+          'actionable link': (16, accentA11),
+        };
+        for (final entry in expected.entries) {
+          final style = _renderedTextStyle(tester, entry.key);
+          expect(style.inherit, isFalse, reason: entry.key);
+          expect(
+            style.fontSize,
+            closeTo(entry.value.$1, 1e-9),
+            reason: entry.key,
+          );
+          expect(style.color, entry.value.$2, reason: entry.key);
+          expect(style.fontStyle, isNull, reason: entry.key);
+          expect(style.backgroundColor, isNull, reason: entry.key);
+          expect(style.shadows, isNull, reason: entry.key);
+          expect(
+            style.decoration,
+            anyOf(isNull, TextDecoration.none),
+            reason: entry.key,
+          );
+        }
+        expect(
+          _renderedTextStyle(tester, 'body copy').fontWeight,
+          FontWeight.w400,
+        );
+        expect(
+          _renderedTextStyle(tester, 'section heading').fontWeight,
+          FontWeight.w700,
+        );
+        expect(
+          _renderedTextStyle(tester, 'command key').fontWeight,
+          FontWeight.w400,
+        );
+        expect(_renderedTextStyle(tester, 'soft code').fontFamily, 'Menlo');
+        expect(_renderedTextStyle(tester, 'ghost code').fontFamily, 'Menlo');
+        for (final label in [
+          'body copy',
+          'section heading',
+          'command key',
+          'inert link',
+          'actionable link',
+        ]) {
+          expect(
+            _renderedTextStyle(tester, label).fontFamily,
+            isNull,
+            reason: label,
+          );
+        }
+      },
+    );
+
+    testWidgets(
+      'ghost preserves ambient Paint until a composed color overrides it',
+      (tester) async {
+        final ambientPaint = Paint()
+          ..color = Colors.green
+          ..strokeWidth = 2;
+        final composedPaint = Paint()
+          ..color = Colors.orange
+          ..strokeWidth = 3;
+
+        await _pump(
+          tester,
+          Builder(
+            builder: (context) => Column(
+              children: [
+                fortalCodeStyle(context, variant: FortalCodeVariant.ghost)(
+                  label: 'paint ghost',
+                ),
+                fortalCodeStyle(
+                  context,
+                  variant: FortalCodeVariant.ghost,
+                ).label(TextStyler().color(Colors.orange))(
+                  label: 'custom ghost',
+                ),
+                fortalCodeStyle(
+                  context,
+                  variant: FortalCodeVariant.ghost,
+                ).label(TextStyler().foreground(composedPaint))(
+                  label: 'custom paint ghost',
+                ),
+              ],
+            ),
+          ),
+          ambient: TextStyle(foreground: ambientPaint),
+        );
+
+        expect(tester.takeException(), isNull);
+        final inherited = _renderedTextStyle(tester, 'paint ghost');
+        expect(inherited.color, isNull);
+        expect(inherited.foreground, same(ambientPaint));
+
+        final customized = _renderedTextStyle(tester, 'custom ghost');
+        expect(customized.color, Colors.orange);
+        expect(customized.foreground, isNull);
+
+        final paintCustomized = _renderedTextStyle(
+          tester,
+          'custom paint ghost',
+        );
+        expect(paintCustomized.color, isNull);
+        expect(paintCustomized.foreground, same(composedPaint));
+      },
+    );
+
+    testWidgets('later merged ghost recipe replaces the ambient fallback', (
       tester,
     ) async {
+      final nearerPaint = Paint()..color = Colors.green;
+      late BadgeStyler outerRecipe;
+      late BadgeStyler nearerRecipe;
+
       await _pump(
         tester,
         Column(
           children: [
-            const FortalCode.soft('code'),
-            const FortalKbd.soft('kbd'),
-            const FortalLink('inert'),
-            FortalLink('actionable', onPressed: _noop),
+            DefaultTextStyle(
+              style: const TextStyle(color: Colors.red),
+              child: Builder(
+                builder: (context) {
+                  outerRecipe = fortalCodeStyle(
+                    context,
+                    variant: FortalCodeVariant.ghost,
+                  );
+                  return const SizedBox.shrink();
+                },
+              ),
+            ),
+            DefaultTextStyle(
+              style: TextStyle(foreground: nearerPaint),
+              child: Builder(
+                builder: (context) {
+                  nearerRecipe = fortalCodeStyle(
+                    context,
+                    variant: FortalCodeVariant.ghost,
+                  );
+                  return const SizedBox.shrink();
+                },
+              ),
+            ),
           ],
         ),
-        ambient: const TextStyle(color: Colors.purple),
       );
 
-      expect(tester.takeException(), isNull);
-      expect(
-        _text(tester, 'code').style?.fontSize,
-        closeTo(kDefaultFontSize * 0.95 * 0.95, 1e-9),
+      await _pump(
+        tester,
+        Column(
+          children: [
+            outerRecipe.merge(nearerRecipe)(label: 'paint later'),
+            nearerRecipe.merge(outerRecipe)(label: 'color later'),
+          ],
+        ),
       );
+
+      final paintLater = _renderedTextStyle(tester, 'paint later');
+      expect(paintLater.color, isNull);
+      expect(paintLater.foreground, same(nearerPaint));
+      expect(paintLater.debugLabel, isNull);
+
+      final colorLater = _renderedTextStyle(tester, 'color later');
       expect(
-        _text(tester, 'kbd').style?.fontSize,
-        closeTo(kDefaultFontSize * 0.75, 1e-9),
+        (colorLater.foreground?.color ?? colorLater.color)?.toARGB32(),
+        Colors.red.toARGB32(),
       );
+      expect(colorLater.debugLabel, isNull);
     });
 
     testWidgets('inert links never underline; upstream gates on anchors', (
@@ -253,6 +461,34 @@ void main() {
 
       expect(_underlined(tester, 'inert always'), isFalse);
       expect(_underlined(tester, 'inert high auto'), isFalse);
+    });
+
+    testWidgets('disabled links never underline even with a callback', (
+      tester,
+    ) async {
+      await _pump(
+        tester,
+        Column(
+          children: [
+            FortalLink(
+              'disabled always',
+              enabled: false,
+              underline: FortalLinkUnderline.always,
+              onPressed: _noop,
+            ),
+            FortalLink(
+              'disabled high auto',
+              enabled: false,
+              highContrast: true,
+              underline: FortalLinkUnderline.auto,
+              onPressed: _noop,
+            ),
+          ],
+        ),
+      );
+
+      expect(_underlined(tester, 'disabled always'), isFalse);
+      expect(_underlined(tester, 'disabled high auto'), isFalse);
     });
 
     testWidgets('actionable links underline per mode', (tester) async {
@@ -325,7 +561,14 @@ void main() {
                 // Upstream gates ghost's colour on an explicit accent, so an
                 // opt-out ghost inherits the ambient foreground.
                 expect(fill, isNull);
-                expect(fg, isNull);
+                expect(fg, Colors.purple);
+                expect(
+                  _renderedTextStyle(
+                    tester,
+                    '${variant.name}-$highContrast',
+                  ).color,
+                  Colors.purple,
+                );
             }
           }
         }
@@ -375,7 +618,7 @@ void main() {
           ],
         ),
       );
-      expect(_text(tester, 'plain ghost').style?.color, isNull);
+      expect(_renderedTextStyle(tester, 'plain ghost').color, Colors.purple);
       expect(_text(tester, 'accent ghost').style?.color, tokens.accentA11);
       expect(_text(tester, 'accent hc ghost').style?.color, tokens.accent12);
     });
@@ -923,15 +1166,18 @@ void main() {
     ) async {
       final accentA11 = await _resolveToken(tester, FortalTokens.accentA11);
       final accent12 = await _resolveToken(tester, FortalTokens.accent12);
+      final gray12 = await _resolveToken(tester, FortalTokens.gray12);
 
       await _pump(
         tester,
         const Column(
           children: [
-            FortalText('inherited text'),
+            FortalText('neutral text'),
+            FortalText('neutral hc text', highContrast: true),
             FortalText('accent text', accent: true),
             FortalText('accent hc text', accent: true, highContrast: true),
-            FortalHeading('inherited heading'),
+            FortalHeading('neutral heading'),
+            FortalHeading('neutral hc heading', highContrast: true),
             FortalHeading('accent heading', accent: true),
             FortalHeading(
               'accent hc heading',
@@ -943,10 +1189,12 @@ void main() {
       );
 
       // highContrast alone is inert: upstream gates the colour on the accent.
-      expect(_text(tester, 'inherited text').style?.color, isNull);
+      expect(_text(tester, 'neutral text').style?.color, gray12);
+      expect(_text(tester, 'neutral hc text').style?.color, gray12);
       expect(_text(tester, 'accent text').style?.color, accentA11);
       expect(_text(tester, 'accent hc text').style?.color, accent12);
-      expect(_text(tester, 'inherited heading').style?.color, isNull);
+      expect(_text(tester, 'neutral heading').style?.color, gray12);
+      expect(_text(tester, 'neutral hc heading').style?.color, gray12);
       expect(_text(tester, 'accent heading').style?.color, accentA11);
       expect(_text(tester, 'accent hc heading').style?.color, accent12);
     });
@@ -1084,6 +1332,9 @@ Future<void> _pump(
 
 Text _text(WidgetTester tester, String text) =>
     tester.widget<Text>(find.text(text));
+
+TextStyle _renderedTextStyle(WidgetTester tester, String text) =>
+    tester.renderObject<RenderParagraph>(find.text(text)).text.style!;
 
 BadgeSpec _surface(WidgetTester tester) {
   final widget = tester.widget<RemixBadge>(find.byType(RemixBadge));

--- a/packages/remix_fortal/test/fortal/fortal_control_matrix_test.dart
+++ b/packages/remix_fortal/test/fortal/fortal_control_matrix_test.dart
@@ -177,8 +177,8 @@ void main() {
       expect(dataList.size, FortalDataListSize.size2);
       expect(dataList.highContrast, isFalse);
 
-      // Typography sizes are nullable so an omitted size inherits the ambient
-      // style, exactly as an unsized Radix Text renders at 1em.
+      // Typography sizes stay nullable so recipes can distinguish an omitted
+      // size (the text3 token default) from an explicit token selection.
       const text = FortalText('Body');
       const heading = FortalHeading('Title');
       const code = FortalCode('code');

--- a/packages/remix_fortal/test/fortal/fortal_theme_resolution_test.dart
+++ b/packages/remix_fortal/test/fortal/fortal_theme_resolution_test.dart
@@ -81,16 +81,47 @@ void main() {
     }
   });
 
-  testWidgets('unsized typography measures 1em against the root, not the host', (
+  testWidgets('root scope keeps a courtesy DefaultTextStyle for bare Text', (
     tester,
   ) async {
-    // The host supplies a deliberately wrong ambient size; the scope must win.
     await tester.pumpWidget(
       DefaultTextStyle(
         style: const TextStyle(fontSize: 40),
         child: const FortalScope(
           child: Directionality(
             textDirection: TextDirection.ltr,
+            child: Text('courtesy'),
+          ),
+        ),
+      ),
+    );
+
+    // The scope still offers its root run to ordinary Flutter text, even
+    // though Fortal typography no longer depends on that courtesy fallback.
+    final style = tester
+        .renderObject<RenderParagraph>(find.text('courtesy'))
+        .text
+        .style!;
+    expect(tester.widget<Text>(find.text('courtesy')).style, isNull);
+    expect(style.fontSize, 16);
+    expect(style.height, 1.5);
+    expect(style.letterSpacing, 0);
+    expect(style.fontWeight, FontWeight.w400);
+  });
+
+  testWidgets('unsized typography anchors to tokens over a nearer text style', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const FortalScope(
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: DefaultTextStyle(
+            style: TextStyle(
+              fontSize: 20,
+              letterSpacing: 2,
+              color: Colors.green,
+            ),
             child: Column(
               children: [FortalText('body'), FortalCode.soft('code')],
             ),
@@ -99,7 +130,6 @@ void main() {
       ),
     );
 
-    expect(tester.widget<Text>(find.text('body')).style?.fontSize, isNull);
     expect(
       tester
           .renderObject<RenderParagraph>(find.text('body'))
@@ -108,45 +138,13 @@ void main() {
           ?.fontSize,
       16,
     );
-    // Code's em geometry is derived from the resolved ambient size.
     expect(
       tester.widget<Text>(find.text('code')).style?.fontSize,
       closeTo(16 * 0.95 * 0.95, 1e-9),
     );
   });
 
-  testWidgets('unsized typography inherits a nearer text style', (
-    tester,
-  ) async {
-    await tester.pumpWidget(
-      const FortalScope(
-        child: Directionality(
-          textDirection: TextDirection.ltr,
-          child: DefaultTextStyle(
-            style: TextStyle(fontSize: 20, letterSpacing: 2),
-            child: Column(
-              children: [FortalText('body'), FortalCode.soft('code')],
-            ),
-          ),
-        ),
-      ),
-    );
-
-    expect(
-      tester
-          .renderObject<RenderParagraph>(find.text('body'))
-          .text
-          .style
-          ?.fontSize,
-      20,
-    );
-    expect(
-      tester.widget<Text>(find.text('code')).style?.fontSize,
-      closeTo(20 * 0.95 * 0.95, 1e-9),
-    );
-  });
-
-  testWidgets('a nested scope preserves the nearest text style', (
+  testWidgets('a nested scope reanchors unsized typography to its tokens', (
     tester,
   ) async {
     // Accent and scaling are the two reasons a real subtree re-scopes; neither
@@ -178,14 +176,17 @@ void main() {
         .renderObject<RenderParagraph>(find.text('body'))
         .text
         .style!;
-    expect(body.fontSize, 20);
-    expect(body.fontWeight, FontWeight.w700);
-    expect(body.letterSpacing, 2);
-    expect(body.color, const Color(0xFF00FF00));
-    // Code keeps deriving its em geometry from that preserved ambient size.
+    expect(body.fontSize, 17.6);
+    expect(body.fontWeight, FontWeight.w400);
+    expect(body.letterSpacing, 0);
+    expect(
+      body.color,
+      MixScope.tokenOf(FortalTokens.gray12, tester.element(find.text('body'))),
+    );
+    // Code's geometry follows the nested scope's scaled text3 token.
     expect(
       tester.widget<Text>(find.text('code')).style?.fontSize,
-      closeTo(20 * 0.95 * 0.95, 1e-9),
+      closeTo(17.6 * 0.95 * 0.95, 1e-9),
     );
   });
 

--- a/skills/using-remix/SKILL.md
+++ b/skills/using-remix/SKILL.md
@@ -62,11 +62,15 @@ Also import `package:remix/remix.dart` when the file uses `Remix*` widgets,
 
 Every subtree that renders a `Fortal*` widget, a `fortal*Style()` recipe, or a
 `FortalTokens` value needs `FortalScope`. The outermost scope also establishes
-the Radix theme root's default text run — `text3` at `gray-12` — which is what
-an unsized `FortalText`, `FortalCode`, `FortalKbd`, or `FortalLink` measures
-`1em` against.
+a courtesy `DefaultTextStyle` for bare Flutter `Text`: the Radix theme root run
+of `text3` at `gray-12`, regular weight, and no pinned font family. This is a
+fallback for ordinary Flutter text, analogous to Material's `bodyMedium`; it
+does not supply the text run for Fortal typography, which resolves its own
+token defaults. Transparent, non-accent `FortalCode.ghost` deliberately keeps
+only the ambient foreground so inline code can blend with surrounding text.
 
-Placement depends on the host, and getting it wrong costs that text run:
+Placement depends on the host, and getting it wrong costs that courtesy
+bare-`Text` fallback:
 
 **`WidgetsApp` or a custom host — put the scope above the app.**
 
@@ -96,18 +100,20 @@ MaterialApp(
 
 Those apps hand `WidgetsApp` their own root `DefaultTextStyle`, which is
 installed *below* anything wrapping the app — so a scope placed above
-`MaterialApp` still supplies tokens but loses the root text run. `builder` wraps
-the whole `Navigator`, so this placement still reaches pushed routes and raw
-`Overlay` entries.
+`MaterialApp` still supplies tokens but loses the courtesy text fallback.
+`builder` wraps the whole `Navigator`, so bare `Text` in pushed routes and raw
+`Overlay` entries receives that fallback.
 
-Symptom of the wrong placement under `MaterialApp`: text in a hand-rolled
-`OverlayEntry` renders red, monospace, with a yellow double underline — that is
-Flutter's "put your text in a Material" fallback, not a Remix bug.
+Symptom of the wrong placement under `MaterialApp`: **bare Flutter `Text`** in
+a hand-rolled `OverlayEntry` renders red, monospace, with a yellow double
+underline — that is Flutter's "put your text in a Material" fallback, not a
+Remix bug. Fortal typography pins its own token run; non-accent ghost Code only
+retains the ambient foreground.
 
-A nested `FortalScope` re-scopes tokens only; it inherits the closest text style
-rather than restating the root run, so re-scoping a subtree for a different
-accent or scaling leaves the text running through it at its current size and
-color.
+A nested `FortalScope` re-scopes tokens only; it does not restate the courtesy
+bare-`Text` run. Re-scoping a subtree for a different accent or scaling leaves
+the surrounding Flutter text inheritance unchanged while Fortal typography
+resolves against the nested tokens.
 
 Ordinary `Remix*` widgets with fully custom styles do not need `FortalScope`.
 

--- a/skills/using-remix/references/fortal.md
+++ b/skills/using-remix/references/fortal.md
@@ -156,8 +156,15 @@ FortalLink('Read the docs', onPressed: openDocs)
 Rules that matter when writing code:
 
 - Omitting `size` on `FortalText`, `FortalCode`, `FortalKbd`, or `FortalLink`
-  inherits the ambient `DefaultTextStyle`, matching an unsized Radix `Text` at
-  `1em`. `FortalHeading` defaults to `size6` and `bold`.
+  pins the `text3` token metrics. `FortalText` also pins regular weight and
+  neutral `gray-12`; `FortalHeading` pins neutral `gray-12` and defaults to
+  `size6` and `bold`. Fortal typography never derives its token run from the
+  ambient `DefaultTextStyle`; transparent, non-accent `FortalCode.ghost`
+  retains only that style's foreground.
+- This deliberately differs from Radix CSS, where an unsized `Text` is `1em`.
+  Pass an explicit `size:` to select another token size, such as
+  `FortalText('Body copy', size: .size3)` or
+  `FortalHeading('Overview', size: .size6)`.
 - `headingLevel` drives accessibility only; it never changes the visual `size`.
   Page titles are level 1, sections and cards below them level 2.
 - Colour is opt-in: `accent: true` gives `accent-a11` and adding
@@ -208,21 +215,22 @@ page background behind its child.
 
 ### Scope placement
 
-The **outermost** `FortalScope` also establishes the Radix theme root's default
-text run — `text3` (16px, 1.5 line height, 0 letter spacing) at `gray-12`,
-regular weight, with no pinned font family. That is what an unsized
-`FortalText`, `FortalCode`, `FortalKbd`, or `FortalLink` measures `1em` against
-when there is no closer `DefaultTextStyle`, so placement matters:
+The **outermost** `FortalScope` establishes a courtesy `DefaultTextStyle` for
+bare Flutter `Text`: the Radix theme root run — `text3` (16px, 1.5 line height,
+0 letter spacing) at `gray-12`, regular weight, and no pinned font family.
+This is analogous to Material's `bodyMedium`; it is not the source of a Fortal
+typography run, which is always pinned from Fortal tokens. Placement therefore
+matters for bare `Text`:
 
 | Host | Put the scope |
 | --- | --- |
 | `WidgetsApp`, router, or a custom host | Above the app |
 | `MaterialApp`, `CupertinoApp` | In `builder:` |
 
-A **nested** scope re-scopes tokens only. It inherits the closest text style
-instead of restating the root run, so wrapping a subtree in
+A **nested** scope re-scopes tokens only. It does not restate the courtesy
+bare-`Text` run, so wrapping a subtree in
 `FortalScope(accent: .red, hasBackground: false, ...)` re-themes its tokens
-without resizing or recoloring the text already running through it.
+without changing the surrounding Flutter text inheritance.
 
 ```dart
 // MaterialApp / CupertinoApp
@@ -234,18 +242,21 @@ MaterialApp(
 
 Those apps pass `WidgetsApp` their own root `DefaultTextStyle`, which lands
 below anything wrapping the app. A scope placed above `MaterialApp` still
-supplies tokens, but its root text run is overridden. `builder:` sits below that
-style and above the `Navigator`, so pushed routes and raw `Overlay` entries
-receive the Fortal fallback.
+supplies tokens, but its courtesy bare-`Text` fallback is overridden.
+`builder:` sits below that style and above the `Navigator`, so pushed routes
+and raw `Overlay` entries receive the Fortal fallback.
 
-Normal Flutter inheritance still applies below the scope. A nearer
-`DefaultTextStyle`, including one from `Material` or `Scaffold`, wins. Unsized
-Fortal typography deliberately inherits it; use `size: FortalTextSize.size3`
-when a component needs the exact 16px Radix root size inside such a surface.
+Normal Flutter inheritance still applies to bare `Text` below the scope. A
+nearer `DefaultTextStyle`, including one from `Material` or `Scaffold`, wins
+for that bare text. Fortal typography does not inherit that run: its unsized
+components use their documented token defaults, and `size:` selects another
+token size. Transparent, non-accent `FortalCode.ghost` deliberately keeps only
+the ambient foreground so it can blend into surrounding text.
 
-If text inside a hand-rolled `OverlayEntry` renders red and monospace with a
-yellow double underline, the scope is in the wrong place: that is Flutter's
-"put your text in a Material" fallback style.
+If **bare Flutter `Text`** inside a hand-rolled `OverlayEntry` renders red and
+monospace with a yellow double underline, the scope is in the wrong place:
+that is Flutter's "put your text in a Material" fallback style. Fortal
+typography children pin their own token run.
 
 `FortalThemeConfig` is the immutable config object form:
 

--- a/skills/using-remix/references/overlays.md
+++ b/skills/using-remix/references/overlays.md
@@ -88,7 +88,9 @@ variant.
 Spec timing defaults: `waitDuration` 300ms (hover delay), `showDuration`
 1500ms (touch long-press), `dismissDuration` 100ms (hover-exit grace).
 The tooltip styler's `label(...)` spec is applied through `DefaultTextStyle`,
-so normal `Text` descendants inside an arbitrary `tooltipChild` inherit it.
+so bare `Text` descendants inside an arbitrary `tooltipChild` inherit it.
+Fortal typography children pin their own token run instead; transparent,
+non-accent `FortalCode.ghost` retains only the ambient foreground.
 
 Fortal preset: `FortalTooltip` — same params, no variant/size.
 

--- a/skills/using-remix/references/styling.md
+++ b/skills/using-remix/references/styling.md
@@ -171,17 +171,18 @@ class _MyAppState extends State<MyApp> {
 
   @override
   Widget build(BuildContext context) {
-    return FortalScope(
-      accent: FortalAccentColor.indigo,
-      brightness: _brightness,
-      child: MaterialApp(
-        theme: ThemeData(brightness: _brightness),
-        home: Scaffold(
-          body: FortalSwitch(
-            selected: _brightness == Brightness.dark,
-            onChanged: (dark) => setState(() =>
-                _brightness = dark ? Brightness.dark : Brightness.light),
-          ),
+    return MaterialApp(
+      theme: ThemeData(brightness: _brightness),
+      builder: (context, child) => FortalScope(
+        accent: FortalAccentColor.indigo,
+        brightness: _brightness,
+        child: child!,
+      ),
+      home: Scaffold(
+        body: FortalSwitch(
+          selected: _brightness == Brightness.dark,
+          onChanged: (dark) => setState(() =>
+              _brightness = dark ? Brightness.dark : Brightness.light),
         ),
       ),
     );


### PR DESCRIPTION
## Description

Unsized Fortal typography previously inherited the nearest Flutter
`DefaultTextStyle`. Material surfaces could therefore replace the intended
Fortal run with host metrics and colors, which made the same component render
differently depending on its ancestor widgets and required the dashboard's
`DashboardSurfaceTone` workaround.

This change adopts token-backed defaults:

- unsized Text, Code, Kbd, and Link anchor their metrics to `text3`;
- neutral Text and Heading use `gray12`, while Text defaults to the regular
  weight token;
- Code and Kbd retain their Radix size factors, now computed from tokens;
- every Fortal typography recipe uses a non-inheriting Flutter `TextStyle`, so
  host typography fields cannot leak into its resolved run;
- transparent, non-accent ghost Code keeps only the ambient foreground as a
  post-composition fallback, allowing an explicit recipe color or foreground
  to override it safely and allowing a later merged ghost recipe to replace an
  earlier ambient fallback;
- disabled Links no longer enter the actionable underline recipe when they
  retain a callback;
- `FortalScope` keeps its root `DefaultTextStyle` solely as a courtesy fallback
  for bare Flutter `Text`;
- the dashboard workaround is removed and gallery-owned bare labels use
  Fortal typography.

The rebased Link changes build on the `RemixLink`/`LinkStyler` architecture
landed in #151. Documentation, the public skill guidance, parity exceptions,
and coverage evidence now describe the same token-default contract.

Users relying on a surrounding `DefaultTextStyle` to resize or reweight an
unsized Fortal component must pass the desired Fortal `size` or `weight`
explicitly.

## Related Issues

Supersedes the dashboard text-run workaround introduced in #136. Integrates
with the `RemixLink` implementation from #151; it does not close either PR.

---

## Checklist

- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors.
- [x] I have updated or added relevant documentation (doc comments with `///`).
- [x] I am prepared to follow up on review comments in a timely manner.

## Breaking Change

Does this PR require users of the package to manually update their code?

- [x] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

## Validation

- `fvm dart run build_runner build --delete-conflicting-outputs`
- formatting and `git diff --check`
- `fvm flutter analyze --fatal-infos` in `packages/remix_fortal`
- `fvm flutter analyze --fatal-infos` in `apps/dashboard`
- `fvm dart run tool/fortal_parity/check.dart`
- `fvm dart run tool/validate_docs.dart`
- root toolchain, hosted-Mix, Material-independence, and generated-source checks
- `fvm flutter test` in `packages/remix_fortal` — 381/381
- `fvm flutter test` in `apps/dashboard` — 48/48
- macOS dashboard Typography gallery inspected in dark/light appearances and
  with the gray theme changed; the Link gallery was rechecked after rebasing
  onto #151.
