### PR TITLE
ci: release remix and remix_fortal in lockstep on one version

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -74,7 +74,12 @@ jobs:
           # meaningful. melos commits by default, which would leave a clean tree
           # and make a successful run look like "nothing to version". It also
           # implies --no-git-tag-version.
-          melos version --no-git-commit-version --yes $overrides
+          # `< /dev/null` because manual `-V` versioning asks whether you want
+          # an extra changelog entry. melos only skips that prompt when
+          # `stdin.hasTerminal` is false, and `--yes` does not cover it, so the
+          # redirect is what guarantees the default instead of a runner that
+          # happens to have no tty.
+          melos version --no-git-commit-version --yes $overrides < /dev/null
 
           # The pair must land aligned; verify rather than trust the inputs.
           dart run tool/check_version_alignment.dart

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,8 +1,13 @@
 name: Prepare Version Bump
 
-# Pushes a branch that bumps versions and changelogs from conventional
-# commits. It never tags and never publishes: `publish.yml` fires on a tag push,
-# so the tag is pushed by hand after this PR is reviewed and merged.
+# Pushes a branch that sets both published packages to one explicit version and
+# writes their changelogs from conventional commits. It never tags and never
+# publishes: `publish.yml` fires on a tag push, so the tag is pushed by hand
+# after this PR is reviewed and merged.
+#
+# The version is a single input rather than one per package. remix and
+# remix_fortal ship as a pair and must carry the identical version, so there is
+# no per-package value to disagree about.
 #
 # It pushes a branch and prints its compare link rather than opening the pull
 # request itself. Opening one from a workflow needs "Allow GitHub Actions to
@@ -12,18 +17,9 @@ name: Prepare Version Bump
 on:
   workflow_dispatch:
     inputs:
-      remix_version:
-        description: "Exact version for remix (e.g. 1.0.0-beta.5). Cannot be combined with graduate."
-        required: false
-        default: ""
-      remix_fortal_version:
-        description: "Exact version for remix_fortal (e.g. 0.1.0-beta.4). Cannot be combined with graduate."
-        required: false
-        default: ""
-      graduate:
-        description: "Graduate the prerelease line to stable instead of bumping beta"
-        type: boolean
-        default: false
+      version:
+        description: "Exact version for BOTH remix and remix_fortal (e.g. 1.0.0-beta.5)."
+        required: true
 
 permissions:
   contents: write
@@ -58,20 +54,16 @@ jobs:
         run: |
           set -euo pipefail
 
-          overrides=""
-          if [ -n "${{ inputs.remix_version }}" ]; then
-            overrides="$overrides -V remix:${{ inputs.remix_version }}"
-          fi
-          if [ -n "${{ inputs.remix_fortal_version }}" ]; then
-            overrides="$overrides -V remix_fortal:${{ inputs.remix_fortal_version }}"
-          fi
+          version='${{ inputs.version }}'
 
-          # melos rejects manual versions combined with either mode:
-          # "Cannot use manualVersions with asPrerelease or asStableRelease."
-          if [ -n "$overrides" ] && [ "${{ inputs.graduate }}" = "true" ]; then
-            echo "::error::Exact versions cannot be combined with graduate. Choose one."
-            exit 1
-          fi
+          # One input applied to both packages, rather than a version per
+          # package that a human has to keep in step. remix and remix_fortal
+          # release in lockstep (tool/check_version_alignment.dart enforces it
+          # in CI), and melos has no lockstep mode of its own — left to derive
+          # versions from commits it would bump each package independently and
+          # split the pair apart. Passing an explicit `-V` for both is what
+          # keeps them identical.
+          overrides="-V remix:$version -V remix_fortal:$version"
 
           dart pub global activate melos
           melos bootstrap
@@ -82,13 +74,10 @@ jobs:
           # meaningful. melos commits by default, which would leave a clean tree
           # and make a successful run look like "nothing to version". It also
           # implies --no-git-tag-version.
-          if [ -n "$overrides" ]; then
-            melos version --no-git-commit-version --yes $overrides
-          elif [ "${{ inputs.graduate }}" = "true" ]; then
-            melos version --graduate --no-git-commit-version --yes
-          else
-            melos version --prerelease --preid beta --no-git-commit-version --yes
-          fi
+          melos version --no-git-commit-version --yes $overrides
+
+          # The pair must land aligned; verify rather than trust the inputs.
+          dart run tool/check_version_alignment.dart
 
           if git diff --quiet && git diff --cached --quiet; then
             echo "No packages required versioning."
@@ -110,8 +99,10 @@ jobs:
             echo
             echo "[Open the pull request]($url)"
             echo
+            echo "Both packages are on \`${{ inputs.version }}\`."
+            echo
             echo "After merging, push the release tags in order:"
-            echo '1. `remix-v<version>` — wait until pub.dev serves it'
-            echo '2. `remix_fortal-v<version>`'
+            echo '1. `remix-v${{ inputs.version }}` — wait until pub.dev serves it'
+            echo '2. `remix_fortal-v${{ inputs.version }}`'
           } >> "$GITHUB_STEP_SUMMARY"
           echo "Open the pull request: $url"

--- a/apps/dashboard/pubspec.yaml
+++ b/apps/dashboard/pubspec.yaml
@@ -14,8 +14,8 @@ dependencies:
   # Workspace resolution uses the local packages during development; these
   # hosted constraints keep the app manifest deployable outside the workspace.
   mix_chart: ^0.0.1-beta.1
-  remix: ^1.0.0-beta.2
-  remix_fortal: ^0.1.0-beta.1
+  remix: ^1.0.0-beta.5
+  remix_fortal: ^1.0.0-beta.5
 
 dev_dependencies:
   flutter_test:

--- a/apps/demo/pubspec.yaml
+++ b/apps/demo/pubspec.yaml
@@ -20,8 +20,8 @@ dependencies:
   widgetbook: ^3.25.0
   # Workspace resolution uses the local packages during development; these
   # hosted constraints keep the app manifest deployable outside the workspace.
-  remix: ^1.0.0-beta.2
-  remix_fortal: ^0.1.0-beta.1
+  remix: ^1.0.0-beta.5
+  remix_fortal: ^1.0.0-beta.5
 
 dev_dependencies:
   flutter_test:

--- a/apps/playground/pubspec.yaml
+++ b/apps/playground/pubspec.yaml
@@ -14,8 +14,8 @@ dependencies:
   cupertino_icons: ^1.0.8
   # Workspace resolution uses the local packages during development; these
   # hosted constraints keep the app manifest deployable outside the workspace.
-  remix: ^1.0.0-beta.2
-  remix_fortal: ^0.1.0-beta.1
+  remix: ^1.0.0-beta.5
+  remix_fortal: ^1.0.0-beta.5
 
 dev_dependencies:
   flutter_test:

--- a/packages/remix/CHANGELOG.md
+++ b/packages/remix/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.0.0-beta.5
+
+> Note: This release has breaking changes.
+
+ - **FEAT**(remix): add styler field metadata, raise Mix floor to 2.2.0-beta.5 (#158).
+ - **BREAKING** **REFACTOR**(remix): make interactive components visual-only over naked_ui (#157).
+ - **BREAKING** **REFACTOR**(remix): generate callable component stylers (#152).
+ - **BREAKING** **FEAT**(remix): add RemixLink and rebuild FortalLink on it (#151).
+
 ## 1.0.0-beta.4
 
 - **BREAKING**: `RemixIconButton.semanticLabel` is required and must be

--- a/packages/remix/pubspec.yaml
+++ b/packages/remix/pubspec.yaml
@@ -12,7 +12,7 @@ topics:
   - styling
   - mix
 
-version: 1.0.0-beta.4
+version: 1.0.0-beta.5
 
 # Consumer floor, matching `mix` and `naked_ui`. Intentionally lower than the
 # workspace's own toolchain floor: dev tooling needs a newer SDK than the

--- a/packages/remix_fortal/CHANGELOG.md
+++ b/packages/remix_fortal/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 1.0.0-beta.5
+
+> Note: This release has breaking changes.
+
+ - **REFACTOR**(fortal): consolidate base button state styling.
+ - **FIX**(ci): make the version workflow able to complete (#149).
+ - **FEAT**(remix): add styler field metadata, raise Mix floor to 2.2.0-beta.5 (#158).
+ - **FEAT**(fortal): add opt-in icon index and document soft AA (#155).
+ - **DOCS**(fortal): reference catalog, generated from the parity manifest (#154).
+ - **BREAKING** **REFACTOR**(remix): make interactive components visual-only over naked_ui (#157).
+ - **BREAKING** **REFACTOR**(fortal): default unsized typography from tokens, not ambient text (#153).
+ - **BREAKING** **REFACTOR**(remix): generate callable component stylers (#152).
+ - **BREAKING** **FEAT**(remix): add RemixLink and rebuild FortalLink on it (#151).
+
 ## 0.1.0-beta.3
 
 - **FEAT**: Regenerate the Fortal Select wrappers for the new trigger indicator

--- a/packages/remix_fortal/pubspec.yaml
+++ b/packages/remix_fortal/pubspec.yaml
@@ -15,7 +15,7 @@ topics:
 # Pre-release because every dependency below is itself a pre-release; pub warns
 # when a stable package is built on beta foundations. Graduate to 0.1.0 when
 # remix reaches 1.0.0 stable.
-version: 0.1.0-beta.3
+version: 1.0.0-beta.5
 
 # Consumer floor, matching `remix` and `mix`. See packages/remix/pubspec.yaml.
 environment:
@@ -37,7 +37,7 @@ dependencies:
   # package. `tool/fortal_parity/check.dart` (_checkRemixHostedPin) fails if the
   # two ever fall out of sync. `melos version` rewrites this line when `remix`
   # bumps, because remix_fortal depends on it.
-  remix: ^1.0.0-beta.4
+  remix: ^1.0.0-beta.5
   mix: ^2.2.0-beta.5
   mix_annotations: ^2.2.0-beta.1
   mix_chart: ^0.0.1-beta.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -103,6 +103,10 @@ melos:
       packageFilters:
         dirExists: test
 
+    version:align:check:
+      run: dart run tool/check_version_alignment.dart
+      description: Verify remix and remix_fortal carry the identical version
+
     mix:consumer:check:
       run: dart run tool/check_consumer_mix.dart
       description: Verify consumer tests resolve the declared hosted Mix release
@@ -131,6 +135,7 @@ melos:
     ci:
       steps:
         - toolchain:check
+        - version:align:check
         - mix:consumer:check
         - material:check
         - generate:check

--- a/tool/check_version_alignment.dart
+++ b/tool/check_version_alignment.dart
@@ -1,0 +1,71 @@
+import 'dart:io';
+
+import 'package:pub_semver/pub_semver.dart';
+import 'package:yaml/yaml.dart';
+
+/// Published packages that must always carry the identical version.
+///
+/// `remix_fortal` is a theme layer over `remix` and the two are only ever
+/// tested against each other, so a released pair is the unit consumers
+/// install. Sharing one version makes that pairing legible from the version
+/// alone instead of requiring a changelog lookup.
+///
+/// Melos has no lockstep mode: it versions each package from its own commits,
+/// and the propagation is one-way (a `remix` bump reaches `remix_fortal` as a
+/// dependent, never the reverse). So a `remix_fortal`-only release would drift
+/// the pair apart with nothing to stop it. This checker is that stop.
+const _lockstepPackages = ['remix', 'remix_fortal'];
+
+void main() {
+  final workspaceRoot = Directory.current.absolute;
+  final versions = <String, Version>{};
+  final failures = <String>[];
+
+  for (final package in _lockstepPackages) {
+    final pubspecFile = File(
+      '${workspaceRoot.path}/packages/$package/pubspec.yaml',
+    );
+    if (!pubspecFile.existsSync()) {
+      failures.add('packages/$package/pubspec.yaml is missing');
+      continue;
+    }
+
+    final pubspec = loadYaml(pubspecFile.readAsStringSync()) as YamlMap;
+    final declared = pubspec['version'];
+    if (declared is! String) {
+      failures.add('$package does not declare a version');
+      continue;
+    }
+
+    try {
+      versions[package] = Version.parse(declared);
+    } on FormatException {
+      failures.add('$package declares an unparseable version "$declared"');
+    }
+  }
+
+  if (versions.length == _lockstepPackages.length) {
+    final distinct = versions.values.toSet();
+    if (distinct.length > 1) {
+      failures.add(
+        'lockstep packages disagree: '
+        '${versions.entries.map((e) => '${e.key} ${e.value}').join(', ')}. '
+        'Release them on one version — pass the same value to both '
+        '`remix_version` and `remix_fortal_version` in the version workflow.',
+      );
+    } else {
+      stdout.writeln(
+        'Lockstep versions aligned: '
+        '${_lockstepPackages.join(', ')} all on ${distinct.single}.',
+      );
+    }
+  }
+
+  if (failures.isEmpty) return;
+
+  stderr.writeln('Version alignment validation failed:');
+  for (final failure in failures) {
+    stderr.writeln('- $failure');
+  }
+  exitCode = 1;
+}


### PR DESCRIPTION
Makes an identical version across `remix` and `remix_fortal` a hard,
enforced requirement, and aligns the current pair on `1.0.0-beta.5`.

## Why this needs enforcement

Melos has no lockstep mode. It versions each package from its own commits
and propagates one way only — a `remix` bump reaches `remix_fortal` as a
dependent, never the reverse — so a fortal-only release would split the
pair apart with nothing to catch it. Running the existing auto-derivation
on `main` produces exactly that drift:

```
remix          1.0.0-beta.4  ->  1.0.0-beta.5
remix_fortal   0.1.0-beta.3  ->  0.1.0-beta.4
```

## Changes

- **`tool/check_version_alignment.dart`** — fails if the two versions differ,
  in the style of the existing `check_consumer_mix.dart` / `check_toolchain.dart`.
  Wired into `melos run ci` as `version:align:check`.
- **`version.yml` takes one `version` input** applied to both packages via `-V`,
  replacing the two per-package inputs. The workflow can no longer express two
  different versions, and it re-runs the checker after melos to verify.
- **Both packages aligned on `1.0.0-beta.5`** (`remix_fortal` jumps from
  `0.1.0-beta.3`), with changelogs and fortal's `remix: ^1.0.0-beta.5`
  constraint generated by the same command the workflow now runs.

The alignment ships with the checker rather than after it: the check fails
against the pre-alignment versions, so splitting them would leave `main` red
in between.

## Note on a prompt that would have hit the workflow

Making `-V` unconditional puts the workflow on melos's manual-versioning path,
which asks whether you want an extra changelog entry. `--yes` does not cover
that prompt — melos only skips it when `stdin.hasTerminal` is false
(`utils.dart:192-199`). Actions runners have no tty so it would have defaulted,
but the invocation now redirects `< /dev/null` so it does not depend on that.

## Verification

- `melos run ci` — 8/8 steps, exit 0. `remix` 2674, `remix_fortal` 387,
  `dashboard` 53, `demo` 30.
- `dart pub publish --dry-run` — 0 warnings for both packages.

## Follow-up, not done here

`release:version` and `release:graduate` in `pubspec.yaml` still auto-derive
per package, which is the drift this PR outlaws. Nothing references them —
`version.yml` calls `melos version` directly. Suggest deleting both so the
workflow is the only release path, but left alone pending a call.