### PR TITLE
feat(dashboard): publish the showcase on GitHub Pages

### DIFF
--- a/.github/workflows/deploy_web.yml
+++ b/.github/workflows/deploy_web.yml
@@ -1,4 +1,4 @@
-name: Deploy Remix showcases
+name: Deploy web showcases
 
 on:
   push:

--- a/.github/workflows/deploy_widgetbook.yml
+++ b/.github/workflows/deploy_widgetbook.yml
@@ -1,7 +1,9 @@
-name: Deploy Widgetbook
+name: Deploy Remix showcases
 
 on:
   push:
+    branches: ["main"]
+  pull_request:
     branches: ["main"]
   workflow_dispatch:
 
@@ -11,9 +13,9 @@ permissions:
   pages: write
   id-token: write
 
-# Allow only one concurrent deployment
+# Allow only one concurrent Pages run per branch or pull request
 concurrency:
-  group: "pages"
+  group: "pages-${{ github.ref }}"
   cancel-in-progress: false
 
 jobs:
@@ -31,7 +33,7 @@ jobs:
           cache: true
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v5
 
       - name: Install Melos
         run: dart pub global activate melos
@@ -39,16 +41,27 @@ jobs:
       - name: Bootstrap workspace
         run: melos bootstrap
 
-      - name: Build web
+      - name: Build component catalog
         working-directory: apps/demo
         run: flutter build web --release --base-href /remix/
 
+      - name: Build dashboard
+        working-directory: apps/dashboard
+        run: flutter build web --release --base-href /remix/dashboard/
+
+      - name: Assemble Pages site
+        run: |
+          mkdir -p build/pages/dashboard
+          cp -R apps/demo/build/web/. build/pages/
+          cp -R apps/dashboard/build/web/. build/pages/dashboard/
+
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
-          path: apps/demo/build/web
+          path: build/pages
 
   deploy:
+    if: github.event_name != 'pull_request'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/README.md
+++ b/README.md
@@ -314,6 +314,11 @@ Remix is ideal for:
 
 ## Examples
 
+Live examples:
+
+- [Fortal dashboard](https://conceptadev.github.io/remix/dashboard/) — a polished product dashboard with responsive layouts, charts, data, and live theme controls.
+- [Component catalog](https://conceptadev.github.io/remix/) — the Widgetbook catalog for reviewing Remix and Fortal components, variants, and states.
+
 Check out `apps/dashboard`, `apps/demo`, and the per-package examples in
 `packages/remix/example` and `packages/remix_fortal/example` for complete working examples demonstrating:
 - Component usage patterns

--- a/apps/dashboard/README.md
+++ b/apps/dashboard/README.md
@@ -3,6 +3,10 @@
 A polished product dashboard demonstrating Remix's Fortal theme, components,
 and chart recipes built on `mix_chart`.
 
+## Live demo
+
+[Open the Fortal dashboard](https://conceptadev.github.io/remix/dashboard/).
+
 ## Preview
 
 ### Desktop

--- a/apps/demo/README.md
+++ b/apps/demo/README.md
@@ -3,6 +3,10 @@
 This package is the Widgetbook catalog for reviewing Remix components, Fortal
 presets, variants, states, and preview scenarios.
 
+## Live catalog
+
+[Open the Remix component catalog](https://conceptadev.github.io/remix/).
+
 From the repository root:
 
 ```sh

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -261,6 +261,11 @@ Remix is ideal for:
 
 ## Examples
 
+Live examples:
+
+- [Fortal dashboard](https://conceptadev.github.io/remix/dashboard/) — a polished product dashboard with responsive layouts, charts, data, and live theme controls.
+- [Component catalog](https://conceptadev.github.io/remix/) — the Widgetbook catalog for reviewing Remix and Fortal components, variants, and states.
+
 Check out `apps/dashboard`, `apps/demo`, and the per-package examples in
 `packages/remix/example` and `packages/remix_fortal/example` for complete working examples demonstrating:
 - Component usage patterns


### PR DESCRIPTION
## Description

- Extend the existing GitHub Pages workflow to publish one combined artifact instead of introducing a competing deployment.
- Preserve the Widgetbook catalog at `https://conceptadev.github.io/remix/` and add the Fortal dashboard at `https://conceptadev.github.io/remix/dashboard/`.
- Build Pages artifacts on pull requests while skipping the production deployment job until merge or manual dispatch.
- Update the repository, docs home, and app READMEs with the live showcase links.

## URL layout

| Surface | URL |
| --- | --- |
| Widgetbook catalog | `https://conceptadev.github.io/remix/` |
| Fortal dashboard | `https://conceptadev.github.io/remix/dashboard/` |

## Validation

- `fvm dart run melos run ci` — passed, including 30 demo, 53 dashboard, 387 Fortal, and 2,674 Remix tests
- `fvm flutter build web --release --base-href /remix/` in `apps/demo` — passed
- `fvm flutter build web --release --base-href /remix/dashboard/` in `apps/dashboard` — passed
- Combined Pages artifact — 86 MB with the expected `/remix/` and `/remix/dashboard/` base tags
- Local Pages-shaped HTTP smoke test — 200 responses for both entry points, dashboard JavaScript, and Fortal font assets
- Workflow YAML parsing and `act -l -W .github/workflows/deploy_web.yml` — passed

The pull-request workflow builds and uploads the candidate artifact, but its deployment job is intentionally skipped. Merging to `main` publishes the dashboard through the existing `github-pages` environment.

## Related Issues

None.

---

## Checklist

- [x] The changed deployment behavior is covered by production builds and artifact smoke tests.
- [x] I have updated the relevant repository and app documentation.
- [x] I am prepared to follow up on review comments in a timely manner.

## Breaking Change

Does this PR require users of the package to manually update their code?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.
