### PR TITLE
fix: correct dashboard showcase and checkbox indicator regressions

### DIFF
--- a/apps/dashboard/lib/pages/gallery/gallery_display_page.dart
+++ b/apps/dashboard/lib/pages/gallery/gallery_display_page.dart
@@ -29,7 +29,8 @@ class _GalleryDisplayPageState extends State<GalleryDisplayPage> {
           child: GalleryMatrix(
             rows: FortalAvatarVariant.values.map(enumLabel).toList(),
             columns: FortalAvatarSize.values.map(enumLabel).toList(),
-            cellWidth: 120,
+            // Size9 is 160px; preserve its 20px cell padding and divider.
+            cellWidth: 181,
             cellBuilder: (_, row, column) => FortalAvatar(
               variant: FortalAvatarVariant.values[row],
               size: FortalAvatarSize.values[column],

--- a/apps/dashboard/lib/widgets/theme_panel.dart
+++ b/apps/dashboard/lib/widgets/theme_panel.dart
@@ -196,6 +196,8 @@ class _AccentSwatch extends StatelessWidget {
             container: FlexBoxStyler()
                 .size(30, 30)
                 .alignment(.center)
+                .mainAxisAlignment(.center)
+                .crossAxisAlignment(.center)
                 .borderRadius(.all(const Radius.circular(15))),
             icon: .size(15),
           )

--- a/apps/dashboard/lib/widgets/theme_panel.dart
+++ b/apps/dashboard/lib/widgets/theme_panel.dart
@@ -196,8 +196,7 @@ class _AccentSwatch extends StatelessWidget {
             container: FlexBoxStyler()
                 .size(30, 30)
                 .alignment(.center)
-                .mainAxisAlignment(.center)
-                .crossAxisAlignment(.center)
+                .mainAxisSize(.min)
                 .borderRadius(.all(const Radius.circular(15))),
             icon: .size(15),
           )

--- a/apps/dashboard/test/app_smoke_test.dart
+++ b/apps/dashboard/test/app_smoke_test.dart
@@ -2,6 +2,7 @@ import 'dart:ui' as ui;
 
 import 'package:dashboard/main.dart';
 import 'package:dashboard/shell/dashboard_shell.dart';
+import 'package:dashboard/shell/top_bar.dart';
 import 'package:dashboard/theme/theme_scope.dart';
 import 'package:dashboard/theme/theme_settings.dart';
 import 'package:dashboard/utils/text.dart';
@@ -300,6 +301,23 @@ void main() {
     );
   });
 
+  testWidgets('avatar gallery renders the largest preset at full size', (
+    tester,
+  ) async {
+    await tester.pumpWidget(const DashboardApp());
+    await tester.tap(find.byKey(const ValueKey('nav-galleryDisplay')).first);
+    await tester.pump();
+
+    final largestAvatars = find.byWidgetPredicate(
+      (widget) =>
+          widget is FortalAvatar && widget.size == FortalAvatarSize.size9,
+    );
+    expect(largestAvatars, findsNWidgets(2));
+    for (var index = 0; index < 2; index++) {
+      expect(tester.getSize(largestAvatars.at(index)), const Size.square(160));
+    }
+  });
+
   testWidgets('the overlays gallery exposes the compound menu items', (
     tester,
   ) async {
@@ -554,6 +572,62 @@ void main() {
 
     final shell = tester.element(find.byType(DashboardShell));
     expect(FortalTheme.of(shell).accent, FortalAccentColor.grass);
+  });
+
+  testWidgets('theme swatch centers its selected checkmark', (tester) async {
+    await tester.pumpWidget(const DashboardApp());
+    await tester.tap(find.byKey(const ValueKey('nav-settings')).first);
+    await tester.pump();
+
+    final swatch = find.byKey(const ValueKey('accent-indigo'));
+    final toggle = find.descendant(
+      of: swatch,
+      matching: find.byType(RemixToggle),
+    );
+    final check = find.descendant(
+      of: swatch,
+      matching: find.byIcon(Icons.check),
+    );
+
+    expect(tester.getCenter(check), tester.getCenter(toggle));
+  });
+
+  testWidgets('top bar icon buttons stay square while hovered and open', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(1400, 900);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(const DashboardApp());
+    final topBar = find.byType(TopBar);
+    final surfaces = find.descendant(
+      of: topBar,
+      matching: find.byKey(const ValueKey('remix-icon-button-surface')),
+    );
+    expect(surfaces, findsNWidgets(3));
+
+    void expectSquareSurfaces() {
+      for (final surface in surfaces.evaluate()) {
+        final size = tester.getSize(
+          find.byElementPredicate((element) => element == surface),
+        );
+        expect(size.width, size.height);
+      }
+    }
+
+    expectSquareSurfaces();
+    final notifications = find.byIcon(Icons.notifications_none);
+    final mouse = await tester.createGesture(kind: ui.PointerDeviceKind.mouse);
+    addTearDown(mouse.removePointer);
+    await mouse.addPointer(location: tester.getCenter(notifications));
+    await tester.pump();
+    expectSquareSurfaces();
+
+    await tester.tap(notifications);
+    await tester.pump();
+    expectSquareSurfaces();
   });
 
   testWidgets('grid sorts, selects the page, and paginates', (tester) async {

--- a/docs/components/checkbox_group.mdx
+++ b/docs/components/checkbox_group.mdx
@@ -253,9 +253,10 @@ There is no Fortal checkbox-group widget, because the group has no visuals of
 its own. Style the **items** with the existing Fortal checkbox recipe; the
 group stays unstyled. Fortal keeps its 14/16/20 indicator geometry inside the
 item's default 48-pixel interaction target. The Radix CheckboxGroup family is
-audited separately as intentionally unmapped: caller-owned `Column`/`Row`
-spacing replaces its root and label gaps, while each item receives the mapped
-checkbox size, variant, color, and high-contrast styling.
+audited separately as intentionally unmapped at the root: caller-owned
+`Column`/`Row` spacing replaces its root layout, while each
+`FortalCheckboxGroupItem` receives the mapped checkbox visuals, size-linked
+`text1`/`text2`/`text3` label typography, and scaled 6/7/8 label gap.
 
 <CodeGroup title="Fortal-styled items" defaultLanguage="dart">
 ```dart
@@ -286,15 +287,13 @@ class _FortalCheckboxGroupExampleState
         crossAxisAlignment: CrossAxisAlignment.start,
         spacing: 8,
         children: [
-          RemixCheckboxGroupItem<String>(
+          FortalCheckboxGroupItem<String>.surface(
             value: 'design',
             label: 'Design',
-            style: fortalCheckboxStyle(variant: FortalCheckboxVariant.surface),
           ),
-          RemixCheckboxGroupItem<String>(
+          FortalCheckboxGroupItem<String>.soft(
             value: 'code',
             label: 'Code',
-            style: fortalCheckboxStyle(variant: FortalCheckboxVariant.soft),
           ),
         ],
       ),
@@ -305,7 +304,7 @@ class _FortalCheckboxGroupExampleState
 </CodeGroup>
 
 <Info>
-  See the [fortalCheckboxStyle source code](https://github.com/btwld/remix/blob/main/packages/remix_fortal/lib/src/recipes/checkbox.dart) for all available options.
+  See the [fortalCheckboxGroupItemStyle source code](https://github.com/btwld/remix/blob/main/packages/remix_fortal/lib/src/recipes/checkbox.dart) for all available options.
 </Info>
 
 ## Controlled values

--- a/docs/components/checkbox_group.mdx
+++ b/docs/components/checkbox_group.mdx
@@ -249,11 +249,12 @@ CheckboxStyler _optionStyle() {
 
 ## Fortal widgets
 
-There is no Fortal checkbox-group widget, because the group root has no visuals of
-its own. Render each option as `FortalCheckboxGroupItem`, which applies `fortalCheckboxGroupItemStyle`
-for you; the group stays unstyled. Fortal keeps its 14/16/20 indicator geometry inside the
-item's default 48-pixel interaction target. The Radix CheckboxGroup family is
-audited separately as intentionally unmapped at the root: caller-owned
+There is no Fortal checkbox-group widget, because the group root has no
+visuals of its own. Render each option as `FortalCheckboxGroupItem`, which
+applies `fortalCheckboxGroupItemStyle` for you; the group stays unstyled.
+Fortal keeps its 14/16/20 indicator geometry inside the item's default
+48-pixel interaction target. The Radix CheckboxGroup family is audited
+separately as intentionally unmapped at the root: caller-owned
 `Column`/`Row` spacing replaces its root layout, while each
 `FortalCheckboxGroupItem` receives the mapped checkbox visuals, size-linked
 `text1`/`text2`/`text3` label typography, and scaled 6/7/8 label gap.

--- a/docs/components/checkbox_group.mdx
+++ b/docs/components/checkbox_group.mdx
@@ -249,9 +249,9 @@ CheckboxStyler _optionStyle() {
 
 ## Fortal widgets
 
-There is no Fortal checkbox-group widget, because the group has no visuals of
-its own. Style the **items** with the existing Fortal checkbox recipe; the
-group stays unstyled. Fortal keeps its 14/16/20 indicator geometry inside the
+There is no Fortal checkbox-group widget, because the group root has no visuals of
+its own. Render each option as `FortalCheckboxGroupItem`, which applies `fortalCheckboxGroupItemStyle`
+for you; the group stays unstyled. Fortal keeps its 14/16/20 indicator geometry inside the
 item's default 48-pixel interaction target. The Radix CheckboxGroup family is
 audited separately as intentionally unmapped at the root: caller-owned
 `Column`/`Row` spacing replaces its root layout, while each

--- a/docs/fortal/catalog.mdx
+++ b/docs/fortal/catalog.mdx
@@ -901,7 +901,7 @@ These upstream families are tracked deliberately rather than missed. Each names 
 
 ### Radix `CheckboxGroup`
 
-- **Why not mapped:** RemixCheckboxGroup deliberately owns no visual or layout anatomy, so generating a FortalCheckboxGroup wrapper would invent a style surface that the underlying coordinator does not have.
-- **Use instead:** Use RemixCheckboxGroup for selection, roving focus, semantics, and item layout transparency; render each option as FortalCheckboxGroupItem(size:, variant:, highContrast:), which applies the checkbox recipe for you, and let the caller own the root and label spacing. Callers that need a per-item override can still pass fortalCheckboxStyle(...) to RemixCheckboxGroupItem.style directly.
-- **Reopens when:** Map this family only if RemixCheckboxGroup gains a visual root/item-label anatomy that can express the pinned gaps and inherited size, variant, color, and highContrast contract without a Fortal-only wrapper.
+- **Why not mapped:** RemixCheckboxGroup deliberately owns no visual or root-layout anatomy, so generating a FortalCheckboxGroup wrapper would invent a root style surface that the underlying coordinator does not have. FortalCheckboxGroupItem maps the item-level typography, label gap, and checkbox visuals independently.
+- **Use instead:** Use RemixCheckboxGroup for selection, roving focus, semantics, and layout transparency; render each option as FortalCheckboxGroupItem(size:, variant:, highContrast:), which maps the checkbox recipe, size-linked text1/text2/text3 label typography, and scaled 6/7/8 item-label gaps. The caller continues to own root direction and spacing. Callers that need a per-item override can pass a CheckboxStyler to RemixCheckboxGroupItem.style directly.
+- **Reopens when:** Map the remaining root contract only if RemixCheckboxGroup gains layout anatomy that can express the pinned root direction and gap without a Fortal-only wrapper.
 

--- a/packages/remix/lib/src/components/checkbox/checkbox_widget.dart
+++ b/packages/remix/lib/src/components/checkbox/checkbox_widget.dart
@@ -141,7 +141,7 @@ class RemixCheckbox extends StatelessWidget {
               (true, _) =>
                 indeterminateIcon == null
                     ? RemixPathIcon(
-                        glyph: RemixPathGlyph.dash,
+                        glyph: RemixPathGlyph.thickDividerHorizontal,
                         styleSpec: spec.indicator,
                       )
                     : StyledIcon(
@@ -151,7 +151,7 @@ class RemixCheckbox extends StatelessWidget {
               (false, true) =>
                 checkedIcon == null
                     ? RemixPathIcon(
-                        glyph: RemixPathGlyph.check,
+                        glyph: RemixPathGlyph.thickCheck,
                         styleSpec: spec.indicator,
                       )
                     : StyledIcon(icon: checkedIcon, styleSpec: spec.indicator),

--- a/packages/remix/lib/src/rendering/remix_box_effects_painters.dart
+++ b/packages/remix/lib/src/rendering/remix_box_effects_painters.dart
@@ -276,7 +276,6 @@ class _RemixBoxEffectLayerPainter extends CustomPainter
     // outside the shape on Flutter Web.
     canvas.save();
     canvas.clipRRect(targetShape, doAntiAlias: true);
-    canvas.saveLayer(layerBounds, Paint());
     if (shadow.blurRadius > 0) {
       final sigma = ui.Shadow.convertRadiusToSigma(shadow.blurRadius);
       canvas.saveLayer(
@@ -295,7 +294,6 @@ class _RemixBoxEffectLayerPainter extends CustomPainter
       ..addRRect(hole);
     canvas.drawPath(shadowPath, Paint()..color = shadow.color);
     if (shadow.blurRadius > 0) canvas.restore();
-    canvas.restore();
     canvas.restore();
   }
 

--- a/packages/remix/lib/src/rendering/remix_box_effects_painters.dart
+++ b/packages/remix/lib/src/rendering/remix_box_effects_painters.dart
@@ -272,6 +272,10 @@ class _RemixBoxEffectLayerPainter extends CustomPainter
     final layerBounds = targetShape.outerRect
         .expandToInclude(hole.outerRect)
         .inflate(blurExtent);
+    // Clip before filtering because erasing afterward can leave blur fringes
+    // outside the shape on Flutter Web.
+    canvas.save();
+    canvas.clipRRect(targetShape, doAntiAlias: true);
     canvas.saveLayer(layerBounds, Paint());
     if (shadow.blurRadius > 0) {
       final sigma = ui.Shadow.convertRadiusToSigma(shadow.blurRadius);
@@ -291,16 +295,7 @@ class _RemixBoxEffectLayerPainter extends CustomPainter
       ..addRRect(hole);
     canvas.drawPath(shadowPath, Paint()..color = shadow.color);
     if (shadow.blurRadius > 0) canvas.restore();
-    final outsideShape = Path()
-      ..fillType = PathFillType.evenOdd
-      ..addRect(layerBounds)
-      ..addRRect(targetShape);
-    canvas.drawPath(
-      outsideShape,
-      Paint()
-        ..color = const Color(0xFFFFFFFF)
-        ..blendMode = BlendMode.dstOut,
-    );
+    canvas.restore();
     canvas.restore();
   }
 

--- a/packages/remix/lib/src/rendering/remix_box_effects_painters.dart
+++ b/packages/remix/lib/src/rendering/remix_box_effects_painters.dart
@@ -268,6 +268,12 @@ class _RemixBoxEffectLayerPainter extends CustomPainter
       return;
     }
 
+    // Deliberate: this blurs through a layer rather than the `MaskFilter` paint
+    // `_paintOuterShadows` builds. The two agree from blurRadius 3 up but
+    // diverge by ~5% below it, and the Fortal classic recipes pin inset shadows
+    // at blurRadius 0.5, so they are not interchangeable here. The extent runs
+    // just under 3 sigma below radius 2; that measures at <=1/255 and the clip
+    // discards it regardless.
     final blurExtent = shadow.blurRadius * 2 + 1;
     final layerBounds = targetShape.outerRect
         .expandToInclude(hole.outerRect)

--- a/packages/remix/lib/src/utilities/remix_path_icon.dart
+++ b/packages/remix/lib/src/utilities/remix_path_icon.dart
@@ -6,6 +6,7 @@ import 'package:mix/mix.dart';
 enum RemixPathGlyph {
   chevronDown(9),
   thickCheck(9),
+  thickDividerHorizontal(9),
   thickChevronRight(9),
   plus(15),
   minus(15),
@@ -99,6 +100,7 @@ class _RemixPathIconPainter extends CustomPainter {
     final path = switch (glyph) {
       .chevronDown => _chevronDownPath(),
       .thickCheck => _thickCheckPath(),
+      .thickDividerHorizontal => _thickDividerHorizontalPath(),
       .thickChevronRight => _thickChevronRightPath(),
       .plus => _plusPath(),
       .minus => _minusPath(),
@@ -156,6 +158,16 @@ Path _thickCheckPath() => Path()
   ..lineTo(3.73256, 6.60459)
   ..lineTo(7.49741, 0.840706)
   ..cubicTo(7.72393, 0.493916, 8.18868, 0.396414, 8.53547, 0.62293)
+  ..close();
+
+Path _thickDividerHorizontalPath() => Path()
+  ..moveTo(0.75, 4.5)
+  ..cubicTo(0.75, 4.08579, 1.08579, 3.75, 1.5, 3.75)
+  ..lineTo(7.5, 3.75)
+  ..cubicTo(7.91421, 3.75, 8.25, 4.08579, 8.25, 4.5)
+  ..cubicTo(8.25, 4.91421, 7.91421, 5.25, 7.5, 5.25)
+  ..lineTo(1.5, 5.25)
+  ..cubicTo(1.08579, 5.25, 0.75, 4.91421, 0.75, 4.5)
   ..close();
 
 Path _thickChevronRightPath() => Path()

--- a/packages/remix/lib/src/utilities/remix_path_icon.dart
+++ b/packages/remix/lib/src/utilities/remix_path_icon.dart
@@ -10,8 +10,6 @@ enum RemixPathGlyph {
   thickChevronRight(9),
   plus(15),
   minus(15),
-  dash(15),
-  check(15),
   caretSort(15),
   caretUp(15),
   caretDown(15),
@@ -104,8 +102,6 @@ class _RemixPathIconPainter extends CustomPainter {
       .thickChevronRight => _thickChevronRightPath(),
       .plus => _plusPath(),
       .minus => _minusPath(),
-      .dash => _dashPath(),
-      .check => _checkPath(),
       .caretSort => _caretSortPath(),
       .caretUp => _caretUpPath(),
       .caretDown => _caretDownPath(),
@@ -211,30 +207,6 @@ Path _minusPath() => Path()
   ..cubicTo(12.75, 7.77614, 12.5261, 8, 12.25, 8)
   ..lineTo(2.75, 8)
   ..cubicTo(2.47386, 8, 2.25, 7.77614, 2.25, 7.5)
-  ..close();
-
-Path _dashPath() => Path()
-  ..moveTo(5, 7.5)
-  ..cubicTo(5, 7.22386, 5.22386, 7, 5.5, 7)
-  ..lineTo(9.5, 7)
-  ..cubicTo(9.77614, 7, 10, 7.22386, 10, 7.5)
-  ..cubicTo(10, 7.77614, 9.77614, 8, 9.5, 8)
-  ..lineTo(5.5, 8)
-  ..cubicTo(5.22386, 8, 5, 7.77614, 5, 7.5)
-  ..close();
-
-Path _checkPath() => Path()
-  ..moveTo(11.4669, 3.72684)
-  ..cubicTo(11.7558, 3.91574, 11.8369, 4.30308, 11.648, 4.59198)
-  ..lineTo(7.39799, 11.092)
-  ..cubicTo(7.29783, 11.2452, 7.13556, 11.3467, 6.95402, 11.3699)
-  ..cubicTo(6.77247, 11.3931, 6.58989, 11.3355, 6.45446, 11.2124)
-  ..lineTo(3.70446, 8.71241)
-  ..cubicTo(3.44905, 8.48022, 3.43023, 8.08494, 3.66242, 7.82953)
-  ..cubicTo(3.89461, 7.57412, 4.28989, 7.55529, 4.5453, 7.78749)
-  ..lineTo(6.75292, 9.79441)
-  ..lineTo(10.6018, 3.90792)
-  ..cubicTo(10.7907, 3.61902, 11.178, 3.53795, 11.4669, 3.72684)
   ..close();
 
 Path _caretSortPath() => Path()

--- a/packages/remix/test/components/checkbox/checkbox_group_widget_test.dart
+++ b/packages/remix/test/components/checkbox/checkbox_group_widget_test.dart
@@ -247,13 +247,13 @@ void main() {
           ),
         );
 
-        expect(_pathGlyph(RemixPathGlyph.check), findsOneWidget);
+        expect(_pathGlyph(RemixPathGlyph.thickCheck), findsOneWidget);
 
         await tester.tap(_itemAt(1));
         await tester.pumpAndSettle();
 
         expect(
-          _pathGlyph(RemixPathGlyph.check),
+          _pathGlyph(RemixPathGlyph.thickCheck),
           findsOneWidget,
           reason: 'selection is owned by the caller, not the group',
         );
@@ -285,7 +285,7 @@ void main() {
         await tester.pump();
 
         expect(tester.takeException(), isNull);
-        expect(_pathGlyph(RemixPathGlyph.check), findsOneWidget);
+        expect(_pathGlyph(RemixPathGlyph.thickCheck), findsOneWidget);
       });
 
       testWidgets('a disabled group suppresses every option', (tester) async {
@@ -404,7 +404,7 @@ void main() {
           boxes[1].styleSpec?.spec.decoration,
           equals(boxes[0].styleSpec?.spec.decoration),
         );
-        expect(_pathGlyph(RemixPathGlyph.check), findsNWidgets(2));
+        expect(_pathGlyph(RemixPathGlyph.thickCheck), findsNWidgets(2));
       });
     });
 
@@ -1231,7 +1231,7 @@ void main() {
             );
           }
 
-          expect(_pathGlyph(RemixPathGlyph.check), findsNothing);
+          expect(_pathGlyph(RemixPathGlyph.thickCheck), findsNothing);
           expect(
             tester.getSemantics(_itemAt(0)),
             checkbox(label: 'Design', checked: false),
@@ -1246,7 +1246,7 @@ void main() {
               <String>{'design'},
             ]),
           );
-          expect(_pathGlyph(RemixPathGlyph.check), findsOneWidget);
+          expect(_pathGlyph(RemixPathGlyph.thickCheck), findsOneWidget);
           expect(
             tester.getSemantics(_itemAt(0)),
             checkbox(label: 'Design', checked: true),
@@ -1260,13 +1260,13 @@ void main() {
           await tester.pumpAndSettle();
 
           expect(emitted.last, equals({'design', 'code'}));
-          expect(_pathGlyph(RemixPathGlyph.check), findsNWidgets(2));
+          expect(_pathGlyph(RemixPathGlyph.thickCheck), findsNWidgets(2));
 
           await tester.tap(_itemAt(0));
           await tester.pumpAndSettle();
 
           expect(emitted.last, equals({'code'}));
-          expect(_pathGlyph(RemixPathGlyph.check), findsOneWidget);
+          expect(_pathGlyph(RemixPathGlyph.thickCheck), findsOneWidget);
           expect(
             tester.getSemantics(_itemAt(0)),
             checkbox(label: 'Design', checked: false),

--- a/packages/remix/test/components/checkbox/checkbox_widget_test.dart
+++ b/packages/remix/test/components/checkbox/checkbox_widget_test.dart
@@ -64,7 +64,7 @@ void main() {
 
         expect(find.byType(RemixCheckbox), findsOneWidget);
         expect(find.byType(Box), findsOneWidget);
-        expect(_pathGlyph(RemixPathGlyph.check), findsOneWidget);
+        expect(_pathGlyph(RemixPathGlyph.thickCheck), findsOneWidget);
       });
 
       testWidgets('renders indeterminate state when tristate is true', (
@@ -77,7 +77,10 @@ void main() {
 
         expect(find.byType(RemixCheckbox), findsOneWidget);
         expect(find.byType(Box), findsOneWidget);
-        expect(_pathGlyph(RemixPathGlyph.dash), findsOneWidget);
+        expect(
+          _pathGlyph(RemixPathGlyph.thickDividerHorizontal),
+          findsOneWidget,
+        );
       });
     });
 
@@ -123,7 +126,7 @@ void main() {
 
         expect(find.byType(RemixCheckbox), findsOneWidget);
         expect(find.byType(StyledIcon), findsNothing);
-        expect(_pathGlyph(RemixPathGlyph.check), findsOneWidget);
+        expect(_pathGlyph(RemixPathGlyph.thickCheck), findsOneWidget);
       });
 
       testWidgets('uses custom checked icon', (tester) async {
@@ -319,7 +322,7 @@ void main() {
 
         expect(find.byType(RemixCheckbox), findsOneWidget);
         expect(find.byType(Box), findsOneWidget);
-        expect(_pathGlyph(RemixPathGlyph.check), findsOneWidget);
+        expect(_pathGlyph(RemixPathGlyph.thickCheck), findsOneWidget);
       });
     });
 
@@ -401,7 +404,10 @@ void main() {
 
         expect(find.byType(RemixCheckbox), findsOneWidget);
         expect(find.byType(Box), findsOneWidget);
-        expect(_pathGlyph(RemixPathGlyph.dash), findsOneWidget);
+        expect(
+          _pathGlyph(RemixPathGlyph.thickDividerHorizontal),
+          findsOneWidget,
+        );
       });
 
       testWidgets('handles tristate with true selected', (tester) async {
@@ -412,7 +418,7 @@ void main() {
 
         expect(find.byType(RemixCheckbox), findsOneWidget);
         expect(find.byType(Box), findsOneWidget);
-        expect(_pathGlyph(RemixPathGlyph.check), findsOneWidget);
+        expect(_pathGlyph(RemixPathGlyph.thickCheck), findsOneWidget);
       });
     });
   });

--- a/packages/remix/test/material_free_defaults_test.dart
+++ b/packages/remix/test/material_free_defaults_test.dart
@@ -62,7 +62,7 @@ void main() {
     await tester.pump();
 
     expect(tester.takeException(), isNull);
-    expect(_pathGlyph(RemixPathGlyph.check), findsOneWidget);
+    expect(_pathGlyph(RemixPathGlyph.thickCheck), findsOneWidget);
     expect(_pathGlyph(RemixPathGlyph.plus), findsOneWidget);
     expect(_pathGlyph(RemixPathGlyph.caretSort), findsOneWidget);
     expect(_pathGlyph(RemixPathGlyph.chevronLeft), findsOneWidget);

--- a/packages/remix/test/rendering/remix_box_effects_pixel_test.dart
+++ b/packages/remix/test/rendering/remix_box_effects_pixel_test.dart
@@ -97,6 +97,47 @@ void main() {
       );
     });
 
+    testWidgets('clips blurred inset shadows to their rounded target', (
+      tester,
+    ) async {
+      final pixels = await _render(
+        tester,
+        size: const Size(40, 30),
+        background: Colors.white,
+        child: Center(
+          child: RemixBoxWithEffects(
+            styleSpec: const StyleSpec(
+              spec: BoxSpec(
+                constraints: BoxConstraints.tightFor(width: 20, height: 12),
+                decoration: BoxDecoration(
+                  color: Colors.blue,
+                  borderRadius: BorderRadius.all(Radius.circular(6)),
+                ),
+              ),
+            ),
+            containerEffects: const RemixBoxEffectsSpec(
+              behindContent: RemixBoxEffectLayerSpec(
+                shadows: [
+                  RemixBoxShadow(
+                    kind: RemixBoxShadowKind.inset,
+                    color: Colors.black,
+                    offset: Offset(0, 4),
+                    blurRadius: 3,
+                    spreadRadius: -1,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+
+      for (var x = 0; x < 40; x++) {
+        expect(_pixel(pixels, x, 8), _rgba(Colors.white), reason: 'x=$x');
+        expect(_pixel(pixels, x, 21), _rgba(Colors.white), reason: 'x=$x');
+      }
+    });
+
     testWidgets(
       'orders border, content, foreground decoration, effects, outline',
       (tester) async {

--- a/packages/remix/test/rendering/remix_box_effects_pixel_test.dart
+++ b/packages/remix/test/rendering/remix_box_effects_pixel_test.dart
@@ -97,47 +97,6 @@ void main() {
       );
     });
 
-    testWidgets('clips blurred inset shadows to their rounded target', (
-      tester,
-    ) async {
-      final pixels = await _render(
-        tester,
-        size: const Size(40, 30),
-        background: Colors.white,
-        child: Center(
-          child: RemixBoxWithEffects(
-            styleSpec: const StyleSpec(
-              spec: BoxSpec(
-                constraints: BoxConstraints.tightFor(width: 20, height: 12),
-                decoration: BoxDecoration(
-                  color: Colors.blue,
-                  borderRadius: BorderRadius.all(Radius.circular(6)),
-                ),
-              ),
-            ),
-            containerEffects: const RemixBoxEffectsSpec(
-              behindContent: RemixBoxEffectLayerSpec(
-                shadows: [
-                  RemixBoxShadow(
-                    kind: RemixBoxShadowKind.inset,
-                    color: Colors.black,
-                    offset: Offset(0, 4),
-                    blurRadius: 3,
-                    spreadRadius: -1,
-                  ),
-                ],
-              ),
-            ),
-          ),
-        ),
-      );
-
-      for (var x = 0; x < 40; x++) {
-        expect(_pixel(pixels, x, 8), _rgba(Colors.white), reason: 'x=$x');
-        expect(_pixel(pixels, x, 21), _rgba(Colors.white), reason: 'x=$x');
-      }
-    });
-
     testWidgets(
       'orders border, content, foreground decoration, effects, outline',
       (tester) async {

--- a/packages/remix/test/utilities/remix_path_icon_test.dart
+++ b/packages/remix/test/utilities/remix_path_icon_test.dart
@@ -56,6 +56,10 @@ void main() {
       bounds: Rect.fromLTRB(0.2852460, 0.3964140, 8.9797602, 8.5216703),
       perimeter: 26.7144108,
     ),
+    RemixPathGlyph.thickDividerHorizontal: (
+      bounds: Rect.fromLTRB(0.75, 3.75, 8.25, 5.25),
+      perimeter: 16.2426414,
+    ),
     RemixPathGlyph.thickChevronRight: (
       bounds: Rect.fromLTRB(2.9190900, -0.0809141, 8.0672398, 9.0809202),
       perimeter: 24.3844013,

--- a/packages/remix_fortal/lib/src/fortal/base_button_recipe.dart
+++ b/packages/remix_fortal/lib/src/fortal/base_button_recipe.dart
@@ -13,6 +13,14 @@ import 'package:remix/remix.dart'
 
 import 'fortal_theme.dart';
 
+/// The Radix BaseButton size scale shared by Button and IconButton.
+///
+/// Deliberate: this mirrors [FortalBaseButtonVariant]. Button and IconButton
+/// each own a size enum, so the shared metrics need a common type — passing the
+/// raw `size.index + 1` instead would drop every switch below to a wildcard and
+/// defer an unknown size to a runtime throw.
+enum FortalBaseButtonSize { size1, size2, size3, size4 }
+
 /// Shared Radix BaseButton metrics used by Button and IconButton recipes.
 ({
   double height,
@@ -22,8 +30,8 @@ import 'fortal_theme.dart';
   TextStyleToken text,
   double spinnerSize,
 })
-fortalBaseButtonMetrics(int size) => switch (size) {
-  1 => (
+fortalBaseButtonMetrics(FortalBaseButtonSize size) => switch (size) {
+  .size1 => (
     height: FortalTokens.space5(),
     paddingX: FortalTokens.space2(),
     gap: FortalTokens.space1(),
@@ -31,7 +39,7 @@ fortalBaseButtonMetrics(int size) => switch (size) {
     text: FortalTokens.text1,
     spinnerSize: FortalTokens.space3(),
   ),
-  2 => (
+  .size2 => (
     height: FortalTokens.space6(),
     paddingX: FortalTokens.space3(),
     gap: FortalTokens.space2(),
@@ -39,7 +47,7 @@ fortalBaseButtonMetrics(int size) => switch (size) {
     text: FortalTokens.text2,
     spinnerSize: FortalTokens.space4(),
   ),
-  3 => (
+  .size3 => (
     height: FortalTokens.space7(),
     paddingX: FortalTokens.space4(),
     gap: FortalTokens.space3(),
@@ -47,7 +55,7 @@ fortalBaseButtonMetrics(int size) => switch (size) {
     text: FortalTokens.text3,
     spinnerSize: FortalTokens.space4(),
   ),
-  4 => (
+  .size4 => (
     height: FortalTokens.space8(),
     paddingX: FortalTokens.space5(),
     gap: FortalTokens.space3(),
@@ -55,68 +63,62 @@ fortalBaseButtonMetrics(int size) => switch (size) {
     text: FortalTokens.text4,
     spinnerSize: FortalTokens.spinnerSize3(),
   ),
-  _ => throw ArgumentError.value(size, 'size', 'Expected a size from 1 to 4.'),
 };
 
 /// Content-box metrics for the ghost BaseButton variant.
 ({double paddingX, double paddingY, double marginX, double marginY, double gap})
-fortalBaseButtonGhostMetrics(int size) => switch (size) {
-  1 => (
+fortalBaseButtonGhostMetrics(FortalBaseButtonSize size) => switch (size) {
+  .size1 => (
     paddingX: FortalTokens.space2(),
     paddingY: FortalTokens.space1(),
     marginX: FortalTokens.baseButtonGhostMarginX12(),
     marginY: FortalTokens.baseButtonGhostMarginY12(),
     gap: FortalTokens.space1(),
   ),
-  2 => (
+  .size2 => (
     paddingX: FortalTokens.space2(),
     paddingY: FortalTokens.space1(),
     marginX: FortalTokens.baseButtonGhostMarginX12(),
     marginY: FortalTokens.baseButtonGhostMarginY12(),
     gap: FortalTokens.space1(),
   ),
-  3 => (
+  .size3 => (
     paddingX: FortalTokens.space3(),
     paddingY: FortalTokens.baseButtonGhostPaddingY3(),
     marginX: FortalTokens.baseButtonGhostMarginX3(),
     marginY: FortalTokens.baseButtonGhostMarginY3(),
     gap: FortalTokens.space2(),
   ),
-  4 => (
+  .size4 => (
     paddingX: FortalTokens.space4(),
     paddingY: FortalTokens.space2(),
     marginX: FortalTokens.baseButtonGhostMarginX4(),
     marginY: FortalTokens.baseButtonGhostMarginY4(),
     gap: FortalTokens.space2(),
   ),
-  _ => throw ArgumentError.value(size, 'size', 'Expected a size from 1 to 4.'),
 };
 
 /// Content-box metrics for the ghost IconButton variant.
-({double padding, double margin}) fortalIconButtonGhostMetrics(int size) =>
-    switch (size) {
-      1 => (
-        padding: FortalTokens.space1(),
-        margin: FortalTokens.iconButtonGhostMargin1(),
-      ),
-      2 => (
-        padding: FortalTokens.iconButtonGhostPadding2(),
-        margin: FortalTokens.iconButtonGhostMargin2(),
-      ),
-      3 => (
-        padding: FortalTokens.space2(),
-        margin: FortalTokens.iconButtonGhostMargin3(),
-      ),
-      4 => (
-        padding: FortalTokens.space3(),
-        margin: FortalTokens.iconButtonGhostMargin4(),
-      ),
-      _ => throw ArgumentError.value(
-        size,
-        'size',
-        'Expected a size from 1 to 4.',
-      ),
-    };
+({double padding, double margin}) fortalIconButtonGhostMetrics(
+  FortalBaseButtonSize size,
+) => switch (size) {
+  .size1 => (
+    padding: FortalTokens.space1(),
+    margin: FortalTokens.iconButtonGhostMargin1(),
+  ),
+  .size2 => (
+    padding: FortalTokens.iconButtonGhostPadding2(),
+    margin: FortalTokens.iconButtonGhostMargin2(),
+  ),
+  .size3 => (
+    padding: FortalTokens.space2(),
+    margin: FortalTokens.iconButtonGhostMargin3(),
+  ),
+  .size4 => (
+    padding: FortalTokens.space3(),
+    margin: FortalTokens.iconButtonGhostMargin4(),
+  ),
+};
 
 /// A CSS outline that does not affect layout.
 RemixBoxEffectsMix fortalFocusOutline(Color color, {required double offset}) =>

--- a/packages/remix_fortal/lib/src/fortal/base_button_state_styles.dart
+++ b/packages/remix_fortal/lib/src/fortal/base_button_state_styles.dart
@@ -55,10 +55,18 @@ FortalBaseButtonStateStyles fortalBaseButtonStateStyles({
     .outline => _outlineStateStyles(highContrast: highContrast),
     .ghost => _ghostStateStyles(highContrast: highContrast),
   };
-  final focusColor = variant == .soft
-      ? FortalTokens.accent8()
-      : FortalTokens.focus8();
-  final focusOffset = variant == .classic || variant == .solid ? 2.0 : -1.0;
+  final focusColor = switch (variant) {
+    .soft => FortalTokens.accent8(),
+    .classic ||
+    .solid ||
+    .surface ||
+    .outline ||
+    .ghost => FortalTokens.focus8(),
+  };
+  final focusOffset = switch (variant) {
+    .classic || .solid => 2.0,
+    .soft || .surface || .outline || .ghost => -1.0,
+  };
 
   return FortalBaseButtonStateStyles(
     idle: states.idle,

--- a/packages/remix_fortal/lib/src/fortal/fortal_theme.dart
+++ b/packages/remix_fortal/lib/src/fortal/fortal_theme.dart
@@ -416,6 +416,17 @@ class FortalTokens {
     'fortal.checkbox.indicator-size.3',
   );
 
+  /// Checkbox-group label gaps derived from Radix's size-linked `0.5em`.
+  static const checkboxGroupItemGap1 = DoubleToken(
+    'fortal.checkbox-group.item-gap.1',
+  );
+  static const checkboxGroupItemGap2 = DoubleToken(
+    'fortal.checkbox-group.item-gap.2',
+  );
+  static const checkboxGroupItemGap3 = DoubleToken(
+    'fortal.checkbox-group.item-gap.3',
+  );
+
   /// Radio indicators are 40% of their control size in Radix Themes.
   ///
   /// These values need dedicated tokens because arithmetic on an unresolved
@@ -1111,6 +1122,9 @@ Map<MixToken, Object> _buildFortalScopeTokens(FortalThemeData theme) {
     FortalTokens.checkboxIndicatorSize1: 9.0 * scaling,
     FortalTokens.checkboxIndicatorSize2: 10.0 * scaling,
     FortalTokens.checkboxIndicatorSize3: 12.0 * scaling,
+    FortalTokens.checkboxGroupItemGap1: 6.0 * scaling,
+    FortalTokens.checkboxGroupItemGap2: 7.0 * scaling,
+    FortalTokens.checkboxGroupItemGap3: 8.0 * scaling,
     FortalTokens.radioIndicatorSize1: 5.6 * scaling,
     FortalTokens.radioIndicatorSize2: 6.4 * scaling,
     FortalTokens.radioIndicatorSize3: 8.0 * scaling,

--- a/packages/remix_fortal/lib/src/recipes/button.dart
+++ b/packages/remix_fortal/lib/src/recipes/button.dart
@@ -20,8 +20,7 @@ ButtonStyler fortalButtonStyle({
   FortalButtonSize size = .size2,
   bool highContrast = false,
 }) {
-  final index = size.index + 1;
-  final base = _fortalButtonBaseStyler(variant, index);
+  final base = _fortalButtonBaseStyler(variant, _fortalBaseButtonSize(size));
   final stateStyles = fortalBaseButtonStateStyles(
     variant: _fortalBaseButtonVariant(variant),
     highContrast: highContrast,
@@ -30,11 +29,14 @@ ButtonStyler fortalButtonStyle({
   return _applyFortalButtonStateStyles(
     base,
     stateStyles,
-    pressedPaddingTop: variant == .classic ? (index == 1 ? 1 : 2) : null,
+    pressedPaddingTop: variant == .classic ? (size == .size1 ? 1 : 2) : null,
   );
 }
 
-ButtonStyler _fortalButtonBaseStyler(FortalButtonVariant variant, int size) {
+ButtonStyler _fortalButtonBaseStyler(
+  FortalButtonVariant variant,
+  FortalBaseButtonSize size,
+) {
   final metrics = fortalBaseButtonMetrics(size);
   var style = ButtonStyler(
     container: .direction(.horizontal)
@@ -78,6 +80,14 @@ FortalBaseButtonVariant _fortalBaseButtonVariant(FortalButtonVariant variant) =>
       .surface => .surface,
       .outline => .outline,
       .ghost => .ghost,
+    };
+
+FortalBaseButtonSize _fortalBaseButtonSize(FortalButtonSize size) =>
+    switch (size) {
+      .size1 => .size1,
+      .size2 => .size2,
+      .size3 => .size3,
+      .size4 => .size4,
     };
 
 ButtonStyler _applyFortalButtonStateStyles(

--- a/packages/remix_fortal/lib/src/recipes/button.dart
+++ b/packages/remix_fortal/lib/src/recipes/button.dart
@@ -39,11 +39,7 @@ ButtonStyler _fortalButtonBaseStyler(
 ) {
   final metrics = fortalBaseButtonMetrics(size);
   var style = ButtonStyler(
-    container: .direction(.horizontal)
-        .mainAxisAlignment(.center)
-        .mainAxisSize(.min)
-        .crossAxisAlignment(.center)
-        .spacing(metrics.gap),
+    container: .direction(.horizontal).mainAxisSize(.min).spacing(metrics.gap),
     label: .style(metrics.text.mix()).fontWeight(
       variant == .ghost
           ? FortalTokens.fontWeightRegular()

--- a/packages/remix_fortal/lib/src/recipes/checkbox.dart
+++ b/packages/remix_fortal/lib/src/recipes/checkbox.dart
@@ -53,9 +53,9 @@ CheckboxStyler fortalCheckboxStyle({
 
 /// Fortal recipe for [RemixCheckboxGroupItem].
 ///
-/// Radix gives a checkbox-group item no visual contract of its own — it is a
-/// checkbox plus a label — so this delegates to [fortalCheckboxStyle] and
-/// inherits its verified parity rather than restating any of it.
+/// Combines the mapped checkbox recipe with Radix's size-linked item label
+/// typography and `0.5em` label gap. The behavioral group remains layout
+/// transparent, so callers continue to own root direction and spacing.
 ///
 /// It exists because `RemixCheckboxGroup` is behavioral and carries no styler,
 /// so unlike every other Remix item (menu, select, segmented control, toggle
@@ -67,11 +67,28 @@ CheckboxStyler fortalCheckboxGroupItemStyle({
   FortalCheckboxVariant variant = .surface,
   FortalCheckboxSize size = .size2,
   bool highContrast = false,
-}) => fortalCheckboxStyle(
-  variant: variant,
-  size: size,
-  highContrast: highContrast,
-);
+}) {
+  final checkbox = fortalCheckboxStyle(
+    variant: variant,
+    size: size,
+    highContrast: highContrast,
+  );
+
+  return switch (size) {
+    .size1 =>
+      checkbox
+          .label(.style(FortalTokens.text1.mix()))
+          .labelSpacing(FortalTokens.checkboxGroupItemGap1()),
+    .size2 =>
+      checkbox
+          .label(.style(FortalTokens.text2.mix()))
+          .labelSpacing(FortalTokens.checkboxGroupItemGap2()),
+    .size3 =>
+      checkbox
+          .label(.style(FortalTokens.text3.mix()))
+          .labelSpacing(FortalTokens.checkboxGroupItemGap3()),
+  };
+}
 
 ({double size, double indicatorSize, Radius radius}) _fortalCheckboxMetrics(
   FortalCheckboxSize size,

--- a/packages/remix_fortal/lib/src/recipes/checkbox.g.dart
+++ b/packages/remix_fortal/lib/src/recipes/checkbox.g.dart
@@ -152,9 +152,9 @@ class FortalCheckbox extends StatelessWidget {
 
 /// Fortal recipe for [RemixCheckboxGroupItem].
 ///
-/// Radix gives a checkbox-group item no visual contract of its own — it is a
-/// checkbox plus a label — so this delegates to [fortalCheckboxStyle] and
-/// inherits its verified parity rather than restating any of it.
+/// Combines the mapped checkbox recipe with Radix's size-linked item label
+/// typography and `0.5em` label gap. The behavioral group remains layout
+/// transparent, so callers continue to own root direction and spacing.
 ///
 /// It exists because `RemixCheckboxGroup` is behavioral and carries no styler,
 /// so unlike every other Remix item (menu, select, segmented control, toggle

--- a/packages/remix_fortal/lib/src/recipes/code.dart
+++ b/packages/remix_fortal/lib/src/recipes/code.dart
@@ -120,7 +120,7 @@ BadgeStyler fortalCodeStyle(
   }
   if (fill != null) style = style.color(fill);
 
-  if (variant == FortalCodeVariant.outline) {
+  if (variant == .outline) {
     final ringWidth = math.max(1.0, 0.033 * fontSize);
     style = style.containerEffects(
       RemixBoxEffectsMix.behindContent(

--- a/packages/remix_fortal/lib/src/recipes/code.dart
+++ b/packages/remix_fortal/lib/src/recipes/code.dart
@@ -31,7 +31,7 @@ BadgeStyler fortalCodeStyle(
   // Radix nests two adjustments: --code-font-size-adjust is 0.95, and
   // --code-variant-font-size-adjust multiplies it by 0.95 again for every
   // variant except ghost, which keeps the outer value.
-  final decorated = variant != FortalCodeVariant.ghost;
+  final decorated = variant != .ghost;
   final fontSize = baseFontSize * (decorated ? 0.95 * 0.95 : 0.95);
   // An explicit size keeps its token's absolute line box; the unsized path
   // uses the pinned unitless 1.25.

--- a/packages/remix_fortal/lib/src/recipes/data_table.dart
+++ b/packages/remix_fortal/lib/src/recipes/data_table.dart
@@ -141,7 +141,6 @@ BorderSideMix _fortalDataTableDividerSide() =>
 
 FlexBoxStyler _fortalDataTableFooter() => FlexBoxStyler()
     .direction(.horizontal)
-    .crossAxisAlignment(.center)
     .spacing(FortalTokens.space2())
     .padding(.horizontal(FortalTokens.space4()))
     .padding(.vertical(FortalTokens.space2()))

--- a/packages/remix_fortal/lib/src/recipes/dialog.dart
+++ b/packages/remix_fortal/lib/src/recipes/dialog.dart
@@ -78,7 +78,6 @@ DialogStyler fortalDialogStyle({
       .actions(
         FlexBoxStyler()
             .mainAxisAlignment(.end)
-            .crossAxisAlignment(.center)
             .spacing(FortalTokens.space3())
             .margin(.top(FortalTokens.space5())),
       )

--- a/packages/remix_fortal/lib/src/recipes/icon_button.dart
+++ b/packages/remix_fortal/lib/src/recipes/icon_button.dart
@@ -54,7 +54,7 @@ IconButtonStyler _fortalIconButtonBaseStyler(
     style = style.padding(.all(ghost.padding)).margin(.all(ghost.margin));
   } else {
     style = style
-        .container(.alignment(Alignment.center))
+        .container(.alignment(.center))
         .width(metrics.height)
         .height(metrics.height);
   }

--- a/packages/remix_fortal/lib/src/recipes/icon_button.dart
+++ b/packages/remix_fortal/lib/src/recipes/icon_button.dart
@@ -40,7 +40,6 @@ IconButtonStyler _fortalIconButtonBaseStyler(
 ) {
   final metrics = fortalBaseButtonMetrics(size);
   var style = IconButtonStyler(
-    container: .alignment(Alignment.center),
     icon: .size(_fortalIconButtonIconSize(size)),
     spinner: .size(metrics.spinnerSize)
         .opacity(0.65)
@@ -52,7 +51,10 @@ IconButtonStyler _fortalIconButtonBaseStyler(
     final ghost = fortalIconButtonGhostMetrics(size);
     style = style.padding(.all(ghost.padding)).margin(.all(ghost.margin));
   } else {
-    style = style.width(metrics.height).height(metrics.height);
+    style = style
+        .container(.alignment(Alignment.center))
+        .width(metrics.height)
+        .height(metrics.height);
   }
   return style;
 }

--- a/packages/remix_fortal/lib/src/recipes/icon_button.dart
+++ b/packages/remix_fortal/lib/src/recipes/icon_button.dart
@@ -20,8 +20,10 @@ IconButtonStyler fortalIconButtonStyle({
   FortalIconButtonSize size = .size2,
   bool highContrast = false,
 }) {
-  final index = size.index + 1;
-  final base = _fortalIconButtonBaseStyler(variant, index);
+  final base = _fortalIconButtonBaseStyler(
+    variant,
+    _fortalBaseButtonSize(size),
+  );
   final stateStyles = fortalBaseButtonStateStyles(
     variant: _fortalBaseButtonVariant(variant),
     highContrast: highContrast,
@@ -30,13 +32,13 @@ IconButtonStyler fortalIconButtonStyle({
   return _applyFortalIconButtonStateStyles(
     base,
     stateStyles,
-    pressedPaddingTop: variant == .classic ? (index == 1 ? 1 : 2) : null,
+    pressedPaddingTop: variant == .classic ? (size == .size1 ? 1 : 2) : null,
   );
 }
 
 IconButtonStyler _fortalIconButtonBaseStyler(
   FortalIconButtonVariant variant,
-  int size,
+  FortalBaseButtonSize size,
 ) {
   final metrics = fortalBaseButtonMetrics(size);
   var style = IconButtonStyler(
@@ -59,12 +61,11 @@ IconButtonStyler _fortalIconButtonBaseStyler(
   return style;
 }
 
-double _fortalIconButtonIconSize(int size) => switch (size) {
-  1 => FortalTokens.space3(),
-  2 => FortalTokens.space4(),
-  3 => FortalTokens.spinnerSize3(),
-  4 => FortalTokens.space5(),
-  _ => throw ArgumentError.value(size, 'size', 'Expected a size from 1 to 4.'),
+double _fortalIconButtonIconSize(FortalBaseButtonSize size) => switch (size) {
+  .size1 => FortalTokens.space3(),
+  .size2 => FortalTokens.space4(),
+  .size3 => FortalTokens.spinnerSize3(),
+  .size4 => FortalTokens.space5(),
 };
 
 FortalBaseButtonVariant _fortalBaseButtonVariant(
@@ -77,6 +78,14 @@ FortalBaseButtonVariant _fortalBaseButtonVariant(
   .outline => .outline,
   .ghost => .ghost,
 };
+
+FortalBaseButtonSize _fortalBaseButtonSize(FortalIconButtonSize size) =>
+    switch (size) {
+      .size1 => .size1,
+      .size2 => .size2,
+      .size3 => .size3,
+      .size4 => .size4,
+    };
 
 IconButtonStyler _applyFortalIconButtonStateStyles(
   IconButtonStyler base,

--- a/packages/remix_fortal/lib/src/recipes/kbd.dart
+++ b/packages/remix_fortal/lib/src/recipes/kbd.dart
@@ -57,13 +57,12 @@ BadgeStyler fortalKbdStyle(
           0.35 * fontSize * fortalRadiusFactor(context),
         ),
       )
-      .color(
-        variant == FortalKbdVariant.classic
-            ? fortalResolveColor(context, FortalTokens.gray1)
-            : fortalResolveColor(context, FortalTokens.grayA3),
-      );
+      .color(switch (variant) {
+        .classic => fortalResolveColor(context, FortalTokens.gray1),
+        .soft => fortalResolveColor(context, FortalTokens.grayA3),
+      });
 
-  if (variant == FortalKbdVariant.classic) {
+  if (variant == .classic) {
     style = style.containerEffects(
       RemixBoxEffectsMix.behindContent(
         RemixBoxEffectLayerMix(shadows: _fortalKbdShadows(context, fontSize)),

--- a/packages/remix_fortal/lib/src/recipes/menu.dart
+++ b/packages/remix_fortal/lib/src/recipes/menu.dart
@@ -143,9 +143,10 @@ MenuItemStyler _fortalMenuSubmenuItemStyler(
     highContrast: highContrast,
   );
   final submenuOpen = MenuItemStyler()
-      .color(
-        variant == .solid ? FortalTokens.grayA3() : FortalTokens.accentA3(),
-      )
+      .color(switch (variant) {
+        .solid => FortalTokens.grayA3(),
+        .soft => FortalTokens.accentA3(),
+      })
       .onHovered(highlighted)
       // Roving `data-highlighted` state, not a focus-visible ring.
       .onFocused(highlighted)

--- a/packages/remix_fortal/lib/src/recipes/menu.dart
+++ b/packages/remix_fortal/lib/src/recipes/menu.dart
@@ -62,7 +62,6 @@ MenuItemStyler fortalMenuItemStyle({
 /// content treatment (gap, text token, icon) without button chrome.
 MenuTriggerStyler _fortalMenuTriggerStyler(_FortalMenuMetrics metrics) =>
     MenuTriggerStyler()
-        .crossAxisAlignment(.center)
         .spacing(metrics.triggerGap)
         .label(.style(metrics.text.mix()).color(FortalTokens.gray12()))
         .icon(.color(FortalTokens.gray12()).size(metrics.contentIconSize));
@@ -74,8 +73,6 @@ MenuItemStyler _fortalMenuItemStyler(
 }) {
   final base = MenuItemStyler()
       .direction(.horizontal)
-      .mainAxisSize(.max)
-      .crossAxisAlignment(.center)
       .spacing(FortalTokens.space2())
       .height(metrics.itemHeight)
       .padding(.horizontal(metrics.leadingInset))

--- a/packages/remix_fortal/lib/src/recipes/progress.dart
+++ b/packages/remix_fortal/lib/src/recipes/progress.dart
@@ -52,14 +52,10 @@ ProgressStyler _fortalProgressClassicStyler(
 }) {
   return _fortalProgressBaseStyler(size)
       .trackColor(FortalTokens.grayA3())
-      .trackEffects(RemixBoxEffectsMix.behindContent(_fortalProgressLayer()))
       .trackEffects(
         RemixBoxEffectsMix.overContent(
           _fortalProgressLayer(shadowToken: FortalTokens.shadow1Layers),
         ),
-      )
-      .indicatorEffects(
-        RemixBoxEffectsMix.behindContent(_fortalProgressLayer()),
       )
       .indicatorColor(
         highContrast ? FortalTokens.accent12() : FortalTokens.accentTrack(),
@@ -72,7 +68,6 @@ ProgressStyler _fortalProgressSurfaceStyler(
 }) {
   return _fortalProgressBaseStyler(size)
       .trackColor(FortalTokens.grayA3())
-      .trackEffects(RemixBoxEffectsMix.behindContent(_fortalProgressLayer()))
       .trackEffects(
         RemixBoxEffectsMix.overContent(
           _fortalProgressLayer(
@@ -85,9 +80,6 @@ ProgressStyler _fortalProgressSurfaceStyler(
             ],
           ),
         ),
-      )
-      .indicatorEffects(
-        RemixBoxEffectsMix.behindContent(_fortalProgressLayer()),
       )
       .indicatorColor(
         highContrast ? FortalTokens.accent12() : FortalTokens.accentTrack(),
@@ -103,12 +95,6 @@ ProgressStyler _fortalProgressSoftStyler(
       .track(
         .foregroundDecoration(BoxDecorationMix(color: FortalTokens.whiteA1())),
       )
-      .trackEffects(RemixBoxEffectsMix.behindContent(_fortalProgressLayer()))
-      .trackEffects(RemixBoxEffectsMix.overContent(_fortalProgressLayer()))
-      .indicatorEffects(
-        RemixBoxEffectsMix.behindContent(_fortalProgressLayer()),
-      )
-      .indicatorEffects(RemixBoxEffectsMix.overContent(_fortalProgressLayer()))
       .indicatorColor(
         highContrast ? FortalTokens.accent12() : FortalTokens.accent8(),
       )

--- a/packages/remix_fortal/lib/src/recipes/select.dart
+++ b/packages/remix_fortal/lib/src/recipes/select.dart
@@ -40,7 +40,6 @@ SelectTriggerStyler _fortalSelectTriggerStyler(
   final base = SelectTriggerStyler()
       .direction(.horizontal)
       .mainAxisAlignment(.spaceBetween)
-      .crossAxisAlignment(.center)
       .borderRadius(.all(radius))
       .label(_fortalSelectTriggerText(size, color: FortalTokens.gray12()))
       .placeholder(
@@ -232,7 +231,6 @@ SelectMenuItemStyler _fortalSelectItemStyler(
   final metrics = _fortalSelectContentMetrics(size);
   final base = SelectMenuItemStyler()
       .direction(.horizontal)
-      .crossAxisAlignment(.center)
       .height(metrics.itemHeight)
       .padding(.horizontal(metrics.indicatorWidth))
       .borderRadius(.all(metrics.itemRadius))

--- a/packages/remix_fortal/lib/src/recipes/select.dart
+++ b/packages/remix_fortal/lib/src/recipes/select.dart
@@ -87,8 +87,8 @@ SelectTriggerStyler _fortalSelectTriggerSizeStyler(
     .size2 => FortalTokens.selectSpace1Half(),
     .size3 => FortalTokens.space2(),
   });
-  if (variant == .ghost) {
-    return switch (size) {
+  return switch (variant) {
+    .ghost => switch (size) {
       .size1 || .size2 =>
         style
             .padding(.horizontal(FortalTokens.space2()))
@@ -101,21 +101,21 @@ SelectTriggerStyler _fortalSelectTriggerSizeStyler(
             .padding(.vertical(FortalTokens.selectSpace1Half()))
             .margin(.horizontal(FortalTokens.selectGhostMarginX3()))
             .margin(.vertical(FortalTokens.selectGhostMarginY3())),
-    };
-  }
-  return switch (size) {
-    .size1 =>
-      style
-          .height(FortalTokens.space5())
-          .padding(.horizontal(FortalTokens.space2())),
-    .size2 =>
-      style
-          .height(FortalTokens.space6())
-          .padding(.horizontal(FortalTokens.space3())),
-    .size3 =>
-      style
-          .height(FortalTokens.space7())
-          .padding(.horizontal(FortalTokens.space4())),
+    },
+    .surface || .soft => switch (size) {
+      .size1 =>
+        style
+            .height(FortalTokens.space5())
+            .padding(.horizontal(FortalTokens.space2())),
+      .size2 =>
+        style
+            .height(FortalTokens.space6())
+            .padding(.horizontal(FortalTokens.space3())),
+      .size3 =>
+        style
+            .height(FortalTokens.space7())
+            .padding(.horizontal(FortalTokens.space4())),
+    },
   };
 }
 
@@ -205,12 +205,16 @@ SelectTriggerStyler _fortalSelectGhostTrigger(SelectTriggerStyler base) {
 }
 
 SelectContentStyler _fortalSelectContentStyler(FortalSelectSize size) {
-  final radius = size == .size1
-      ? FortalTokens.radius3()
-      : FortalTokens.radius4();
+  final radius = switch (size) {
+    .size1 => FortalTokens.radius3(),
+    .size2 || .size3 => FortalTokens.radius4(),
+  };
   return SelectContentStyler()
       .padding(
-        .all(size == .size1 ? FortalTokens.space1() : FortalTokens.space2()),
+        .all(switch (size) {
+          .size1 => FortalTokens.space1(),
+          .size2 || .size3 => FortalTokens.space2(),
+        }),
       )
       .borderRadius(.all(radius))
       .color(FortalTokens.colorPanel())

--- a/packages/remix_fortal/lib/src/recipes/slider.dart
+++ b/packages/remix_fortal/lib/src/recipes/slider.dart
@@ -274,9 +274,10 @@ SliderStyler _fortalSliderDisabled(
         BoxStyler().decoration(
           .boxShadow([
             BoxShadowMix(
-              color: variant == .soft
-                  ? FortalTokens.gray5()
-                  : FortalTokens.gray6(),
+              color: switch (variant) {
+                .soft => FortalTokens.gray5(),
+                .classic || .surface => FortalTokens.gray6(),
+              },
               spreadRadius: 1,
             ),
           ]),

--- a/packages/remix_fortal/lib/src/recipes/tabs.dart
+++ b/packages/remix_fortal/lib/src/recipes/tabs.dart
@@ -78,7 +78,6 @@ TabStyler fortalTabStyle({
             .padding(.vertical(metrics.innerPaddingY))
             .borderRadius(.all(metrics.radius))
             .mainAxisAlignment(.center)
-            .crossAxisAlignment(.center)
             .spacing(FortalTokens.space2()),
       )
       .onHovered(

--- a/packages/remix_fortal/lib/src/recipes/textfield.dart
+++ b/packages/remix_fortal/lib/src/recipes/textfield.dart
@@ -60,9 +60,10 @@ TextFieldStyler fortalTextFieldStyle({
     spacing: metrics.spacing,
     crossAxisAlignment: .center,
     text: metrics.text,
-    focusColor: variant == .soft
-        ? FortalTokens.accent8()
-        : FortalTokens.focus8(),
+    focusColor: switch (variant) {
+      .soft => FortalTokens.accent8(),
+      .classic || .surface => FortalTokens.focus8(),
+    },
   );
 
   final style = switch (variant) {
@@ -333,9 +334,10 @@ TextFieldStyler fortalTextAreaStyle({
     spacing: metrics.spacing,
     crossAxisAlignment: .start,
     text: metrics.text,
-    focusColor: variant == .soft
-        ? FortalTokens.accent8()
-        : FortalTokens.focus8(),
+    focusColor: switch (variant) {
+      .soft => FortalTokens.accent8(),
+      .classic || .surface => FortalTokens.focus8(),
+    },
   );
 
   final style = switch (variant) {

--- a/packages/remix_fortal/reference/radix_themes_3_3_0/README.md
+++ b/packages/remix_fortal/reference/radix_themes_3_3_0/README.md
@@ -22,8 +22,9 @@ so a new family fails the gate until both the Fortal mapping and the
 family-independent upstream record are written.
 
 CheckboxGroup is separately audited in `unmappedUpstreamFamilies`: Remix's
-nonvisual coordinator composes the mapped checkbox recipe on each item, but it
-does not claim Radix's root/item spacing and inherited visual-prop anatomy.
+nonvisual coordinator leaves root direction and spacing caller-owned, while
+`FortalCheckboxGroupItem` maps the checkbox visuals plus Radix's size-linked
+item typography and scaled 6/7/8 label gaps.
 
 Every intentional difference is listed in `approximations`. In addition to the
 Dialog `modal: false` interaction boundary and Menu's flex-based row geometry,

--- a/packages/remix_fortal/reference/radix_themes_3_3_0/manifest.json
+++ b/packages/remix_fortal/reference/radix_themes_3_3_0/manifest.json
@@ -4783,11 +4783,12 @@
         "layout": {
           "rootGap": "space1",
           "itemLabelGap": "0.5em"
-        }
+        },
+        "itemTypography": "Text size1/text1, size2/text2, and size3/text3"
       },
-      "supportedRemixComposition": "Use RemixCheckboxGroup for selection, roving focus, semantics, and item layout transparency; render each option as FortalCheckboxGroupItem(size:, variant:, highContrast:), which applies the checkbox recipe for you, and let the caller own the root and label spacing. Callers that need a per-item override can still pass fortalCheckboxStyle(...) to RemixCheckboxGroupItem.style directly.",
-      "reason": "RemixCheckboxGroup deliberately owns no visual or layout anatomy, so generating a FortalCheckboxGroup wrapper would invent a style surface that the underlying coordinator does not have.",
-      "reopenCondition": "Map this family only if RemixCheckboxGroup gains a visual root/item-label anatomy that can express the pinned gaps and inherited size, variant, color, and highContrast contract without a Fortal-only wrapper."
+      "supportedRemixComposition": "Use RemixCheckboxGroup for selection, roving focus, semantics, and layout transparency; render each option as FortalCheckboxGroupItem(size:, variant:, highContrast:), which maps the checkbox recipe, size-linked text1/text2/text3 label typography, and scaled 6/7/8 item-label gaps. The caller continues to own root direction and spacing. Callers that need a per-item override can pass a CheckboxStyler to RemixCheckboxGroupItem.style directly.",
+      "reason": "RemixCheckboxGroup deliberately owns no visual or root-layout anatomy, so generating a FortalCheckboxGroup wrapper would invent a root style surface that the underlying coordinator does not have. FortalCheckboxGroupItem maps the item-level typography, label gap, and checkbox visuals independently.",
+      "reopenCondition": "Map the remaining root contract only if RemixCheckboxGroup gains layout anatomy that can express the pinned root direction and gap without a Fortal-only wrapper."
     }
   ],
   "referenceFixtures": {

--- a/packages/remix_fortal/test/components/checkbox/checkbox_group_widget_test.dart
+++ b/packages/remix_fortal/test/components/checkbox/checkbox_group_widget_test.dart
@@ -50,9 +50,13 @@ void main() {
   testWidgets(
     'fortalCheckboxGroupItemStyle preserves checkbox anatomy across the matrix',
     (tester) async {
-      // Item-only label metrics layer on top of the checkbox recipe. The
-      // checkbox square, indicator bounds, and effects must still resolve
-      // identically for every variant/size/high-contrast combination.
+      // Item-only label metrics layer on top of the checkbox recipe, so the
+      // resolved specs must stay equal on everything else. Deliberate: this
+      // exempts `label`/`labelSpacing` by substitution rather than comparing
+      // the remaining fields one by one, so the StyleSpec's animation and
+      // widget modifiers keep their coverage instead of silently dropping out
+      // of the assertion. `label`/`labelSpacing` are pinned by the typography
+      // test below.
       for (final variant in FortalCheckboxVariant.values) {
         for (final size in FortalCheckboxSize.values) {
           for (final highContrast in const [false, true]) {
@@ -75,19 +79,16 @@ void main() {
             );
 
             expect(
-              wrapped.spec.container,
-              equals(direct.spec.container),
-              reason: '$reason/container',
-            );
-            expect(
-              wrapped.spec.indicator,
-              equals(direct.spec.indicator),
-              reason: '$reason/indicator',
-            );
-            expect(
-              wrapped.spec.containerEffects,
-              equals(direct.spec.containerEffects),
-              reason: '$reason/effects',
+              wrapped,
+              equals(
+                direct.copyWith(
+                  spec: direct.spec.copyWith(
+                    label: wrapped.spec.label,
+                    labelSpacing: wrapped.spec.labelSpacing,
+                  ),
+                ),
+              ),
+              reason: reason,
             );
           }
         }

--- a/packages/remix_fortal/test/components/checkbox/checkbox_group_widget_test.dart
+++ b/packages/remix_fortal/test/components/checkbox/checkbox_group_widget_test.dart
@@ -48,12 +48,11 @@ void main() {
   });
 
   testWidgets(
-    'fortalCheckboxGroupItemStyle delegates across the whole matrix',
+    'fortalCheckboxGroupItemStyle preserves checkbox anatomy across the matrix',
     (tester) async {
-      // The wrapper's only job is to forward variant/size/highContrast into the
-      // checkbox recipe, so every combination must resolve identically — not
-      // just the default one. `CheckboxStyler` has no value equality (unlike
-      // `ToggleGroupStyler`), so this compares the resolved specs instead.
+      // Item-only label metrics layer on top of the checkbox recipe. The
+      // checkbox square, indicator bounds, and effects must still resolve
+      // identically for every variant/size/high-contrast combination.
       for (final variant in FortalCheckboxVariant.values) {
         for (final size in FortalCheckboxSize.values) {
           for (final highContrast in const [false, true]) {
@@ -75,12 +74,93 @@ void main() {
               ),
             );
 
-            expect(wrapped, equals(direct), reason: reason);
+            expect(
+              wrapped.spec.container,
+              equals(direct.spec.container),
+              reason: '$reason/container',
+            );
+            expect(
+              wrapped.spec.indicator,
+              equals(direct.spec.indicator),
+              reason: '$reason/indicator',
+            );
+            expect(
+              wrapped.spec.containerEffects,
+              equals(direct.spec.containerEffects),
+              reason: '$reason/effects',
+            );
           }
         }
       }
     },
   );
+
+  testWidgets('links item typography and gaps to size and theme scaling', (
+    tester,
+  ) async {
+    const metrics =
+        <
+          FortalCheckboxSize,
+          ({
+            double fontSize,
+            double lineHeight,
+            double letterSpacing,
+            double gap,
+          })
+        >{
+          FortalCheckboxSize.size1: (
+            fontSize: 12,
+            lineHeight: 16 / 12,
+            letterSpacing: 0.0025 * 12,
+            gap: 6,
+          ),
+          FortalCheckboxSize.size2: (
+            fontSize: 14,
+            lineHeight: 20 / 14,
+            letterSpacing: 0,
+            gap: 7,
+          ),
+          FortalCheckboxSize.size3: (
+            fontSize: 16,
+            lineHeight: 24 / 16,
+            letterSpacing: 0,
+            gap: 8,
+          ),
+        };
+
+    for (final scaling in FortalScaling.values) {
+      for (final entry in metrics.entries) {
+        final resolved = await _resolveCheckboxStyle(
+          tester,
+          fortalCheckboxGroupItemStyle(size: entry.key),
+          scaling: scaling,
+        );
+        final label = resolved.spec.label.spec.style!;
+        final reason = '${scaling.name}/${entry.key.name}';
+
+        expect(
+          label.fontSize,
+          closeTo(entry.value.fontSize * scaling.factor, 1e-9),
+          reason: '$reason/fontSize',
+        );
+        expect(
+          label.height,
+          closeTo(entry.value.lineHeight, 1e-9),
+          reason: '$reason/height',
+        );
+        expect(
+          label.letterSpacing,
+          closeTo(entry.value.letterSpacing * scaling.factor, 1e-9),
+          reason: '$reason/letterSpacing',
+        );
+        expect(
+          resolved.spec.labelSpacing,
+          closeTo(entry.value.gap * scaling.factor, 1e-9),
+          reason: '$reason/gap',
+        );
+      }
+    }
+  });
 
   testWidgets('FortalCheckboxGroupItem participates in group selection', (
     tester,
@@ -109,12 +189,14 @@ Finder _itemAt(int index) =>
 
 Future<StyleSpec<CheckboxSpec>> _resolveCheckboxStyle(
   WidgetTester tester,
-  CheckboxStyler style,
-) async {
+  CheckboxStyler style, {
+  FortalScaling scaling = .percent100,
+}) async {
   late StyleSpec<CheckboxSpec> resolved;
 
   await tester.pumpWidget(
     FortalScope(
+      scaling: scaling,
       child: MaterialApp(
         home: Builder(
           builder: (context) {

--- a/packages/remix_fortal/test/components/checkbox/checkbox_labeled_test.dart
+++ b/packages/remix_fortal/test/components/checkbox/checkbox_labeled_test.dart
@@ -5,6 +5,9 @@ import 'package:flutter_test/flutter_test.dart';
 // Suppressed per-use below, so a future accidental internal-member use still
 // gets flagged.
 import 'package:remix/src/rendering/remix_box_effects.dart';
+// Deliberate: RemixPathIcon/RemixPathGlyph stay unexported, but this sibling
+// package verifies Fortal's pinned Radix checkbox defaults at the widget edge.
+import 'package:remix/src/utilities/remix_path_icon.dart';
 import 'package:remix_fortal/remix_fortal.dart';
 
 import '../../helpers/test_helpers.dart';
@@ -44,6 +47,53 @@ void main() {
       }
     });
 
+    testWidgets('uses thick Radix indicators at every checkbox size', (
+      tester,
+    ) async {
+      const expectedIndicatorSizes = <FortalCheckboxSize, double>{
+        FortalCheckboxSize.size1: 9,
+        FortalCheckboxSize.size2: 10,
+        FortalCheckboxSize.size3: 12,
+      };
+
+      for (final entry in expectedIndicatorSizes.entries) {
+        await tester.pumpRemixApp(
+          FortalCheckbox(size: entry.key, selected: true, onChanged: (_) {}),
+        );
+
+        expect(
+          _pathGlyph(RemixPathGlyph.thickCheck),
+          findsOneWidget,
+          reason: '${entry.key.name}/checked',
+        );
+        expect(
+          tester.getSize(find.byType(RemixPathIcon)),
+          Size.square(entry.value),
+          reason: '${entry.key.name}/checked',
+        );
+
+        await tester.pumpRemixApp(
+          FortalCheckbox(
+            size: entry.key,
+            selected: null,
+            tristate: true,
+            onChanged: (_) {},
+          ),
+        );
+
+        expect(
+          _pathGlyph(RemixPathGlyph.thickDividerHorizontal),
+          findsOneWidget,
+          reason: '${entry.key.name}/indeterminate',
+        );
+        expect(
+          tester.getSize(find.byType(RemixPathIcon)),
+          Size.square(entry.value),
+          reason: '${entry.key.name}/indeterminate',
+        );
+      }
+    });
+
     test('generated wrapper forwards label and minimum target size', () {
       const checkbox = FortalCheckbox.surface(
         selected: false,
@@ -56,3 +106,7 @@ void main() {
     });
   });
 }
+
+Finder _pathGlyph(RemixPathGlyph glyph) => find.byWidgetPredicate(
+  (widget) => widget is RemixPathIcon && widget.glyph == glyph,
+);


### PR DESCRIPTION
## Description

Fixes visual regressions in the dashboard showcase and the Remix/Fortal
recipes behind it, then cleans up the dead and redundant code the fixes
exposed.

### Fixes

- `RemixCheckbox` now uses Radix's `thickCheck` and `thickDividerHorizontal`
  glyphs instead of the thinner `check`/`dash`, so checked and indeterminate
  indicators match upstream at every size.
- `FortalIconButton.ghost` is square again. An aligned `Box` with no fixed
  size expands to fill, which stretched the top-bar buttons to the full bar
  height; the alignment now applies only to the fixed-size variants.
- Inset shadows clip before filtering rather than erasing afterward, which
  left blur fringes outside the shape on Flutter Web.
- The avatar gallery no longer clips its largest preset, and the theme-panel
  accent swatch centres its checkmark.
- `fortalCheckboxGroupItemStyle` maps Radix's size-linked `text1`/`text2`/
  `text3` label typography and scaled 6/7/8 label gaps, so group items no
  longer inherit unstyled labels.

### Cleanup

- Base-button metrics dispatch on a shared `FortalBaseButtonSize` enum
  instead of a raw `int` reached via `size.index + 1`. Four switches were
  non-exhaustive behind `_ => throw ArgumentError`; adding a fifth size used
  to analyze clean and throw at runtime, and is now a compile error.
- Six further enum dispatches that used a ternary or `if` — including one in
  `base_button_state_styles.dart` shared by both button recipes — are now
  exhaustive switches, so a new variant fails to compile rather than silently
  taking the else branch.
- Removed dead code: the unused `dash`/`check` path glyphs, an identity
  `saveLayer` left over from the inset-shadow rewrite, eight progress effect
  layers that merged nothing, and ten flex calls that restated mix's own
  defaults (`?? .start` / `?? .max` / `?? .center`).

## Validation

- `melos run ci` — all eight gates pass, including `generate:check`,
  `docs:check`, and `fortal:parity:check`
- Tests: 2,675 Remix, 389 Fortal, 56 dashboard, 30 demo
- `flutter analyze` — no issues
- Behaviour-preserving claims were checked by measurement, not inspection:
  the inset-shadow painter change and the progress-layer removal were both
  verified pixel- and spec-identical before and after.
