### PR TITLE
chore(release): version packages 1.0.0-beta.6

### DIFF
--- a/apps/dashboard/pubspec.yaml
+++ b/apps/dashboard/pubspec.yaml
@@ -14,8 +14,8 @@ dependencies:
   # Workspace resolution uses the local packages during development; these
   # hosted constraints keep the app manifest deployable outside the workspace.
   mix_chart: ^0.0.1-beta.1
-  remix: ^1.0.0-beta.5
-  remix_fortal: ^1.0.0-beta.5
+  remix: ^1.0.0-beta.6
+  remix_fortal: ^1.0.0-beta.6
 
 dev_dependencies:
   flutter_test:

--- a/apps/demo/pubspec.yaml
+++ b/apps/demo/pubspec.yaml
@@ -20,8 +20,8 @@ dependencies:
   widgetbook: ^3.25.0
   # Workspace resolution uses the local packages during development; these
   # hosted constraints keep the app manifest deployable outside the workspace.
-  remix: ^1.0.0-beta.5
-  remix_fortal: ^1.0.0-beta.5
+  remix: ^1.0.0-beta.6
+  remix_fortal: ^1.0.0-beta.6
 
 dev_dependencies:
   flutter_test:

--- a/apps/playground/pubspec.yaml
+++ b/apps/playground/pubspec.yaml
@@ -14,8 +14,8 @@ dependencies:
   cupertino_icons: ^1.0.8
   # Workspace resolution uses the local packages during development; these
   # hosted constraints keep the app manifest deployable outside the workspace.
-  remix: ^1.0.0-beta.5
-  remix_fortal: ^1.0.0-beta.5
+  remix: ^1.0.0-beta.6
+  remix_fortal: ^1.0.0-beta.6
 
 dev_dependencies:
   flutter_test:

--- a/packages/remix/CHANGELOG.md
+++ b/packages/remix/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-beta.6
+
+ - **FIX**: correct dashboard showcase and checkbox indicator regressions (#162).
+
 ## 1.0.0-beta.5
 
 > Note: This release has breaking changes.

--- a/packages/remix/pubspec.yaml
+++ b/packages/remix/pubspec.yaml
@@ -12,7 +12,7 @@ topics:
   - styling
   - mix
 
-version: 1.0.0-beta.5
+version: 1.0.0-beta.6
 
 # Consumer floor, matching `mix` and `naked_ui`. Intentionally lower than the
 # workspace's own toolchain floor: dev tooling needs a newer SDK than the

--- a/packages/remix_fortal/CHANGELOG.md
+++ b/packages/remix_fortal/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-beta.6
+
+ - **FIX**: correct dashboard showcase and checkbox indicator regressions (#162).
+
 ## 1.0.0-beta.5
 
 > Note: This release has breaking changes.

--- a/packages/remix_fortal/pubspec.yaml
+++ b/packages/remix_fortal/pubspec.yaml
@@ -15,7 +15,7 @@ topics:
 # Pre-release because every dependency below is itself a pre-release; pub warns
 # when a stable package is built on beta foundations. Graduate to 0.1.0 when
 # remix reaches 1.0.0 stable.
-version: 1.0.0-beta.5
+version: 1.0.0-beta.6
 
 # Consumer floor, matching `remix` and `mix`. See packages/remix/pubspec.yaml.
 environment:
@@ -37,7 +37,7 @@ dependencies:
   # package. `tool/fortal_parity/check.dart` (_checkRemixHostedPin) fails if the
   # two ever fall out of sync. `melos version` rewrites this line when `remix`
   # bumps, because remix_fortal depends on it.
-  remix: ^1.0.0-beta.5
+  remix: ^1.0.0-beta.6
   mix: ^2.2.0-beta.5
   mix_annotations: ^2.2.0-beta.1
   mix_chart: ^0.0.1-beta.1


### PR DESCRIPTION
## Description

Sets both published packages to `1.0.0-beta.6` and writes their changelogs. Produced by the same command `.github/workflows/version.yml` runs:

```
melos version --no-git-commit-version --yes -V remix:1.0.0-beta.6 -V remix_fortal:1.0.0-beta.6
```

Changes:

- `packages/remix` and `packages/remix_fortal` → `1.0.0-beta.6`
- `remix_fortal`'s hosted pin → `remix: ^1.0.0-beta.6`
- App manifests' hosted constraints (`dashboard`, `demo`, `playground`) → `^1.0.0-beta.6`
- Changelog entry in both packages for #162

This is the release PR the template's note refers to, so the `pubspec.yaml` / `CHANGELOG.md` edits are the entire point of it rather than an omission. No library code changes, so no new tests.

## Related Issues

None.

## Verification

Ran locally on this branch, all passing:

- `tool/check_version_alignment.dart` — both packages on `1.0.0-beta.6`
- `tool/check_consumer_mix.dart` — Mix floors resolve as declared
- `tool/check_toolchain.dart` — 2 published packages on Flutter >=3.41.0, 4 workspace-only on >=3.44.0
- `tool/fortal_parity/check.dart` — Radix 3.3.0 contract and the hosted `remix` pin

## After merge

Tags pushed one at a time, per the contract in `publish.yml`:

1. `v1.0.0-beta.6` — publishes `remix`
2. `remix-v1.0.0-beta.6` — bookkeeping tag `melos version` reads; triggers nothing
3. `remix_fortal-v1.0.0-beta.6` — publishes `remix_fortal`, only once pub.dev serves `remix 1.0.0-beta.6`

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.