### PR TITLE
refactor(remix): simplify composite surface rendering

### DIFF
--- a/packages/remix/lib/src/components/accordion/accordion_widget.dart
+++ b/packages/remix/lib/src/components/accordion/accordion_widget.dart
@@ -320,7 +320,7 @@ class _RemixAccordionBodyState<T> extends State<_RemixAccordionBody<T>> {
     // interior seam is a plain divider rather than two independently
     // rounded boxes. See fortalAccordionStyle for the divider half of that
     // treatment.
-    return RemixBoxWithEffects(
+    return RemixBoxAdapter(
       styleSpec: spec.container,
       containerEffects: spec.containerEffects,
       child: NakedAccordion<T>(

--- a/packages/remix/lib/src/components/badge/badge_widget.dart
+++ b/packages/remix/lib/src/components/badge/badge_widget.dart
@@ -59,7 +59,7 @@ class RemixBadge extends StatelessWidget {
                 icon: StyleSpec(spec: IconSpec(color: foreground)),
                 child: child!,
               );
-        return RemixBoxWithEffects(
+        return RemixBoxAdapter(
           styleSpec: spec.container,
           containerEffects: spec.containerEffects,
           child: content,

--- a/packages/remix/lib/src/components/button/button_widget.dart
+++ b/packages/remix/lib/src/components/button/button_widget.dart
@@ -249,7 +249,7 @@ class RemixButton extends StatelessWidget {
         .toList();
 
     // Create content row with visibility control for loading state
-    final contentRow = RemixFlexBoxWithEffects(
+    final contentRow = RemixFlexBoxAdapter(
       styleSpec: spec.container,
       direction: Axis.horizontal,
       containerEffects: spec.containerEffects,

--- a/packages/remix/lib/src/components/callout/callout_widget.dart
+++ b/packages/remix/lib/src/components/callout/callout_widget.dart
@@ -52,7 +52,7 @@ class RemixCallout extends StatelessWidget {
       builder: (context, spec) {
         // For raw constructor, use provided child directly
         if (child != null) {
-          return RemixFlexBoxWithEffects(
+          return RemixFlexBoxAdapter(
             styleSpec: spec.container,
             direction: Axis.horizontal,
             containerEffects: spec.containerEffects,
@@ -83,7 +83,7 @@ class RemixCallout extends StatelessWidget {
           );
         }
 
-        return RemixFlexBoxWithEffects(
+        return RemixFlexBoxAdapter(
           styleSpec: spec.container,
           direction: Axis.horizontal,
           containerEffects: spec.containerEffects,

--- a/packages/remix/lib/src/components/card/card_widget.dart
+++ b/packages/remix/lib/src/components/card/card_widget.dart
@@ -45,7 +45,7 @@ class RemixCard extends StatelessWidget {
       style: style,
       styleSpec: styleSpec,
       builder: (context, spec) {
-        return RemixBoxWithEffects(
+        return RemixBoxAdapter(
           styleSpec: spec.container,
           containerEffects: spec.containerEffects,
           child: child,

--- a/packages/remix/lib/src/components/checkbox/checkbox_widget.dart
+++ b/packages/remix/lib/src/components/checkbox/checkbox_widget.dart
@@ -165,7 +165,7 @@ class RemixCheckbox extends StatelessWidget {
               (false, null) => null,
             };
 
-            final checkbox = RemixBoxWithEffects(
+            final checkbox = RemixBoxAdapter(
               styleSpec: spec.container,
               containerEffects: spec.containerEffects,
               child: indicator,

--- a/packages/remix/lib/src/components/data_table/data_table_widget.dart
+++ b/packages/remix/lib/src/components/data_table/data_table_widget.dart
@@ -711,7 +711,7 @@ class _RemixDataTableViewState<T> extends State<_RemixDataTableView<T>> {
       ],
     );
 
-    return RemixBoxWithEffects(
+    return RemixBoxAdapter(
       styleSpec: _spec.container,
       containerEffects: _spec.containerEffects,
       child: LayoutBuilder(

--- a/packages/remix/lib/src/components/dialog/dialog_widget.dart
+++ b/packages/remix/lib/src/components/dialog/dialog_widget.dart
@@ -229,7 +229,7 @@ class RemixDialog extends StatelessWidget {
 
         // Skip the default column so a fully custom body keeps its layout.
         if (isLoneChild) {
-          return RemixBoxWithEffects(
+          return RemixBoxAdapter(
             styleSpec: spec.container,
             containerEffects: spec.containerEffects,
             child: child!,
@@ -250,7 +250,7 @@ class RemixDialog extends StatelessWidget {
             : null;
 
         // title → description → child → actions; never discard provided content.
-        return RemixBoxWithEffects(
+        return RemixBoxAdapter(
           styleSpec: spec.container,
           containerEffects: spec.containerEffects,
           child: scrollable && hasBody

--- a/packages/remix/lib/src/components/icon_button/icon_button_widget.dart
+++ b/packages/remix/lib/src/components/icon_button/icon_button_widget.dart
@@ -111,7 +111,7 @@ class RemixIconButton extends StatelessWidget {
             maintainSize: true,
             child: _buildIcon(context, spec.icon),
           );
-          final button = RemixBoxWithEffects(
+          final button = RemixBoxAdapter(
             key: const ValueKey('remix-icon-button-surface'),
             styleSpec: spec.container,
             containerEffects: spec.containerEffects,

--- a/packages/remix/lib/src/components/link/link_widget.dart
+++ b/packages/remix/lib/src/components/link/link_widget.dart
@@ -117,7 +117,7 @@ class RemixLink extends StatelessWidget {
             child: child!,
           );
 
-    return RemixBoxWithEffects(
+    return RemixBoxAdapter(
       styleSpec: spec.container,
       containerEffects: spec.containerEffects,
       child: content,

--- a/packages/remix/lib/src/components/menu/menu_widget.dart
+++ b/packages/remix/lib/src/components/menu/menu_widget.dart
@@ -581,7 +581,7 @@ class _RemixMenuItemsPanel<T> extends StatelessWidget {
           item is RemixMenuCheckboxItem<T> || item is RemixMenuRadioGroup<T>,
     );
 
-    return RemixFlexBoxWithEffects(
+    return RemixFlexBoxAdapter(
       styleSpec: overlayStyleSpec,
       direction: Axis.vertical,
       containerEffects: containerEffects,

--- a/packages/remix/lib/src/components/popover/popover_widget.dart
+++ b/packages/remix/lib/src/components/popover/popover_widget.dart
@@ -85,7 +85,7 @@ class RemixPopover extends StatelessWidget {
       builder: (context, spec) {
         return NakedPopover(
           popoverBuilder: (context, info) {
-            return RemixBoxWithEffects(
+            return RemixBoxAdapter(
               styleSpec: spec.container,
               containerEffects: spec.containerEffects,
               child: popoverChild,

--- a/packages/remix/lib/src/components/progress/progress_widget.dart
+++ b/packages/remix/lib/src/components/progress/progress_widget.dart
@@ -59,7 +59,7 @@ class RemixProgress extends StatelessWidget {
           child: Stack(
             children: [
               // Track background
-              RemixBoxWithEffects(
+              RemixBoxAdapter(
                 styleSpec: spec.track,
                 containerEffects: spec.trackEffects,
               ),
@@ -70,7 +70,7 @@ class RemixProgress extends StatelessWidget {
 
                   return SizedBox(
                     width: biggestSize.width * value.clamp(0.0, 1.0),
-                    child: RemixBoxWithEffects(
+                    child: RemixBoxAdapter(
                       styleSpec: spec.indicator,
                       containerEffects: spec.indicatorEffects,
                     ),

--- a/packages/remix/lib/src/components/radio/radio_widget.dart
+++ b/packages/remix/lib/src/components/radio/radio_widget.dart
@@ -109,7 +109,7 @@ class RemixRadio<T> extends StatelessWidget {
           styleSpec: styleSpec,
           controller: NakedRadioState.controllerOf<T>(context),
           builder: (context, spec) {
-            return RemixBoxWithEffects(
+            return RemixBoxAdapter(
               styleSpec: spec.container,
               containerEffects: spec.containerEffects,
               child: state.isSelected ? Box(styleSpec: spec.indicator) : null,

--- a/packages/remix/lib/src/components/segmented_control/segmented_control_widget.dart
+++ b/packages/remix/lib/src/components/segmented_control/segmented_control_widget.dart
@@ -294,7 +294,7 @@ class _RemixSegmentedControlItemWidget<T extends Object>
                   child: StyleSpecBuilder<SegmentedControlItemSpec>(
                     styleSpec: _resolveStyle(context),
                     builder: (context, spec) {
-                      return RemixBoxWithEffects(
+                      return RemixBoxAdapter(
                         styleSpec: spec.container,
                         containerEffects: spec.containerEffects,
                         // Equal segments make most surfaces wider than their

--- a/packages/remix/lib/src/components/select/select_widget.dart
+++ b/packages/remix/lib/src/components/select/select_widget.dart
@@ -399,7 +399,7 @@ class _AnimatedOverlayMenuState extends State<_AnimatedOverlayMenu> {
             opacity: fadeAnimation.value,
             child: StyleSpecBuilder<SelectContentSpec>(
               styleSpec: widget.content,
-              builder: (context, spec) => RemixBoxWithEffects(
+              builder: (context, spec) => RemixBoxAdapter(
                 styleSpec: spec.container,
                 containerEffects: spec.containerEffects,
                 child: ColumnBox(
@@ -444,7 +444,7 @@ class _RemixSelectTriggerWidget extends StatelessWidget {
             ? trigger.expandedIcon
             : trigger.collapsedIcon;
 
-        return RemixFlexBoxWithEffects(
+        return RemixFlexBoxAdapter(
           styleSpec: spec.container,
           direction: Axis.horizontal,
           containerEffects: spec.containerEffects,

--- a/packages/remix/lib/src/components/slider/slider_widget.dart
+++ b/packages/remix/lib/src/components/slider/slider_widget.dart
@@ -206,7 +206,7 @@ class RemixSlider extends StatelessWidget {
                                   SizedBox(
                                     width: double.infinity,
                                     height: spec.trackWidth,
-                                    child: RemixBoxWithEffects(
+                                    child: RemixBoxAdapter(
                                       styleSpec: _sliderRailStyle(
                                         spec.track,
                                         color: spec.trackColor,
@@ -224,7 +224,7 @@ class RemixSlider extends StatelessWidget {
                                       child: SizedBox(
                                         width: double.infinity,
                                         height: spec.rangeWidth,
-                                        child: RemixBoxWithEffects(
+                                        child: RemixBoxAdapter(
                                           styleSpec: _sliderRailStyle(
                                             spec.range,
                                             color: spec.rangeColor,
@@ -243,7 +243,7 @@ class RemixSlider extends StatelessWidget {
                       ),
                       Transform.translate(
                         offset: Offset(thumbPosition, 0),
-                        child: RemixBoxWithEffects(
+                        child: RemixBoxAdapter(
                           styleSpec: spec.thumb,
                           containerEffects:
                               (spec.thumbEffects ?? const RemixBoxEffectsSpec())

--- a/packages/remix/lib/src/components/switch/switch_widget.dart
+++ b/packages/remix/lib/src/components/switch/switch_widget.dart
@@ -108,10 +108,10 @@ class RemixSwitch extends StatelessWidget {
           styleSpec: styleSpec,
           controller: NakedToggleState.controllerOf(context),
           builder: (context, spec) {
-            return RemixBoxWithEffects(
+            return RemixBoxAdapter(
               styleSpec: spec.container,
               containerEffects: spec.trackEffects,
-              child: RemixBoxWithEffects(
+              child: RemixBoxAdapter(
                 styleSpec: spec.thumb,
                 containerEffects: spec.thumbEffects,
               ),

--- a/packages/remix/lib/src/components/textfield/textfield_widget.dart
+++ b/packages/remix/lib/src/components/textfield/textfield_widget.dart
@@ -503,7 +503,7 @@ class _RemixTextFieldBodyState extends State<_RemixTextFieldBody> {
       child: nakedTextField,
     );
 
-    final withAccessories = RemixBoxWithEffects(
+    final withAccessories = RemixBoxAdapter(
       styleSpec: spec.container,
       containerEffects: spec.containerEffects,
       child: Row(

--- a/packages/remix/lib/src/rendering/remix_box_adapter.dart
+++ b/packages/remix/lib/src/rendering/remix_box_adapter.dart
@@ -6,7 +6,7 @@ part of 'remix_box_effects.dart';
 /// dedicated [_RemixBoxEffectsRenderer], while CSS-style negative margins are
 /// handled by the independent outer-layout adapter.
 @internal
-final class RemixBoxAdapter extends StatelessWidget {
+final class RemixBoxAdapter extends StatefulWidget {
   const RemixBoxAdapter({
     super.key,
     required this.styleSpec,
@@ -19,11 +19,23 @@ final class RemixBoxAdapter extends StatelessWidget {
   final Widget? child;
 
   @override
+  State<RemixBoxAdapter> createState() => _RemixBoxAdapterState();
+}
+
+final class _RemixBoxAdapterState extends State<RemixBoxAdapter> {
+  final GlobalKey _childKey = GlobalKey(
+    debugLabel: 'RemixBoxAdapter logical child',
+  );
+
+  @override
   Widget build(BuildContext context) {
-    final effects = containerEffects ?? const RemixBoxEffectsSpec();
+    final effects = widget.containerEffects ?? const RemixBoxEffectsSpec();
+    final child = widget.child == null
+        ? null
+        : KeyedSubtree(key: _childKey, child: widget.child!);
     _validateEffects(effects);
     return StyleSpecBuilder<BoxSpec>(
-      styleSpec: styleSpec,
+      styleSpec: widget.styleSpec,
       builder: (context, spec) {
         final margin = spec.margin;
         if (_canUseStandardMixRendering(effects: effects, margin: margin)) {
@@ -82,39 +94,18 @@ final class RemixFlexBoxAdapter extends StatelessWidget {
     return StyleSpecBuilder<FlexBoxSpec>(
       styleSpec: styleSpec,
       builder: (context, spec) {
-        final box = spec.box?.spec;
-        if (_canUseStandardMixRendering(
-          effects: effects,
-          margin: box?.margin,
-        )) {
-          final resolved = StyleSpec(spec: spec);
-          return switch (direction) {
-            Axis.horizontal => RowBox(styleSpec: resolved, children: children),
-            Axis.vertical => ColumnBox(styleSpec: resolved, children: children),
-            null => FlexBox(styleSpec: resolved, children: children),
-          };
-        }
-
-        final flex = spec.flex?.spec;
-        assert(
-          direction == null ||
-              flex?.direction == null ||
-              direction == flex!.direction,
-          'The forced and styled flex directions must agree.',
-        );
-        final content = Flex(
-          direction: flex?.direction ?? direction ?? Axis.horizontal,
-          mainAxisAlignment: flex?.mainAxisAlignment ?? MainAxisAlignment.start,
-          mainAxisSize: flex?.mainAxisSize ?? MainAxisSize.max,
-          crossAxisAlignment:
-              flex?.crossAxisAlignment ?? CrossAxisAlignment.center,
-          textDirection: flex?.textDirection,
-          verticalDirection: flex?.verticalDirection ?? VerticalDirection.down,
-          textBaseline: flex?.textBaseline,
-          clipBehavior: flex?.clipBehavior ?? Clip.none,
-          spacing: flex?.spacing ?? 0,
-          children: children,
-        );
+        final flexStyleSpec = StyleSpec(spec: FlexBoxSpec(flex: spec.flex));
+        final content = switch (direction) {
+          Axis.horizontal => RowBox(
+            styleSpec: flexStyleSpec,
+            children: children,
+          ),
+          Axis.vertical => ColumnBox(
+            styleSpec: flexStyleSpec,
+            children: children,
+          ),
+          null => FlexBox(styleSpec: flexStyleSpec, children: children),
+        };
         return RemixBoxAdapter(
           styleSpec: spec.box ?? const StyleSpec(spec: BoxSpec()),
           containerEffects: effects,

--- a/packages/remix/lib/src/rendering/remix_box_adapter.dart
+++ b/packages/remix/lib/src/rendering/remix_box_adapter.dart
@@ -1,10 +1,10 @@
 part of 'remix_box_effects.dart';
 
-/// Routes a resolved Mix [Box] surface through the simplest valid renderer.
+/// Routes a resolved Mix [Box] through the simplest compatible renderer.
 ///
-/// Ordinary surfaces remain real Mix Boxes. Only non-empty advanced effects
-/// use [_RemixAdvancedSurface], while CSS-style negative margins are handled by
-/// the independent outer-layout adapter.
+/// Ordinary boxes stay on Mix's standard renderer. Advanced effects use the
+/// dedicated [_RemixBoxEffectsRenderer], while CSS-style negative margins are
+/// handled by the independent outer-layout adapter.
 @internal
 final class RemixBoxAdapter extends StatelessWidget {
   const RemixBoxAdapter({
@@ -26,7 +26,7 @@ final class RemixBoxAdapter extends StatelessWidget {
       styleSpec: styleSpec,
       builder: (context, spec) {
         final margin = spec.margin;
-        if (effects.isEmpty && (margin == null || margin.isNonNegative)) {
+        if (_canUseStandardMixRendering(effects: effects, margin: margin)) {
           return Box(
             styleSpec: StyleSpec(spec: spec),
             child: child,
@@ -42,9 +42,9 @@ final class RemixBoxAdapter extends StatelessWidget {
           );
         } else {
           _validateBoxDecoration(spec.decoration);
-          inner = _RemixAdvancedSurface(
+          inner = _RemixBoxEffectsRenderer(
             spec: innerSpec,
-            containerEffects: effects,
+            effects: effects,
             child: child,
           );
         }
@@ -83,8 +83,10 @@ final class RemixFlexBoxAdapter extends StatelessWidget {
       styleSpec: styleSpec,
       builder: (context, spec) {
         final box = spec.box?.spec;
-        final margin = box?.margin;
-        if (effects.isEmpty && (margin == null || margin.isNonNegative)) {
+        if (_canUseStandardMixRendering(
+          effects: effects,
+          margin: box?.margin,
+        )) {
           final resolved = StyleSpec(spec: spec);
           return switch (direction) {
             Axis.horizontal => RowBox(styleSpec: resolved, children: children),
@@ -123,47 +125,54 @@ final class RemixFlexBoxAdapter extends StatelessWidget {
   }
 }
 
-void _validateEffects(RemixBoxEffectsSpec containerEffects) {
-  if (!containerEffects.backdropBlur.isFinite) {
+bool _canUseStandardMixRendering({
+  required RemixBoxEffectsSpec effects,
+  EdgeInsetsGeometry? margin,
+}) => effects.isEmpty && (margin == null || margin.isNonNegative);
+
+/// Validates at the adapter boundary so every rendering path rejects the same
+/// unsupported values before choosing an implementation.
+void _validateEffects(RemixBoxEffectsSpec effects) {
+  if (!effects.backdropBlur.isFinite) {
     throw FlutterError(
       'RemixBoxEffectsSpec.backdropBlur must be finite. '
-      'Received ${containerEffects.backdropBlur}.',
+      'Received ${effects.backdropBlur}.',
     );
   }
-  if (containerEffects.backdropBlur < 0) {
+  if (effects.backdropBlur < 0) {
     throw FlutterError(
       'RemixBoxEffectsSpec.backdropBlur must be non-negative. '
-      'Received ${containerEffects.backdropBlur}.',
+      'Received ${effects.backdropBlur}.',
     );
   }
-  if (!containerEffects.outline.width.isFinite) {
+  if (!effects.outline.width.isFinite) {
     throw FlutterError(
       'RemixBoxEffectsSpec.outline.width must be finite. '
-      'Received ${containerEffects.outline.width}.',
+      'Received ${effects.outline.width}.',
     );
   }
-  if (containerEffects.outline.width < 0) {
+  if (effects.outline.width < 0) {
     throw FlutterError(
       'RemixBoxEffectsSpec.outline.width must be non-negative. '
-      'Received ${containerEffects.outline.width}.',
+      'Received ${effects.outline.width}.',
     );
   }
-  if (!containerEffects.outlineOffset.isFinite) {
+  if (!effects.outlineOffset.isFinite) {
     throw FlutterError(
       'RemixBoxEffectsSpec.outlineOffset must be finite. '
-      'Received ${containerEffects.outlineOffset}.',
+      'Received ${effects.outlineOffset}.',
     );
   }
-  if (containerEffects.outline.style != BorderStyle.none &&
-      containerEffects.outline.strokeAlign != BorderSide.strokeAlignInside) {
+  if (effects.outline.style != BorderStyle.none &&
+      effects.outline.strokeAlign != BorderSide.strokeAlignInside) {
     throw FlutterError(
       'Remix box effects outlines must use BorderSide.strokeAlignInside.',
     );
   }
-  if (containerEffects.behindContent case final layer?) {
+  if (effects.behindContent case final layer?) {
     _validateEffectLayer(layer, 'behindContent');
   }
-  if (containerEffects.overContent case final layer?) {
+  if (effects.overContent case final layer?) {
     _validateEffectLayer(layer, 'overContent');
   }
 }
@@ -223,146 +232,4 @@ void _validateBoxDecoration(Decoration? decoration) {
     'Remix box effects require a rectangular BoxDecoration. '
     'ShapeDecoration and BoxShape.circle are not supported.',
   );
-}
-
-/// Internal Box equivalent that inserts box effect layers at the decoration
-/// boundary, inside constraints and outside CSS margin and transforms.
-class _RemixAdvancedSurface extends StatelessWidget {
-  const _RemixAdvancedSurface({
-    required this.spec,
-    required this.containerEffects,
-    this.child,
-  });
-
-  final BoxSpec spec;
-  final RemixBoxEffectsSpec containerEffects;
-  final Widget? child;
-
-  @override
-  Widget build(BuildContext context) {
-    Widget? current = child;
-    if (child == null) {
-      current = spec.constraints == null || !spec.constraints!.isTight
-          ? LimitedBox(
-              maxWidth: 0,
-              maxHeight: 0,
-              child: ConstrainedBox(constraints: const BoxConstraints.expand()),
-            )
-          : const SizedBox.shrink();
-    } else if (spec.alignment != null) {
-      current = Align(alignment: spec.alignment!, child: current);
-    }
-
-    final decorationPadding = spec.decoration?.padding;
-    final padding = switch ((spec.padding, decorationPadding)) {
-      (null, final value) => value,
-      (final value, null) => value,
-      (final value?, final decoration?) => value.add(decoration),
-    };
-    if (padding != null) current = Padding(padding: padding, child: current);
-
-    final decoration =
-        spec.decoration as BoxDecoration? ?? const BoxDecoration();
-    final textDirection = Directionality.maybeOf(context);
-    final borderRadius = (decoration.borderRadius ?? BorderRadius.zero).resolve(
-      textDirection,
-    );
-    final behindContent =
-        containerEffects.behindContent ?? const RemixBoxEffectLayerSpec();
-
-    // Box fill -> advanced behindContent -> border -> child.
-    if (decoration.border case final border?) {
-      current = CustomPaint(
-        painter: _RemixBoxBorderPainter(
-          border: border,
-          borderRadius: borderRadius,
-          textDirection: textDirection,
-        ),
-        child: current,
-      );
-    }
-    if (!behindContent.isEmpty) {
-      current = CustomPaint(
-        painter: _RemixBoxEffectLayerPainter(
-          spec: behindContent,
-          borderRadius: borderRadius,
-          textDirection: textDirection,
-          phase: _BoxEffectPaintPhase.inner,
-        ),
-        child: current,
-      );
-    }
-    current = DecoratedBox(
-      decoration: _backgroundDecoration(decoration),
-      child: current,
-    );
-
-    if (containerEffects.backdropBlur > 0) {
-      current = ClipRRect(
-        borderRadius: borderRadius,
-        clipBehavior: Clip.antiAlias,
-        child: BackdropFilter(
-          filter: ui.ImageFilter.blur(
-            sigmaX: containerEffects.backdropBlur,
-            sigmaY: containerEffects.backdropBlur,
-          ),
-          child: current,
-        ),
-      );
-    }
-
-    // Clip decorated content without clipping box effect shadows or outlines.
-    if (spec.clipBehavior case final clip? when clip != Clip.none) {
-      current = ClipPath(
-        clipper: _RemixDecorationClipper(
-          textDirection: textDirection,
-          decoration: decoration,
-        ),
-        clipBehavior: clip,
-        child: current,
-      );
-    }
-
-    if (_decorationShadow(decoration) case final shadow?) {
-      current = DecoratedBox(decoration: shadow, child: current);
-    }
-    if (!behindContent.isEmpty) {
-      current = CustomPaint(
-        painter: _RemixBoxEffectLayerPainter(
-          spec: behindContent,
-          borderRadius: borderRadius,
-          textDirection: textDirection,
-          phase: _BoxEffectPaintPhase.outer,
-        ),
-        child: current,
-      );
-    }
-    if (spec.foregroundDecoration case final overContent?) {
-      current = DecoratedBox(
-        decoration: overContent,
-        position: DecorationPosition.foreground,
-        child: current,
-      );
-    }
-    final hasForeground =
-        containerEffects.overContent != null &&
-        !containerEffects.overContent!.isEmpty;
-    final hasOutline =
-        containerEffects.outline.style != BorderStyle.none &&
-        containerEffects.outline.width > 0;
-    if (hasForeground || hasOutline) {
-      current = CustomPaint(
-        foregroundPainter: _RemixBoxEffectsForegroundPainter(
-          containerEffects: containerEffects,
-          borderRadius: borderRadius,
-          textDirection: textDirection,
-        ),
-        child: current,
-      );
-    }
-    if (spec.constraints case final constraints?) {
-      current = ConstrainedBox(constraints: constraints, child: current);
-    }
-    return current;
-  }
 }

--- a/packages/remix/lib/src/rendering/remix_box_effects.dart
+++ b/packages/remix/lib/src/rendering/remix_box_effects.dart
@@ -10,4 +10,5 @@ import 'remix_blend_mode.dart';
 
 part 'remix_box_effects_model.dart';
 part 'remix_box_effects_adapter.dart';
+part 'remix_box_outer_layout.dart';
 part 'remix_box_effects_painters.dart';

--- a/packages/remix/lib/src/rendering/remix_box_effects.dart
+++ b/packages/remix/lib/src/rendering/remix_box_effects.dart
@@ -9,6 +9,7 @@ import 'package:mix/mix.dart';
 import 'remix_blend_mode.dart';
 
 part 'remix_box_effects_model.dart';
-part 'remix_box_effects_adapter.dart';
+part 'remix_box_adapter.dart';
 part 'remix_box_outer_layout.dart';
+part 'remix_box_effects_renderer.dart';
 part 'remix_box_effects_painters.dart';

--- a/packages/remix/lib/src/rendering/remix_box_effects_adapter.dart
+++ b/packages/remix/lib/src/rendering/remix_box_effects_adapter.dart
@@ -1,9 +1,13 @@
 part of 'remix_box_effects.dart';
 
-/// A Mix [Box] that inserts advanced paint at the decoration boundary.
+/// Routes a resolved Mix [Box] surface through the simplest valid renderer.
+///
+/// Ordinary surfaces remain real Mix Boxes. Only non-empty advanced effects
+/// use [_RemixAdvancedSurface], while CSS-style negative margins are handled by
+/// the independent outer-layout adapter.
 @internal
-final class RemixBoxWithEffects extends StatelessWidget {
-  const RemixBoxWithEffects({
+final class RemixBoxAdapter extends StatelessWidget {
+  const RemixBoxAdapter({
     super.key,
     required this.styleSpec,
     this.containerEffects,
@@ -21,28 +25,44 @@ final class RemixBoxWithEffects extends StatelessWidget {
     return StyleSpecBuilder<BoxSpec>(
       styleSpec: styleSpec,
       builder: (context, spec) {
-        if (effects.isEmpty &&
-            (spec.margin == null || spec.margin!.isNonNegative)) {
+        final margin = spec.margin;
+        if (effects.isEmpty && (margin == null || margin.isNonNegative)) {
           return Box(
             styleSpec: StyleSpec(spec: spec),
             child: child,
           );
         }
-        _validateBoxDecoration(spec.decoration, effects: effects, flex: false);
-        return _RemixDecoratedBox(
-          spec: spec,
-          containerEffects: effects,
-          child: child,
+
+        final innerSpec = _withoutOuterBoxLayout(spec);
+        final Widget inner;
+        if (effects.isEmpty) {
+          inner = Box(
+            styleSpec: StyleSpec(spec: innerSpec),
+            child: child,
+          );
+        } else {
+          _validateBoxDecoration(spec.decoration);
+          inner = _RemixAdvancedSurface(
+            spec: innerSpec,
+            containerEffects: effects,
+            child: child,
+          );
+        }
+        return _applyRemixOuterBoxLayout(
+          margin: margin,
+          transform: spec.transform,
+          transformAlignment: spec.transformAlignment,
+          child: inner,
         );
       },
     );
   }
 }
 
-/// A Mix [FlexBox] that inserts advanced paint at the nested Box boundary.
+/// Flex counterpart of [RemixBoxAdapter].
 @internal
-final class RemixFlexBoxWithEffects extends StatelessWidget {
-  const RemixFlexBoxWithEffects({
+final class RemixFlexBoxAdapter extends StatelessWidget {
+  const RemixFlexBoxAdapter({
     super.key,
     required this.styleSpec,
     this.direction,
@@ -73,7 +93,6 @@ final class RemixFlexBoxWithEffects extends StatelessWidget {
           };
         }
 
-        _validateBoxDecoration(box?.decoration, effects: effects, flex: true);
         final flex = spec.flex?.spec;
         assert(
           direction == null ||
@@ -94,7 +113,7 @@ final class RemixFlexBoxWithEffects extends StatelessWidget {
           spacing: flex?.spacing ?? 0,
           children: children,
         );
-        return RemixBoxWithEffects(
+        return RemixBoxAdapter(
           styleSpec: spec.box ?? const StyleSpec(spec: BoxSpec()),
           containerEffects: effects,
           child: content,
@@ -194,22 +213,12 @@ void _validateEffectLayer(RemixBoxEffectLayerSpec layer, String name) {
   }
 }
 
-void _validateBoxDecoration(
-  Decoration? decoration, {
-  required RemixBoxEffectsSpec effects,
-  required bool flex,
-}) {
+void _validateBoxDecoration(Decoration? decoration) {
   final unsupported =
       (decoration != null && decoration is! BoxDecoration) ||
       decoration is BoxDecoration && decoration.shape == BoxShape.circle;
   if (!unsupported) return;
 
-  if (effects.isEmpty) {
-    throw FlutterError(
-      'Negative Remix ${flex ? 'FlexBox' : 'Box'} margins require a '
-      'rectangular BoxDecoration.',
-    );
-  }
   throw FlutterError(
     'Remix box effects require a rectangular BoxDecoration. '
     'ShapeDecoration and BoxShape.circle are not supported.',
@@ -217,9 +226,9 @@ void _validateBoxDecoration(
 }
 
 /// Internal Box equivalent that inserts box effect layers at the decoration
-/// boundary, inside constraints and margin.
-class _RemixDecoratedBox extends StatelessWidget {
-  const _RemixDecoratedBox({
+/// boundary, inside constraints and outside CSS margin and transforms.
+class _RemixAdvancedSurface extends StatelessWidget {
+  const _RemixAdvancedSurface({
     required this.spec,
     required this.containerEffects,
     this.child,
@@ -354,222 +363,6 @@ class _RemixDecoratedBox extends StatelessWidget {
     if (spec.constraints case final constraints?) {
       current = ConstrainedBox(constraints: constraints, child: current);
     }
-    if (spec.margin case final margin?) {
-      current = margin.isNonNegative
-          ? Padding(padding: margin, child: current)
-          : _RemixNegativeMargin(margin: margin, child: current);
-    }
-    if (spec.transform case final transform?) {
-      current = Transform(
-        transform: transform,
-        alignment: spec.transformAlignment,
-        child: current,
-      );
-    }
     return current;
-  }
-}
-
-/// Lays out a child using CSS margin arithmetic when one or more insets are
-/// negative.
-///
-/// Flutter's [Padding] intentionally rejects negative values, while Radix's
-/// ghost controls use a negative margin to cancel their visual padding in
-/// surrounding layout. This render object keeps the padded child paintable at
-/// its full size while reporting the margin-adjusted footprint to its parent.
-class _RemixNegativeMargin extends SingleChildRenderObjectWidget {
-  const _RemixNegativeMargin({required this.margin, required super.child});
-
-  final EdgeInsetsGeometry margin;
-
-  @override
-  RenderObject createRenderObject(BuildContext context) =>
-      _RenderRemixNegativeMargin(
-        margin: margin,
-        textDirection: Directionality.maybeOf(context),
-      );
-
-  @override
-  void updateRenderObject(
-    BuildContext context,
-    _RenderRemixNegativeMargin renderObject,
-  ) {
-    renderObject
-      ..margin = margin
-      ..textDirection = Directionality.maybeOf(context);
-  }
-}
-
-class _RenderRemixNegativeMargin extends RenderShiftedBox {
-  _RenderRemixNegativeMargin({
-    required EdgeInsetsGeometry margin,
-    required TextDirection? textDirection,
-    RenderBox? child,
-  }) : _margin = margin,
-       _textDirection = textDirection,
-       super(child);
-
-  EdgeInsets? _resolvedMarginCache;
-
-  EdgeInsets get _resolvedMargin =>
-      _resolvedMarginCache ??= margin.resolve(textDirection);
-
-  EdgeInsetsGeometry get margin => _margin;
-  EdgeInsetsGeometry _margin;
-
-  set margin(EdgeInsetsGeometry value) {
-    if (_margin == value) return;
-    _margin = value;
-    _markNeedsResolution();
-  }
-
-  TextDirection? get textDirection => _textDirection;
-  TextDirection? _textDirection;
-
-  set textDirection(TextDirection? value) {
-    if (_textDirection == value) return;
-    _textDirection = value;
-    _markNeedsResolution();
-  }
-
-  void _markNeedsResolution() {
-    _resolvedMarginCache = null;
-    markNeedsLayout();
-  }
-
-  double _intrinsicExtent(double childExtent, double marginExtent) =>
-      math.max(0, childExtent + marginExtent);
-
-  @override
-  double computeMinIntrinsicWidth(double height) {
-    final resolved = _resolvedMargin;
-    return _intrinsicExtent(
-      child?.getMinIntrinsicWidth(math.max(0, height - resolved.vertical)) ?? 0,
-      resolved.horizontal,
-    );
-  }
-
-  @override
-  double computeMaxIntrinsicWidth(double height) {
-    final resolved = _resolvedMargin;
-    return _intrinsicExtent(
-      child?.getMaxIntrinsicWidth(math.max(0, height - resolved.vertical)) ?? 0,
-      resolved.horizontal,
-    );
-  }
-
-  @override
-  double computeMinIntrinsicHeight(double width) {
-    final resolved = _resolvedMargin;
-    return _intrinsicExtent(
-      child?.getMinIntrinsicHeight(math.max(0, width - resolved.horizontal)) ??
-          0,
-      resolved.vertical,
-    );
-  }
-
-  @override
-  double computeMaxIntrinsicHeight(double width) {
-    final resolved = _resolvedMargin;
-    return _intrinsicExtent(
-      child?.getMaxIntrinsicHeight(math.max(0, width - resolved.horizontal)) ??
-          0,
-      resolved.vertical,
-    );
-  }
-
-  Size _constrainOuterSize(BoxConstraints constraints, Size childSize) {
-    final resolved = _resolvedMargin;
-    return constraints.constrain(
-      Size(
-        math.max(0, childSize.width + resolved.horizontal),
-        math.max(0, childSize.height + resolved.vertical),
-      ),
-    );
-  }
-
-  @override
-  @protected
-  Size computeDryLayout(covariant BoxConstraints constraints) {
-    final resolved = _resolvedMargin;
-    final currentChild = child;
-    if (currentChild == null) {
-      return constraints.constrain(
-        Size(math.max(0, resolved.horizontal), math.max(0, resolved.vertical)),
-      );
-    }
-    return _constrainOuterSize(
-      constraints,
-      currentChild.getDryLayout(constraints.deflate(resolved)),
-    );
-  }
-
-  @override
-  double? computeDryBaseline(
-    covariant BoxConstraints constraints,
-    TextBaseline baseline,
-  ) {
-    final currentChild = child;
-    if (currentChild == null) return null;
-    final resolved = _resolvedMargin;
-    final childBaseline = currentChild.getDryBaseline(
-      constraints.deflate(resolved),
-      baseline,
-    );
-    return childBaseline == null ? null : childBaseline + resolved.top;
-  }
-
-  @override
-  void performLayout() {
-    final resolved = _resolvedMargin;
-    final currentChild = child;
-    if (currentChild == null) {
-      size = constraints.constrain(
-        Size(math.max(0, resolved.horizontal), math.max(0, resolved.vertical)),
-      );
-      return;
-    }
-
-    currentChild.layout(constraints.deflate(resolved), parentUsesSize: true);
-    (currentChild.parentData! as BoxParentData).offset = Offset(
-      resolved.left,
-      resolved.top,
-    );
-    size = _constrainOuterSize(constraints, currentChild.size);
-  }
-
-  @override
-  Rect get paintBounds {
-    final currentChild = child;
-    if (currentChild == null) return Offset.zero & size;
-    final offset = (currentChild.parentData! as BoxParentData).offset;
-    return (Offset.zero & size).expandToInclude(
-      currentChild.paintBounds.shift(offset),
-    );
-  }
-
-  @override
-  Rect get semanticBounds => paintBounds;
-
-  @override
-  bool hitTest(BoxHitTestResult result, {required Offset position}) {
-    if (child == null || !hasSize) return false;
-    if (!hitTestChildren(result, position: position)) return false;
-    result.add(BoxHitTestEntry(this, position));
-    return true;
-  }
-
-  @override
-  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
-    properties
-      ..add(DiagnosticsProperty<EdgeInsetsGeometry>('margin', margin))
-      ..add(
-        EnumProperty<TextDirection>(
-          'textDirection',
-          textDirection,
-          defaultValue: null,
-        ),
-      );
   }
 }

--- a/packages/remix/lib/src/rendering/remix_box_effects_renderer.dart
+++ b/packages/remix/lib/src/rendering/remix_box_effects_renderer.dart
@@ -1,0 +1,141 @@
+part of 'remix_box_effects.dart';
+
+/// Internal Box equivalent that inserts box effect layers at the decoration
+/// boundary, inside constraints and outside CSS margin and transforms.
+class _RemixBoxEffectsRenderer extends StatelessWidget {
+  const _RemixBoxEffectsRenderer({
+    required this.spec,
+    required this.effects,
+    this.child,
+  });
+
+  final BoxSpec spec;
+  final RemixBoxEffectsSpec effects;
+  final Widget? child;
+
+  @override
+  Widget build(BuildContext context) {
+    Widget? current = child;
+    if (child == null) {
+      current = spec.constraints == null || !spec.constraints!.isTight
+          ? LimitedBox(
+              maxWidth: 0,
+              maxHeight: 0,
+              child: ConstrainedBox(constraints: const BoxConstraints.expand()),
+            )
+          : const SizedBox.shrink();
+    } else if (spec.alignment != null) {
+      current = Align(alignment: spec.alignment!, child: current);
+    }
+
+    final decorationPadding = spec.decoration?.padding;
+    final padding = switch ((spec.padding, decorationPadding)) {
+      (null, final value) => value,
+      (final value, null) => value,
+      (final value?, final decoration?) => value.add(decoration),
+    };
+    if (padding != null) current = Padding(padding: padding, child: current);
+
+    final decoration =
+        spec.decoration as BoxDecoration? ?? const BoxDecoration();
+    final textDirection = Directionality.maybeOf(context);
+    final borderRadius = (decoration.borderRadius ?? BorderRadius.zero).resolve(
+      textDirection,
+    );
+    final behindContent =
+        effects.behindContent ?? const RemixBoxEffectLayerSpec();
+
+    // Box fill -> advanced behindContent -> border -> child.
+    if (decoration.border case final border?) {
+      current = CustomPaint(
+        painter: _RemixBoxBorderPainter(
+          border: border,
+          borderRadius: borderRadius,
+          textDirection: textDirection,
+        ),
+        child: current,
+      );
+    }
+    if (!behindContent.isEmpty) {
+      current = CustomPaint(
+        painter: _RemixBoxEffectLayerPainter(
+          spec: behindContent,
+          borderRadius: borderRadius,
+          textDirection: textDirection,
+          phase: _BoxEffectPaintPhase.inner,
+        ),
+        child: current,
+      );
+    }
+    current = DecoratedBox(
+      decoration: _backgroundDecoration(decoration),
+      child: current,
+    );
+
+    if (effects.backdropBlur > 0) {
+      current = ClipRRect(
+        borderRadius: borderRadius,
+        clipBehavior: Clip.antiAlias,
+        child: BackdropFilter(
+          filter: ui.ImageFilter.blur(
+            sigmaX: effects.backdropBlur,
+            sigmaY: effects.backdropBlur,
+          ),
+          child: current,
+        ),
+      );
+    }
+
+    // Clip decorated content without clipping box effect shadows or outlines.
+    if (spec.clipBehavior case final clip? when clip != Clip.none) {
+      current = ClipPath(
+        clipper: _RemixDecorationClipper(
+          textDirection: textDirection,
+          decoration: decoration,
+        ),
+        clipBehavior: clip,
+        child: current,
+      );
+    }
+
+    if (_decorationShadow(decoration) case final shadow?) {
+      current = DecoratedBox(decoration: shadow, child: current);
+    }
+    if (!behindContent.isEmpty) {
+      current = CustomPaint(
+        painter: _RemixBoxEffectLayerPainter(
+          spec: behindContent,
+          borderRadius: borderRadius,
+          textDirection: textDirection,
+          phase: _BoxEffectPaintPhase.outer,
+        ),
+        child: current,
+      );
+    }
+    if (spec.foregroundDecoration case final overContent?) {
+      current = DecoratedBox(
+        decoration: overContent,
+        position: DecorationPosition.foreground,
+        child: current,
+      );
+    }
+    final hasForeground =
+        effects.overContent != null && !effects.overContent!.isEmpty;
+    final hasOutline =
+        effects.outline.style != BorderStyle.none && effects.outline.width > 0;
+    if (hasForeground || hasOutline) {
+      current = CustomPaint(
+        foregroundPainter: _RemixBoxEffectsForegroundPainter(
+          containerEffects: effects,
+          borderRadius: borderRadius,
+          textDirection: textDirection,
+        ),
+        child: current,
+      );
+    }
+    if (spec.constraints case final constraints?) {
+      current = ConstrainedBox(constraints: constraints, child: current);
+    }
+    return current;
+  }
+}

--- a/packages/remix/lib/src/rendering/remix_box_outer_layout.dart
+++ b/packages/remix/lib/src/rendering/remix_box_outer_layout.dart
@@ -1,0 +1,241 @@
+part of 'remix_box_effects.dart';
+
+BoxSpec _withoutOuterBoxLayout(BoxSpec spec) => BoxSpec(
+  alignment: spec.alignment,
+  padding: spec.padding,
+  constraints: spec.constraints,
+  decoration: spec.decoration,
+  foregroundDecoration: spec.foregroundDecoration,
+  clipBehavior: spec.clipBehavior,
+);
+
+/// Applies resolved Box layout operations that sit outside decoration and
+/// constraints.
+///
+/// Keeping this separate from advanced effects allows an effects-free Box to
+/// use Mix's normal renderer even when it has a CSS-style negative margin.
+Widget _applyRemixOuterBoxLayout({
+  required EdgeInsetsGeometry? margin,
+  required Matrix4? transform,
+  required AlignmentGeometry? transformAlignment,
+  required Widget child,
+}) {
+  Widget current = child;
+  if (margin != null) {
+    current = margin.isNonNegative
+        ? Padding(padding: margin, child: current)
+        : _RemixNegativeMargin(margin: margin, child: current);
+  }
+  if (transform != null) {
+    current = Transform(
+      transform: transform,
+      alignment: transformAlignment,
+      child: current,
+    );
+  }
+  return current;
+}
+
+/// Lays out a child using CSS margin arithmetic when one or more insets are
+/// negative.
+///
+/// Flutter's [Padding] intentionally rejects negative values, while Radix's
+/// ghost controls use a negative margin to cancel their visual padding in
+/// surrounding layout. This render object keeps the padded child paintable at
+/// its full size while reporting the margin-adjusted footprint to its parent.
+class _RemixNegativeMargin extends SingleChildRenderObjectWidget {
+  const _RemixNegativeMargin({required this.margin, required super.child});
+
+  final EdgeInsetsGeometry margin;
+
+  @override
+  RenderObject createRenderObject(BuildContext context) =>
+      _RenderRemixNegativeMargin(
+        margin: margin,
+        textDirection: Directionality.maybeOf(context),
+      );
+
+  @override
+  void updateRenderObject(
+    BuildContext context,
+    _RenderRemixNegativeMargin renderObject,
+  ) {
+    renderObject
+      ..margin = margin
+      ..textDirection = Directionality.maybeOf(context);
+  }
+}
+
+class _RenderRemixNegativeMargin extends RenderShiftedBox {
+  _RenderRemixNegativeMargin({
+    required EdgeInsetsGeometry margin,
+    required TextDirection? textDirection,
+    RenderBox? child,
+  }) : _margin = margin,
+       _textDirection = textDirection,
+       super(child);
+
+  EdgeInsets? _resolvedMarginCache;
+
+  EdgeInsets get _resolvedMargin =>
+      _resolvedMarginCache ??= margin.resolve(textDirection);
+
+  EdgeInsetsGeometry get margin => _margin;
+  EdgeInsetsGeometry _margin;
+
+  set margin(EdgeInsetsGeometry value) {
+    if (_margin == value) return;
+    _margin = value;
+    _markNeedsResolution();
+  }
+
+  TextDirection? get textDirection => _textDirection;
+  TextDirection? _textDirection;
+
+  set textDirection(TextDirection? value) {
+    if (_textDirection == value) return;
+    _textDirection = value;
+    _markNeedsResolution();
+  }
+
+  void _markNeedsResolution() {
+    _resolvedMarginCache = null;
+    markNeedsLayout();
+  }
+
+  double _intrinsicExtent(double childExtent, double marginExtent) =>
+      math.max(0, childExtent + marginExtent);
+
+  @override
+  double computeMinIntrinsicWidth(double height) {
+    final resolved = _resolvedMargin;
+    return _intrinsicExtent(
+      child?.getMinIntrinsicWidth(math.max(0, height - resolved.vertical)) ?? 0,
+      resolved.horizontal,
+    );
+  }
+
+  @override
+  double computeMaxIntrinsicWidth(double height) {
+    final resolved = _resolvedMargin;
+    return _intrinsicExtent(
+      child?.getMaxIntrinsicWidth(math.max(0, height - resolved.vertical)) ?? 0,
+      resolved.horizontal,
+    );
+  }
+
+  @override
+  double computeMinIntrinsicHeight(double width) {
+    final resolved = _resolvedMargin;
+    return _intrinsicExtent(
+      child?.getMinIntrinsicHeight(math.max(0, width - resolved.horizontal)) ??
+          0,
+      resolved.vertical,
+    );
+  }
+
+  @override
+  double computeMaxIntrinsicHeight(double width) {
+    final resolved = _resolvedMargin;
+    return _intrinsicExtent(
+      child?.getMaxIntrinsicHeight(math.max(0, width - resolved.horizontal)) ??
+          0,
+      resolved.vertical,
+    );
+  }
+
+  Size _constrainOuterSize(BoxConstraints constraints, Size childSize) {
+    final resolved = _resolvedMargin;
+    return constraints.constrain(
+      Size(
+        math.max(0, childSize.width + resolved.horizontal),
+        math.max(0, childSize.height + resolved.vertical),
+      ),
+    );
+  }
+
+  @override
+  @protected
+  Size computeDryLayout(covariant BoxConstraints constraints) {
+    final resolved = _resolvedMargin;
+    final currentChild = child;
+    if (currentChild == null) {
+      return constraints.constrain(
+        Size(math.max(0, resolved.horizontal), math.max(0, resolved.vertical)),
+      );
+    }
+    return _constrainOuterSize(
+      constraints,
+      currentChild.getDryLayout(constraints.deflate(resolved)),
+    );
+  }
+
+  @override
+  double? computeDryBaseline(
+    covariant BoxConstraints constraints,
+    TextBaseline baseline,
+  ) {
+    final currentChild = child;
+    if (currentChild == null) return null;
+    final resolved = _resolvedMargin;
+    final childBaseline = currentChild.getDryBaseline(
+      constraints.deflate(resolved),
+      baseline,
+    );
+    return childBaseline == null ? null : childBaseline + resolved.top;
+  }
+
+  @override
+  void performLayout() {
+    final resolved = _resolvedMargin;
+    final currentChild = child;
+    if (currentChild == null) {
+      size = constraints.constrain(
+        Size(math.max(0, resolved.horizontal), math.max(0, resolved.vertical)),
+      );
+      return;
+    }
+
+    currentChild.layout(constraints.deflate(resolved), parentUsesSize: true);
+    (currentChild.parentData! as BoxParentData).offset = Offset(
+      resolved.left,
+      resolved.top,
+    );
+    size = _constrainOuterSize(constraints, currentChild.size);
+  }
+
+  @override
+  Rect get paintBounds {
+    final currentChild = child;
+    if (currentChild == null) return Offset.zero & size;
+    final offset = (currentChild.parentData! as BoxParentData).offset;
+    return (Offset.zero & size).expandToInclude(
+      currentChild.paintBounds.shift(offset),
+    );
+  }
+
+  @override
+  Rect get semanticBounds => paintBounds;
+
+  @override
+  bool hitTest(BoxHitTestResult result, {required Offset position}) {
+    if (child == null || !hasSize) return false;
+    if (!hitTestChildren(result, position: position)) return false;
+    result.add(BoxHitTestEntry(this, position));
+    return true;
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties
+      ..add(DiagnosticsProperty<EdgeInsetsGeometry>('margin', margin))
+      ..add(
+        EnumProperty<TextDirection>(
+          'textDirection',
+          textDirection,
+          defaultValue: null,
+        ),
+      );
+  }
+}

--- a/packages/remix/lib/src/rendering/remix_box_outer_layout.dart
+++ b/packages/remix/lib/src/rendering/remix_box_outer_layout.dart
@@ -43,6 +43,9 @@ Widget _applyRemixOuterBoxLayout({
 /// ghost controls use a negative margin to cancel their visual padding in
 /// surrounding layout. This render object keeps the padded child paintable at
 /// its full size while reporting the margin-adjusted footprint to its parent.
+/// If the negative totals exceed the child's extent, that reported footprint
+/// clamps to zero. Overflow remains hit-testable here, although an ancestor's
+/// own bounds can still prevent the hit test from reaching this render object.
 class _RemixNegativeMargin extends SingleChildRenderObjectWidget {
   const _RemixNegativeMargin({required this.margin, required super.child});
 
@@ -215,7 +218,14 @@ class _RenderRemixNegativeMargin extends RenderShiftedBox {
   }
 
   @override
-  Rect get semanticBounds => paintBounds;
+  Rect get semanticBounds {
+    final currentChild = child;
+    if (currentChild == null) return Offset.zero & size;
+    final offset = (currentChild.parentData! as BoxParentData).offset;
+    return (Offset.zero & size).expandToInclude(
+      currentChild.semanticBounds.shift(offset),
+    );
+  }
 
   @override
   bool hitTest(BoxHitTestResult result, {required Offset position}) {

--- a/packages/remix/test/components/checkbox/checkbox_group_widget_test.dart
+++ b/packages/remix/test/components/checkbox/checkbox_group_widget_test.dart
@@ -4,7 +4,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:remix/remix.dart';
 import 'package:remix/src/rendering/remix_box_effects.dart'
-    show RemixBoxWithEffects;
+    show RemixBoxAdapter;
 import 'package:remix/src/utilities/remix_path_icon.dart';
 
 import '../../helpers/test_helpers.dart';
@@ -449,7 +449,7 @@ void main() {
           tester.getSize(
             find.descendant(
               of: find.byKey(compactKey),
-              matching: find.byType(RemixBoxWithEffects),
+              matching: find.byType(RemixBoxAdapter),
             ),
           ),
           const Size.square(16),
@@ -478,7 +478,7 @@ void main() {
 
         final item = find.byKey(itemKey);
         final targetRect = tester.getRect(item);
-        final boxRect = tester.getRect(find.byType(RemixBoxWithEffects));
+        final boxRect = tester.getRect(find.byType(RemixBoxAdapter));
         final labelRect = tester.getRect(find.text(label));
         final locations = <Offset>[
           boxRect.center,
@@ -512,7 +512,7 @@ void main() {
           textDirection: TextDirection.rtl,
         );
 
-        final boxRect = tester.getRect(find.byType(RemixBoxWithEffects));
+        final boxRect = tester.getRect(find.byType(RemixBoxAdapter));
         final labelRect = tester.getRect(find.text(label));
         expect(boxRect.left, greaterThan(labelRect.left));
         expect(boxRect.left - labelRect.right, 12);

--- a/packages/remix/test/components/link/link_focus_ring_test.dart
+++ b/packages/remix/test/components/link/link_focus_ring_test.dart
@@ -45,7 +45,7 @@ void main() {
       await tester.pumpAndSettle();
 
       RemixBoxEffectsSpec? paintedEffects() => tester
-          .widget<RemixBoxWithEffects>(find.byType(RemixBoxWithEffects))
+          .widget<RemixBoxAdapter>(find.byType(RemixBoxAdapter))
           .containerEffects;
 
       expect(paintedEffects()?.outline.width ?? 0, 0, reason: 'idle');

--- a/packages/remix/test/components/slider/slider_widget_test.dart
+++ b/packages/remix/test/components/slider/slider_widget_test.dart
@@ -4,7 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:naked_ui/naked_ui.dart';
 import 'package:remix/remix.dart';
 import 'package:remix/src/rendering/remix_box_effects.dart'
-    show RemixBoxWithEffects;
+    show RemixBoxAdapter;
 
 import '../../helpers/test_helpers.dart';
 
@@ -1144,9 +1144,9 @@ void main() {
   });
 }
 
-RemixBoxWithEffects _sliderThumb(WidgetTester tester) {
+RemixBoxAdapter _sliderThumb(WidgetTester tester) {
   return tester
-      .widgetList<RemixBoxWithEffects>(find.byType(RemixBoxWithEffects))
+      .widgetList<RemixBoxAdapter>(find.byType(RemixBoxAdapter))
       .singleWhere(
         (widget) => widget.styleSpec.spec.constraints?.maxWidth == 20,
       );

--- a/packages/remix/test/rendering/remix_blend_mode_test.dart
+++ b/packages/remix/test/rendering/remix_blend_mode_test.dart
@@ -6,7 +6,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:remix/remix.dart';
 import 'package:remix/src/rendering/remix_box_effects.dart'
-    show RemixBoxWithEffects;
+    show RemixBoxAdapter;
 
 const _boundaryKey = ValueKey('blend-boundary');
 
@@ -98,7 +98,7 @@ void main() {
                   top: 6,
                   width: 8,
                   height: 8,
-                  child: RemixBoxWithEffects(
+                  child: RemixBoxAdapter(
                     styleSpec: const StyleSpec(
                       spec: BoxSpec(
                         decoration: BoxDecoration(color: Colors.red),

--- a/packages/remix/test/rendering/remix_box_effects_pixel_test.dart
+++ b/packages/remix/test/rendering/remix_box_effects_pixel_test.dart
@@ -6,7 +6,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:remix/remix.dart';
 import 'package:remix/src/rendering/remix_box_effects.dart'
-    show RemixBoxWithEffects;
+    show RemixBoxAdapter;
 
 void main() {
   group('Remix box effects pixel contract', () {
@@ -16,7 +16,7 @@ void main() {
       final pixels = await _render(
         tester,
         size: const Size(12, 12),
-        child: RemixBoxWithEffects(
+        child: RemixBoxAdapter(
           styleSpec: const StyleSpec(
             spec: BoxSpec(
               constraints: BoxConstraints.tightFor(width: 12, height: 12),
@@ -104,7 +104,7 @@ void main() {
           tester,
           size: const Size(32, 32),
           child: Center(
-            child: RemixBoxWithEffects(
+            child: RemixBoxAdapter(
               styleSpec: const StyleSpec(
                 spec: BoxSpec(
                   constraints: BoxConstraints.tightFor(width: 20, height: 20),
@@ -152,7 +152,7 @@ void main() {
           size: const Size(48, 32),
           background: Colors.white,
           child: Center(
-            child: RemixBoxWithEffects(
+            child: RemixBoxAdapter(
               styleSpec: const StyleSpec(
                 spec: BoxSpec(
                   constraints: BoxConstraints.tightFor(width: 20, height: 20),
@@ -184,7 +184,7 @@ void main() {
   });
 }
 
-Widget _insetSample(RemixBoxShadow shadow) => RemixBoxWithEffects(
+Widget _insetSample(RemixBoxShadow shadow) => RemixBoxAdapter(
   styleSpec: const StyleSpec(
     spec: BoxSpec(
       constraints: BoxConstraints.tightFor(width: 20, height: 24),

--- a/packages/remix/test/rendering/remix_box_effects_test.dart
+++ b/packages/remix/test/rendering/remix_box_effects_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:remix/remix.dart';
 import 'package:remix/src/rendering/remix_box_effects.dart'
@@ -204,6 +205,173 @@ void main() {
   });
 
   group('Box effects geometry', () {
+    testWidgets('preserves mutable child state across Box renderer routes', (
+      tester,
+    ) async {
+      final lifecycle = _ProbeLifecycle();
+
+      Widget build(RemixBoxEffectsSpec? effects) => Directionality(
+        textDirection: TextDirection.ltr,
+        child: RemixBoxAdapter(
+          styleSpec: const StyleSpec(spec: BoxSpec()),
+          containerEffects: effects,
+          child: _MutableStateProbe(lifecycle: lifecycle),
+        ),
+      );
+
+      await tester.pumpWidget(build(null));
+      await tester.tap(find.byKey(_MutableStateProbe.tapKey));
+      await tester.pump();
+      expect(find.text('value: 1'), findsOneWidget);
+
+      await tester.pumpWidget(
+        build(
+          const RemixBoxEffectsSpec(
+            outline: BorderSide(color: Colors.red, width: 1),
+          ),
+        ),
+      );
+      expect(find.text('value: 1'), findsOneWidget);
+      expect(lifecycle.initCount, 1);
+      expect(lifecycle.disposeCount, 0);
+
+      await tester.pumpWidget(build(null));
+      expect(find.text('value: 1'), findsOneWidget);
+      expect(lifecycle.initCount, 1);
+      expect(lifecycle.disposeCount, 0);
+    });
+
+    testWidgets('honors caller changes to the logical child key', (
+      tester,
+    ) async {
+      final lifecycle = _ProbeLifecycle();
+
+      Widget build(Key childKey) => Directionality(
+        textDirection: TextDirection.ltr,
+        child: RemixBoxAdapter(
+          styleSpec: const StyleSpec(spec: BoxSpec()),
+          child: _MutableStateProbe(key: childKey, lifecycle: lifecycle),
+        ),
+      );
+
+      await tester.pumpWidget(build(const ValueKey('first-child')));
+      await tester.tap(find.byKey(_MutableStateProbe.tapKey));
+      await tester.pump();
+      expect(find.text('value: 1'), findsOneWidget);
+
+      await tester.pumpWidget(build(const ValueKey('second-child')));
+      expect(find.text('value: 0'), findsOneWidget);
+      expect(lifecycle.initCount, 2);
+      expect(lifecycle.disposeCount, 1);
+    });
+
+    testWidgets('preserves mutable child state across Flex renderer routes', (
+      tester,
+    ) async {
+      final lifecycle = _ProbeLifecycle();
+
+      Widget build(RemixBoxEffectsSpec? effects) => Directionality(
+        textDirection: TextDirection.ltr,
+        child: RemixFlexBoxAdapter(
+          styleSpec: const StyleSpec(spec: FlexBoxSpec()),
+          direction: Axis.horizontal,
+          containerEffects: effects,
+          children: [_MutableStateProbe(lifecycle: lifecycle)],
+        ),
+      );
+
+      await tester.pumpWidget(build(null));
+      await tester.tap(find.byKey(_MutableStateProbe.tapKey));
+      await tester.pump();
+      expect(find.text('value: 1'), findsOneWidget);
+
+      await tester.pumpWidget(
+        build(
+          const RemixBoxEffectsSpec(
+            outline: BorderSide(color: Colors.red, width: 1),
+          ),
+        ),
+      );
+      expect(find.text('value: 1'), findsOneWidget);
+      expect(lifecycle.initCount, 1);
+      expect(lifecycle.disposeCount, 0);
+
+      await tester.pumpWidget(build(null));
+      expect(find.text('value: 1'), findsOneWidget);
+      expect(lifecycle.initCount, 1);
+      expect(lifecycle.disposeCount, 0);
+    });
+
+    testWidgets('preserves state across positive and negative margins', (
+      tester,
+    ) async {
+      final lifecycle = _ProbeLifecycle();
+
+      Widget build(double margin) => Directionality(
+        textDirection: TextDirection.ltr,
+        child: RemixBoxAdapter(
+          styleSpec: StyleSpec(spec: BoxSpec(margin: EdgeInsets.all(margin))),
+          child: _MutableStateProbe(lifecycle: lifecycle),
+        ),
+      );
+
+      await tester.pumpWidget(build(4));
+      await tester.tap(find.byKey(_MutableStateProbe.tapKey));
+      await tester.pump();
+
+      await tester.pumpWidget(build(-4));
+      expect(find.text('value: 1'), findsOneWidget);
+      expect(lifecycle.initCount, 1);
+      expect(lifecycle.disposeCount, 0);
+
+      await tester.pumpWidget(build(4));
+      expect(find.text('value: 1'), findsOneWidget);
+      expect(lifecycle.initCount, 1);
+      expect(lifecycle.disposeCount, 0);
+    });
+
+    testWidgets('preserves focus while switching Box renderer routes', (
+      tester,
+    ) async {
+      final nodes = <FocusNode>[];
+      var disposeCount = 0;
+
+      Widget build(RemixBoxEffectsSpec? effects) => Directionality(
+        textDirection: TextDirection.ltr,
+        child: FocusScope(
+          child: RemixBoxAdapter(
+            styleSpec: const StyleSpec(spec: BoxSpec()),
+            containerEffects: effects,
+            child: _FocusProbe(
+              onCreate: nodes.add,
+              onDispose: () => disposeCount += 1,
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpWidget(build(null));
+      nodes.single.requestFocus();
+      await tester.pump();
+      expect(nodes.single.hasFocus, isTrue);
+
+      await tester.pumpWidget(
+        build(
+          const RemixBoxEffectsSpec(
+            outline: BorderSide(color: Colors.red, width: 1),
+          ),
+        ),
+      );
+      expect(nodes, hasLength(1));
+      expect(nodes.single.hasFocus, isTrue);
+      expect(disposeCount, 0);
+
+      await tester.pumpWidget(build(null));
+      expect(nodes, hasLength(1));
+      expect(nodes.single.hasFocus, isTrue);
+      expect(disposeCount, 0);
+    });
+
     testWidgets('uses the real Mix Box when effects are absent', (
       tester,
     ) async {
@@ -247,10 +415,44 @@ void main() {
         ),
       );
 
-      expect(find.byType(Box), findsOneWidget);
+      expect(find.byType(Box), findsNWidgets(2));
       expect(find.byType(RowBox), findsOneWidget);
       expect(find.byType(CustomPaint), findsNothing);
     });
+
+    for (final (direction, mixType) in <(Axis?, Type)>[
+      (Axis.horizontal, RowBox),
+      (Axis.vertical, ColumnBox),
+      (null, FlexBox),
+    ]) {
+      for (final advanced in [false, true]) {
+        testWidgets('uses a real $mixType on the '
+            '${advanced ? 'advanced' : 'ordinary'} Flex route', (tester) async {
+          await tester.pumpWidget(
+            Directionality(
+              textDirection: TextDirection.ltr,
+              child: RemixFlexBoxAdapter(
+                styleSpec: StyleSpec(
+                  spec: FlexBoxSpec(
+                    flex: StyleSpec(spec: FlexSpec(direction: direction)),
+                  ),
+                ),
+                direction: direction,
+                containerEffects: advanced
+                    ? const RemixBoxEffectsSpec(
+                        outline: BorderSide(color: Colors.red, width: 1),
+                      )
+                    : null,
+                children: const [SizedBox.square(dimension: 10)],
+              ),
+            ),
+          );
+
+          expect(find.byType(mixType), findsOneWidget);
+          expect(find.byType(Flex), findsOneWidget);
+        });
+      }
+    }
 
     testWidgets('keeps the real Mix Box for an effects-free negative margin', (
       tester,
@@ -327,6 +529,7 @@ void main() {
       );
 
       expect(find.byType(Box), findsOneWidget);
+      expect(find.byType(RowBox), findsOneWidget);
       expect(find.byType(Flex), findsOneWidget);
       expect(find.byType(CustomPaint), findsNothing);
       expect(tester.takeException(), isNull);
@@ -538,6 +741,256 @@ void main() {
       );
     });
 
+    testWidgets('lays out mixed-sign margins with signed CSS arithmetic', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: UnconstrainedBox(
+            child: SizedBox(
+              key: const ValueKey('mixed-margin-footprint'),
+              child: RemixBoxAdapter(
+                styleSpec: const StyleSpec(
+                  spec: BoxSpec(margin: EdgeInsets.fromLTRB(-10, 4, 6, -2)),
+                ),
+                child: const SizedBox(
+                  key: ValueKey('mixed-margin-child'),
+                  width: 40,
+                  height: 30,
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final footprint = tester.getRect(
+        find.byKey(const ValueKey('mixed-margin-footprint')),
+      );
+      final child = tester.getRect(
+        find.byKey(const ValueKey('mixed-margin-child')),
+      );
+      expect(footprint.size, const Size(36, 32));
+      expect(child.topLeft - footprint.topLeft, const Offset(-10, 4));
+      expect(child.size, const Size(40, 30));
+    });
+
+    testWidgets('honors tight constraints while allowing child overflow', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Center(
+            child: SizedBox(
+              key: const ValueKey('tight-margin-footprint'),
+              width: 30,
+              height: 20,
+              child: RemixBoxAdapter(
+                styleSpec: const StyleSpec(
+                  spec: BoxSpec(margin: EdgeInsets.all(-5)),
+                ),
+                child: const SizedBox(
+                  key: ValueKey('tight-margin-child'),
+                  width: 10,
+                  height: 10,
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final footprint = tester.getRect(
+        find.byKey(const ValueKey('tight-margin-footprint')),
+      );
+      final child = tester.getRect(
+        find.byKey(const ValueKey('tight-margin-child')),
+      );
+      expect(footprint.size, const Size(30, 20));
+      expect(child.size, const Size(40, 30));
+      expect(child.topLeft - footprint.topLeft, const Offset(-5, -5));
+    });
+
+    testWidgets('clamps excessively negative unbounded footprints to zero', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: UnconstrainedBox(
+            child: SizedBox(
+              key: const ValueKey('unbounded-margin-footprint'),
+              child: RemixBoxAdapter(
+                styleSpec: const StyleSpec(
+                  spec: BoxSpec(margin: EdgeInsets.all(-20)),
+                ),
+                child: const SizedBox(
+                  key: ValueKey('unbounded-margin-child'),
+                  width: 10,
+                  height: 10,
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(
+        tester.getSize(
+          find.byKey(const ValueKey('unbounded-margin-footprint')),
+        ),
+        Size.zero,
+      );
+      expect(
+        tester.getSize(find.byKey(const ValueKey('unbounded-margin-child'))),
+        const Size(40, 40),
+      );
+    });
+
+    for (final (textDirection, expectedLeft) in <(TextDirection, double)>[
+      (TextDirection.ltr, -5),
+      (TextDirection.rtl, 10),
+    ]) {
+      testWidgets('resolves directional margins in $textDirection', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          Directionality(
+            textDirection: textDirection,
+            child: UnconstrainedBox(
+              child: SizedBox(
+                key: const ValueKey('directional-margin-footprint'),
+                child: RemixBoxAdapter(
+                  styleSpec: const StyleSpec(
+                    spec: BoxSpec(
+                      margin: EdgeInsetsDirectional.only(start: -5, end: 10),
+                    ),
+                  ),
+                  child: const SizedBox(
+                    key: ValueKey('directional-margin-child'),
+                    width: 20,
+                    height: 10,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+
+        final footprint = tester.getRect(
+          find.byKey(const ValueKey('directional-margin-footprint')),
+        );
+        final child = tester.getRect(
+          find.byKey(const ValueKey('directional-margin-child')),
+        );
+        expect(footprint.size, const Size(25, 10));
+        expect(child.left - footprint.left, expectedLeft);
+      });
+    }
+
+    testWidgets('reports signed intrinsic dimensions and baseline offsets', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Center(
+            child: _BaselineRecorder(
+              child: RemixBoxAdapter(
+                styleSpec: const StyleSpec(
+                  spec: BoxSpec(margin: EdgeInsets.fromLTRB(-4, -3, 2, 5)),
+                ),
+                child: const _TestBaselineBox(),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final renderBox = _negativeMarginRenderBox(tester);
+      expect(renderBox.getMinIntrinsicWidth(100), 28);
+      expect(renderBox.getMaxIntrinsicWidth(100), 28);
+      expect(renderBox.getMinIntrinsicHeight(100), 22);
+      expect(renderBox.getMaxIntrinsicHeight(100), 22);
+      expect(
+        tester
+            .renderObject<_RenderBaselineRecorder>(
+              find.byType(_BaselineRecorder),
+            )
+            .baseline,
+        9,
+      );
+      expect(
+        renderBox.getDryBaseline(
+          const BoxConstraints(maxWidth: 100, maxHeight: 100),
+          TextBaseline.alphabetic,
+        ),
+        9,
+      );
+    });
+
+    testWidgets('hit tests painted child overflow outside the footprint', (
+      tester,
+    ) async {
+      var taps = 0;
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Center(
+            child: RemixBoxAdapter(
+              styleSpec: const StyleSpec(
+                spec: BoxSpec(margin: EdgeInsets.symmetric(horizontal: -10)),
+              ),
+              child: GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                onTap: () => taps += 1,
+                child: const SizedBox(
+                  key: ValueKey('overflow-hit-child'),
+                  width: 40,
+                  height: 20,
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final renderBox = _negativeMarginRenderBox(tester);
+      final footprintTopLeft = renderBox.localToGlobal(Offset.zero);
+      final childRect = tester.getRect(
+        find.byKey(const ValueKey('overflow-hit-child')),
+      );
+      expect(childRect.left, lessThan(footprintTopLeft.dx));
+
+      await tester.tapAt(Offset(childRect.left + 2, childRect.center.dy));
+      expect(taps, 1);
+    });
+
+    testWidgets('semantic bounds exclude visual-only paint overflow', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Center(
+            child: RemixBoxAdapter(
+              styleSpec: const StyleSpec(
+                spec: BoxSpec(margin: EdgeInsets.symmetric(horizontal: -5)),
+              ),
+              child: const _OverflowPaintBox(),
+            ),
+          ),
+        ),
+      );
+
+      final renderBox = _negativeMarginRenderBox(tester);
+      expect(renderBox.size, const Size(10, 10));
+      expect(renderBox.paintBounds, const Rect.fromLTRB(-35, -30, 45, 40));
+      expect(renderBox.semanticBounds, const Rect.fromLTRB(-5, 0, 15, 10));
+    });
+
     testWidgets('clips content while preserving hit testing and semantics', (
       tester,
     ) async {
@@ -694,66 +1147,67 @@ void main() {
       });
     }
 
-    testWidgets('applies outer Flex and nested Box metadata exactly once', (
-      tester,
-    ) async {
-      final outerAnimation = AnimationConfig.linear(
-        const Duration(milliseconds: 100),
-      );
-      final innerAnimation = AnimationConfig.linear(
-        const Duration(milliseconds: 200),
-      );
-      await tester.pumpWidget(
-        Directionality(
-          textDirection: TextDirection.ltr,
-          child: RemixFlexBoxAdapter(
-            styleSpec: StyleSpec(
-              spec: FlexBoxSpec(
-                box: StyleSpec(
-                  spec: const BoxSpec(decoration: BoxDecoration()),
-                  animation: innerAnimation,
-                  widgetModifiers: const [OpacityModifier(0.6)],
+    for (final advanced in [false, true]) {
+      testWidgets('applies outer Flex and nested Box metadata exactly once on '
+          'the ${advanced ? 'advanced' : 'ordinary'} route', (tester) async {
+        final outerAnimation = AnimationConfig.linear(
+          const Duration(milliseconds: 100),
+        );
+        final innerAnimation = AnimationConfig.linear(
+          const Duration(milliseconds: 200),
+        );
+        await tester.pumpWidget(
+          Directionality(
+            textDirection: TextDirection.ltr,
+            child: RemixFlexBoxAdapter(
+              styleSpec: StyleSpec(
+                spec: FlexBoxSpec(
+                  box: StyleSpec(
+                    spec: const BoxSpec(decoration: BoxDecoration()),
+                    animation: innerAnimation,
+                    widgetModifiers: const [OpacityModifier(0.6)],
+                  ),
                 ),
+                animation: outerAnimation,
+                widgetModifiers: const [OpacityModifier(0.8)],
               ),
-              animation: outerAnimation,
-              widgetModifiers: const [OpacityModifier(0.8)],
+              direction: Axis.horizontal,
+              containerEffects: advanced
+                  ? const RemixBoxEffectsSpec(
+                      outline: BorderSide(color: Colors.red, width: 1),
+                    )
+                  : null,
+              children: const [SizedBox.square(dimension: 10)],
             ),
-            direction: Axis.horizontal,
-            containerEffects: const RemixBoxEffectsSpec(
-              outline: BorderSide(color: Colors.red, width: 1),
-            ),
-            children: const [SizedBox.square(dimension: 10)],
           ),
-        ),
-      );
+        );
 
-      final opacities = tester
-          .widgetList<Opacity>(find.byType(Opacity))
-          .map((widget) => widget.opacity)
-          .toList();
-      expect(opacities, hasLength(2));
-      expect(opacities, containsAll(<double>[0.6, 0.8]));
-      expect(
-        tester
-            .widgetList<StyleSpecProvider<FlexBoxSpec>>(
-              find.byType(StyleSpecProvider<FlexBoxSpec>),
-            )
-            .where((provider) => provider.spec.animation == outerAnimation),
-        hasLength(1),
-      );
-      expect(
-        tester
-            .widgetList<StyleSpecProvider<BoxSpec>>(
-              find.byType(StyleSpecProvider<BoxSpec>),
-            )
-            .where((provider) => provider.spec.animation == innerAnimation),
-        hasLength(1),
-      );
-    });
+        final opacities = tester
+            .widgetList<Opacity>(find.byType(Opacity))
+            .map((widget) => widget.opacity)
+            .toList();
+        expect(opacities, hasLength(2));
+        expect(opacities, containsAll(<double>[0.6, 0.8]));
+        expect(
+          tester
+              .widgetList<StyleSpecProvider<FlexBoxSpec>>(
+                find.byType(StyleSpecProvider<FlexBoxSpec>),
+              )
+              .where((provider) => provider.spec.animation == outerAnimation),
+          hasLength(1),
+        );
+        expect(
+          tester
+              .widgetList<StyleSpecProvider<BoxSpec>>(
+                find.byType(StyleSpecProvider<BoxSpec>),
+              )
+              .where((provider) => provider.spec.animation == innerAnimation),
+          hasLength(1),
+        );
+      });
+    }
 
-    testWidgets('retains the forced and styled Flex direction assertion', (
-      tester,
-    ) async {
+    testWidgets('uses Mix forced-direction validation', (tester) async {
       await tester.pumpWidget(
         Directionality(
           textDirection: TextDirection.ltr,
@@ -776,8 +1230,162 @@ void main() {
       expect(exception, isA<AssertionError>());
       expect(
         exception.toString(),
-        contains('forced and styled flex directions must agree'),
+        contains('Direction cannot be specified in the spec for RowBox'),
       );
     });
   });
+}
+
+RenderBox _negativeMarginRenderBox(WidgetTester tester) {
+  final finder = find.byWidgetPredicate(
+    (widget) => widget.runtimeType.toString() == '_RemixNegativeMargin',
+  );
+  expect(finder, findsOneWidget);
+  return tester.renderObject<RenderBox>(finder);
+}
+
+final class _ProbeLifecycle {
+  int initCount = 0;
+  int disposeCount = 0;
+}
+
+final class _MutableStateProbe extends StatefulWidget {
+  const _MutableStateProbe({super.key, required this.lifecycle});
+
+  static const tapKey = ValueKey('mutable-state-probe');
+
+  final _ProbeLifecycle lifecycle;
+
+  @override
+  State<_MutableStateProbe> createState() => _MutableStateProbeState();
+}
+
+final class _MutableStateProbeState extends State<_MutableStateProbe> {
+  var _value = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    widget.lifecycle.initCount += 1;
+  }
+
+  @override
+  void dispose() {
+    widget.lifecycle.disposeCount += 1;
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => GestureDetector(
+    key: _MutableStateProbe.tapKey,
+    behavior: HitTestBehavior.opaque,
+    onTap: () => setState(() => _value += 1),
+    child: Text('value: $_value'),
+  );
+}
+
+final class _FocusProbe extends StatefulWidget {
+  const _FocusProbe({required this.onCreate, required this.onDispose});
+
+  final ValueChanged<FocusNode> onCreate;
+  final VoidCallback onDispose;
+
+  @override
+  State<_FocusProbe> createState() => _FocusProbeState();
+}
+
+final class _FocusProbeState extends State<_FocusProbe> {
+  late final FocusNode _focusNode;
+
+  @override
+  void initState() {
+    super.initState();
+    _focusNode = FocusNode();
+    widget.onCreate(_focusNode);
+  }
+
+  @override
+  void dispose() {
+    _focusNode.dispose();
+    widget.onDispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) =>
+      Focus(focusNode: _focusNode, child: const SizedBox.square(dimension: 20));
+}
+
+final class _OverflowPaintBox extends LeafRenderObjectWidget {
+  const _OverflowPaintBox();
+
+  @override
+  RenderObject createRenderObject(BuildContext context) =>
+      _RenderOverflowPaintBox();
+}
+
+final class _TestBaselineBox extends LeafRenderObjectWidget {
+  const _TestBaselineBox();
+
+  @override
+  RenderObject createRenderObject(BuildContext context) =>
+      _RenderTestBaselineBox();
+}
+
+final class _BaselineRecorder extends SingleChildRenderObjectWidget {
+  const _BaselineRecorder({required super.child});
+
+  @override
+  RenderObject createRenderObject(BuildContext context) =>
+      _RenderBaselineRecorder();
+}
+
+final class _RenderBaselineRecorder extends RenderProxyBox {
+  double? baseline;
+
+  @override
+  void performLayout() {
+    child!.layout(constraints.loosen(), parentUsesSize: true);
+    size = constraints.constrain(child!.size);
+    baseline = child!.getDistanceToBaseline(TextBaseline.alphabetic);
+  }
+}
+
+final class _RenderOverflowPaintBox extends RenderBox {
+  @override
+  void performLayout() {
+    size = constraints.constrain(const Size(20, 10));
+  }
+
+  @override
+  Rect get paintBounds =>
+      Rect.fromLTRB(-30, -30, size.width + 30, size.height + 30);
+}
+
+final class _RenderTestBaselineBox extends RenderBox {
+  @override
+  void performLayout() {
+    size = constraints.constrain(const Size(30, 20));
+  }
+
+  @override
+  double computeMinIntrinsicWidth(double height) => 30;
+
+  @override
+  double computeMaxIntrinsicWidth(double height) => 30;
+
+  @override
+  double computeMinIntrinsicHeight(double width) => 20;
+
+  @override
+  double computeMaxIntrinsicHeight(double width) => 20;
+
+  @override
+  double? computeDistanceToActualBaseline(TextBaseline baseline) => 12;
+
+  @override
+  double? computeDryBaseline(
+    covariant BoxConstraints constraints,
+    TextBaseline baseline,
+  ) => 12;
 }

--- a/packages/remix/test/rendering/remix_box_effects_test.dart
+++ b/packages/remix/test/rendering/remix_box_effects_test.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:remix/remix.dart';
 import 'package:remix/src/rendering/remix_box_effects.dart'
-    show RemixBoxWithEffects, RemixFlexBoxWithEffects;
+    show RemixBoxAdapter, RemixFlexBoxAdapter;
 
 void main() {
   group('RemixBoxEffectsSpec', () {
@@ -22,7 +22,7 @@ void main() {
       await tester.pumpWidget(
         Directionality(
           textDirection: TextDirection.ltr,
-          child: RemixBoxWithEffects(
+          child: RemixBoxAdapter(
             styleSpec: const StyleSpec(spec: BoxSpec()),
             containerEffects: const RemixBoxEffectsSpec(
               backdropBlur: double.infinity,
@@ -105,7 +105,7 @@ void main() {
         await tester.pumpWidget(
           Directionality(
             textDirection: TextDirection.ltr,
-            child: RemixBoxWithEffects(
+            child: RemixBoxAdapter(
               styleSpec: const StyleSpec(spec: BoxSpec()),
               containerEffects: effects,
             ),
@@ -148,7 +148,7 @@ void main() {
     testWidgets('rejects outline stroke alignment other than inside', (
       tester,
     ) async {
-      Widget build(double strokeAlign) => RemixBoxWithEffects(
+      Widget build(double strokeAlign) => RemixBoxAdapter(
         styleSpec: const StyleSpec(spec: BoxSpec(decoration: BoxDecoration())),
         containerEffects: RemixBoxEffectsSpec(
           outline: BorderSide(strokeAlign: strokeAlign),
@@ -210,7 +210,7 @@ void main() {
       await tester.pumpWidget(
         Directionality(
           textDirection: TextDirection.ltr,
-          child: RemixBoxWithEffects(
+          child: RemixBoxAdapter(
             styleSpec: const StyleSpec(spec: BoxSpec()),
             child: const SizedBox.square(dimension: 12),
           ),
@@ -229,13 +229,13 @@ void main() {
           textDirection: TextDirection.ltr,
           child: Column(
             children: [
-              RemixBoxWithEffects(
+              RemixBoxAdapter(
                 styleSpec: const StyleSpec(spec: BoxSpec()),
                 containerEffects: const RemixBoxEffectsSpec(
                   behindContent: RemixBoxEffectLayerSpec(),
                 ),
               ),
-              RemixFlexBoxWithEffects(
+              RemixFlexBoxAdapter(
                 styleSpec: const StyleSpec(spec: FlexBoxSpec()),
                 direction: Axis.horizontal,
                 containerEffects: const RemixBoxEffectsSpec(
@@ -252,13 +252,93 @@ void main() {
       expect(find.byType(CustomPaint), findsNothing);
     });
 
+    testWidgets('keeps the real Mix Box for an effects-free negative margin', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Center(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                SizedBox(
+                  key: const ValueKey('negative-footprint'),
+                  child: RemixBoxAdapter(
+                    styleSpec: const StyleSpec(
+                      spec: BoxSpec(
+                        padding: EdgeInsets.symmetric(
+                          horizontal: 8,
+                          vertical: 4,
+                        ),
+                        margin: EdgeInsets.symmetric(
+                          horizontal: -8,
+                          vertical: -4,
+                        ),
+                        decoration: ShapeDecoration(
+                          color: Colors.blue,
+                          shape: StadiumBorder(),
+                        ),
+                      ),
+                    ),
+                    child: const SizedBox(width: 20, height: 10),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(Box), findsOneWidget);
+      expect(find.byType(CustomPaint), findsNothing);
+      expect(tester.takeException(), isNull);
+      expect(
+        tester.getSize(find.byKey(const ValueKey('negative-footprint'))),
+        const Size(20, 10),
+      );
+    });
+
+    testWidgets('keeps a real Mix Box around negative-margin Flex content', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Center(
+            child: RemixFlexBoxAdapter(
+              styleSpec: const StyleSpec(
+                spec: FlexBoxSpec(
+                  box: StyleSpec(
+                    spec: BoxSpec(
+                      margin: EdgeInsets.all(-4),
+                      padding: EdgeInsets.all(4),
+                      decoration: BoxDecoration(),
+                    ),
+                  ),
+                  flex: StyleSpec(spec: FlexSpec(direction: Axis.horizontal)),
+                ),
+              ),
+              direction: Axis.horizontal,
+              children: const [SizedBox.square(dimension: 12)],
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(Box), findsOneWidget);
+      expect(find.byType(Flex), findsOneWidget);
+      expect(find.byType(CustomPaint), findsNothing);
+      expect(tester.takeException(), isNull);
+    });
+
     testWidgets('accepts a radius-only rectangular Box decoration', (
       tester,
     ) async {
       await tester.pumpWidget(
         Directionality(
           textDirection: TextDirection.ltr,
-          child: RemixBoxWithEffects(
+          child: RemixBoxAdapter(
             styleSpec: const StyleSpec(
               spec: BoxSpec(
                 decoration: BoxDecoration(
@@ -284,7 +364,7 @@ void main() {
       await tester.pumpWidget(
         Directionality(
           textDirection: TextDirection.ltr,
-          child: RemixBoxWithEffects(
+          child: RemixBoxAdapter(
             styleSpec: const StyleSpec(spec: BoxSpec()),
             containerEffects: const RemixBoxEffectsSpec(
               outline: BorderSide(color: Colors.green, width: 2),
@@ -308,7 +388,7 @@ void main() {
         await tester.pumpWidget(
           Directionality(
             textDirection: TextDirection.ltr,
-            child: RemixBoxWithEffects(
+            child: RemixBoxAdapter(
               styleSpec: StyleSpec(spec: BoxSpec(decoration: invalid)),
               containerEffects: RemixBoxEffectsSpec(backdropBlur: 1),
               child: const SizedBox.square(dimension: 20),
@@ -363,7 +443,7 @@ void main() {
                 key: const ValueKey('effects-host'),
                 width: 100,
                 height: 80,
-                child: RemixBoxWithEffects(
+                child: RemixBoxAdapter(
                   styleSpec: spec,
                   containerEffects: const RemixBoxEffectsSpec(
                     behindContent: RemixBoxEffectLayerSpec(
@@ -412,7 +492,7 @@ void main() {
             children: [
               SizedBox(
                 key: const ValueKey('negative-footprint'),
-                child: RemixBoxWithEffects(
+                child: RemixBoxAdapter(
                   styleSpec: const StyleSpec(
                     spec: BoxSpec(
                       padding: EdgeInsets.symmetric(horizontal: 8, vertical: 4),
@@ -433,7 +513,7 @@ void main() {
                   child: const SizedBox(width: 20, height: 10),
                 ),
               ),
-              RemixBoxWithEffects(
+              RemixBoxAdapter(
                 key: const ValueKey('null-child'),
                 styleSpec: const StyleSpec(
                   spec: BoxSpec(
@@ -468,7 +548,7 @@ void main() {
         Directionality(
           textDirection: TextDirection.ltr,
           child: Center(
-            child: RemixBoxWithEffects(
+            child: RemixBoxAdapter(
               styleSpec: const StyleSpec(
                 spec: BoxSpec(
                   constraints: BoxConstraints.tightFor(width: 30, height: 20),
@@ -521,7 +601,7 @@ void main() {
       await tester.pumpWidget(
         Directionality(
           textDirection: TextDirection.ltr,
-          child: RemixBoxWithEffects(
+          child: RemixBoxAdapter(
             styleSpec: const StyleSpec(
               spec: BoxSpec(
                 clipBehavior: Clip.hardEdge,
@@ -565,7 +645,7 @@ void main() {
         Widget build(double width) => Directionality(
           textDirection: TextDirection.ltr,
           child: Center(
-            child: RemixBoxWithEffects(
+            child: RemixBoxAdapter(
               key: const ValueKey('animated-box'),
               styleSpec: StyleSpec(
                 spec: BoxSpec(
@@ -626,7 +706,7 @@ void main() {
       await tester.pumpWidget(
         Directionality(
           textDirection: TextDirection.ltr,
-          child: RemixFlexBoxWithEffects(
+          child: RemixFlexBoxAdapter(
             styleSpec: StyleSpec(
               spec: FlexBoxSpec(
                 box: StyleSpec(
@@ -677,7 +757,7 @@ void main() {
       await tester.pumpWidget(
         Directionality(
           textDirection: TextDirection.ltr,
-          child: RemixFlexBoxWithEffects(
+          child: RemixFlexBoxAdapter(
             styleSpec: const StyleSpec(
               spec: FlexBoxSpec(
                 box: StyleSpec(spec: BoxSpec(decoration: BoxDecoration())),

--- a/packages/remix_fortal/lib/src/fortal/fortal.dart
+++ b/packages/remix_fortal/lib/src/fortal/fortal.dart
@@ -6,6 +6,7 @@ export '../radix/colors/colors.dart';
 // Computed helpers and shared types
 export 'computed.dart';
 export 'base_button_recipe.dart';
+export 'surface_frame.dart';
 // Theme tokens and scope builder (consolidated)
 export 'fortal_theme.dart';
 

--- a/packages/remix_fortal/lib/src/fortal/surface_frame.dart
+++ b/packages/remix_fortal/lib/src/fortal/surface_frame.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/widgets.dart';
+import 'package:remix/remix.dart';
+
+/// Builds a rounded panel whose visible frame paints above its children.
+///
+/// Composite surfaces often contain edge-to-edge child backgrounds. A regular
+/// [BoxDecoration] border paints behind those children, so their antialiased
+/// rounded edges can partially cover the frame. This keeps the fill and clip on
+/// the background decoration, reserves the same inset explicitly, and paints
+/// the frame through the container's foreground decoration.
+BoxStyler fortalSurfaceFrame({
+  required Color fillColor,
+  required Color borderColor,
+  required double borderWidth,
+  required Radius radius,
+}) {
+  final borderRadius = BorderRadiusMix.all(radius);
+  return BoxStyler()
+      .color(fillColor)
+      .padding(.all(borderWidth))
+      .borderRadius(borderRadius)
+      .clipBehavior(.antiAlias)
+      .foregroundDecoration(
+        BoxDecorationMix(
+          border: BoxBorderMix.all(
+            BorderSideMix(color: borderColor, width: borderWidth),
+          ),
+          borderRadius: borderRadius,
+        ),
+      );
+}

--- a/packages/remix_fortal/lib/src/recipes/accordion.dart
+++ b/packages/remix_fortal/lib/src/recipes/accordion.dart
@@ -26,16 +26,12 @@ AccordionStyler fortalAccordionStyle({
 }
 
 // Panel anatomy follows the mapped Table family (see data_table.dart):
-// `container` alone owns radius, border, fill, and clipping, while trigger
-// and content stay flat rectangles that simply get cropped to its rounded
-// shape. That is what lets an expanded trigger meet its content with no
-// corner notch — neither part rounds its own corners, so there is no curve
-// for the divider to miss. The divider itself is a foreground border (see
-// `_fortalAccordionBorderSide`), matching the Table row divider technique so
-// it paints without insetting content by a pixel.
+// `container` alone owns radius, frame, fill, and clipping, while trigger and
+// content stay flat rectangles that simply get cropped to its rounded shape.
+// The frame and divider are foreground borders so edge-to-edge child fills
+// cannot partially cover their antialiased edges.
 AccordionStyler _fortalAccordionBaseStyler(FortalAccordionSize size) {
   return AccordionStyler()
-      .container(.clipBehavior(.antiAlias))
       .trigger(.direction(.horizontal))
       .leadingIcon(.color(FortalTokens.gray11()))
       .title(
@@ -65,9 +61,12 @@ AccordionStyler _fortalAccordionSurfaceStyler([
 ]) {
   return _fortalAccordionBaseStyler(size)
       .container(
-        .color(
-          FortalTokens.gray2(),
-        ).border(.all(_fortalAccordionBorderSide(FortalTokens.gray6()))),
+        fortalSurfaceFrame(
+          fillColor: FortalTokens.gray2(),
+          borderColor: FortalTokens.gray6(),
+          borderWidth: FortalTokens.borderWidth1(),
+          radius: _fortalAccordionRadius(size),
+        ),
       )
       .trigger(.color(FortalTokens.gray1()))
       .content(
@@ -92,9 +91,12 @@ AccordionStyler _fortalAccordionSoftStyler([
 ]) {
   return _fortalAccordionBaseStyler(size)
       .container(
-        .color(
-          FortalTokens.accent2(),
-        ).border(.all(_fortalAccordionBorderSide(FortalTokens.accent6()))),
+        fortalSurfaceFrame(
+          fillColor: FortalTokens.accent2(),
+          borderColor: FortalTokens.accent6(),
+          borderWidth: FortalTokens.borderWidth1(),
+          radius: _fortalAccordionRadius(size),
+        ),
       )
       .trigger(.color(FortalTokens.accent2()))
       .title(.color(FortalTokens.accent12()))
@@ -134,7 +136,6 @@ WidgetModifierConfig _fortalAccordionContentTypography(Color color) =>
 AccordionStyler _fortalAccordionSizeStyler(FortalAccordionSize size) {
   return switch (size) {
     .size1 => AccordionStyler(
-      container: .borderRadius(.all(FortalTokens.radius3())),
       trigger: FlexBoxStyler().padding(.all(FortalTokens.space2())),
       leadingIcon: .size(FortalTokens.space4()),
       title: .style(FortalTokens.text2.mix()),
@@ -142,7 +143,6 @@ AccordionStyler _fortalAccordionSizeStyler(FortalAccordionSize size) {
       content: .padding(.all(FortalTokens.space2())),
     ),
     .size2 => AccordionStyler(
-      container: .borderRadius(.all(FortalTokens.radius4())),
       trigger: FlexBoxStyler().padding(.all(FortalTokens.space3())),
       leadingIcon: .size(FortalTokens.spinnerSize3()),
       title: .style(FortalTokens.accordionText2.mix()),
@@ -150,7 +150,6 @@ AccordionStyler _fortalAccordionSizeStyler(FortalAccordionSize size) {
       content: .padding(.all(FortalTokens.space3())),
     ),
     .size3 => AccordionStyler(
-      container: .borderRadius(.all(FortalTokens.radius5())),
       trigger: FlexBoxStyler().padding(.all(FortalTokens.space4())),
       leadingIcon: .size(FortalTokens.space5()),
       title: .style(FortalTokens.text3.mix()),
@@ -159,3 +158,9 @@ AccordionStyler _fortalAccordionSizeStyler(FortalAccordionSize size) {
     ),
   };
 }
+
+Radius _fortalAccordionRadius(FortalAccordionSize size) => switch (size) {
+  .size1 => FortalTokens.radius3(),
+  .size2 => FortalTokens.radius4(),
+  .size3 => FortalTokens.radius5(),
+};

--- a/packages/remix_fortal/lib/src/recipes/data_table.dart
+++ b/packages/remix_fortal/lib/src/recipes/data_table.dart
@@ -150,14 +150,14 @@ FlexBoxStyler _fortalDataTableFooter() => FlexBoxStyler()
 
 DataTableStyler _fortalDataTableSurface(DataTableStyler base, Radius radius) {
   return base
-      .color(FortalTokens.colorPanel())
-      .border(
-        BoxBorderMix.all(
-          BorderSideMix(color: FortalTokens.dataTableBorder(), width: 1),
+      .container(
+        fortalSurfaceFrame(
+          fillColor: FortalTokens.colorPanel(),
+          borderColor: FortalTokens.dataTableBorder(),
+          borderWidth: FortalTokens.borderWidth1(),
+          radius: radius,
         ),
       )
-      .borderRadius(.all(radius))
-      .clipBehavior(Clip.antiAlias)
       .containerEffects(
         RemixBoxEffectsMix.backdropBlur(FortalTokens.panelBlur()),
       )

--- a/packages/remix_fortal/test/components/accordion/accordion_widget_test.dart
+++ b/packages/remix_fortal/test/components/accordion/accordion_widget_test.dart
@@ -7,7 +7,7 @@ import '../../helpers/test_helpers.dart';
 
 // Panel anatomy derives from the mapped Table family (see
 // packages/remix_fortal/lib/src/recipes/data_table.dart): the container owns
-// radius, border, fill, and clipping so the trigger and content crop into
+// radius, foreground frame, fill, and clipping so the trigger and content crop into
 // one rounded shape instead of each rounding their own corners. These tests
 // pin that contract directly, plus the content font size that keeps a
 // passage from ever reading larger than its own title.
@@ -34,14 +34,17 @@ void main() {
     ) async {
       final tokens = await _tokens(tester);
       final spec = await _resolve(tester, fortalAccordionStyle());
-      final border = _border(spec.container.spec);
+      final box = spec.container.spec;
+      final border = _foregroundBorder(box);
 
       expect(border?.top.color, tokens.gray6);
       expect(border?.top.width, 1);
-      // A regular (inset) border, unlike the foreground divider between
-      // trigger and content: it insets the whole panel uniformly instead of
-      // eating into one child's own padding.
-      expect(spec.container.spec.decoration, isA<BoxDecoration>());
+      expect((box.decoration as BoxDecoration).border, isNull);
+      expect(box.padding, const EdgeInsets.all(1));
+      expect(
+        (box.foregroundDecoration as BoxDecoration).borderRadius,
+        (box.decoration as BoxDecoration).borderRadius,
+      );
     });
 
     testWidgets('soft container carries the accent panel border', (
@@ -49,7 +52,7 @@ void main() {
     ) async {
       final tokens = await _tokens(tester);
       final spec = await _resolve(tester, fortalAccordionStyle(variant: .soft));
-      final border = _border(spec.container.spec);
+      final border = _foregroundBorder(spec.container.spec);
 
       expect(border?.top.color, tokens.accent6);
     });
@@ -105,8 +108,8 @@ void main() {
           .spec;
       final containerDecoration = containerSpec.decoration as BoxDecoration;
 
-      // The container is the single ancestor whose decoration carries the
-      // panel's border and radius, above both the trigger and the content.
+      // The container is the single decorated ancestor above both the trigger
+      // and content; its foreground decoration carries the visible frame.
       final containerBoxes = find.byWidgetPredicate(
         (widget) =>
             widget is DecoratedBox && widget.decoration == containerDecoration,
@@ -158,8 +161,8 @@ DefaultTextStyleModifier _defaultTextStyleModifier(StyleSpec<BoxSpec> box) {
       .single;
 }
 
-Border? _border(BoxSpec box) =>
-    (box.decoration as BoxDecoration?)?.border as Border?;
+Border? _foregroundBorder(BoxSpec box) =>
+    (box.foregroundDecoration as BoxDecoration?)?.border as Border?;
 
 double _radius(BoxSpec box) => (box.decoration as BoxDecoration).borderRadius!
     .resolve(TextDirection.ltr)

--- a/packages/remix_fortal/test/components/checkbox/checkbox_group_widget_test.dart
+++ b/packages/remix_fortal/test/components/checkbox/checkbox_group_widget_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:remix/remix.dart';
-// `RemixBoxWithEffects` is `@internal` to `remix`, but this sibling package's
+// `RemixBoxAdapter` is `@internal` to `remix`, but this sibling package's
 // tests need it to measure how a Remix component renders a Fortal recipe.
 // Suppressed per-use below, so a future accidental internal-member use still
 // gets flagged.
@@ -40,7 +40,7 @@ void main() {
       );
       expect(
         // ignore: invalid_use_of_internal_member
-        tester.getSize(find.byType(RemixBoxWithEffects)),
+        tester.getSize(find.byType(RemixBoxAdapter)),
         Size.square(entry.value),
         reason: entry.key.name,
       );

--- a/packages/remix_fortal/test/components/checkbox/checkbox_labeled_test.dart
+++ b/packages/remix_fortal/test/components/checkbox/checkbox_labeled_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-// `RemixBoxWithEffects` is `@internal` to `remix`, but this sibling package's
+// `RemixBoxAdapter` is `@internal` to `remix`, but this sibling package's
 // tests need it to measure how a Remix component renders a Fortal recipe.
 // Suppressed per-use below, so a future accidental internal-member use still
 // gets flagged.
@@ -40,7 +40,7 @@ void main() {
         );
         expect(
           // ignore: invalid_use_of_internal_member
-          tester.getSize(find.byType(RemixBoxWithEffects)),
+          tester.getSize(find.byType(RemixBoxAdapter)),
           Size.square(entry.value),
           reason: entry.key.name,
         );

--- a/packages/remix_fortal/test/components/data_table/data_table_fortal_parity_test.dart
+++ b/packages/remix_fortal/test/components/data_table/data_table_fortal_parity_test.dart
@@ -113,7 +113,7 @@ void main() {
   });
 
   group('variants', () {
-    testWidgets('surface uses the panel, the mixed border, and gray-a2', (
+    testWidgets('surface uses a foreground frame above the panel and rows', (
       tester,
     ) async {
       final tokens = await _tokens(tester);
@@ -122,10 +122,16 @@ void main() {
         fortalDataTableStyle(variant: .surface),
       );
       final container = spec.container.spec.decoration! as BoxDecoration;
+      final foreground =
+          spec.container.spec.foregroundDecoration! as BoxDecoration;
+      final border = foreground.border! as Border;
 
       expect(container.color, tokens.panel);
-      expect((container.border! as Border).top.color, tokens.tableBorder);
-      expect((container.border! as Border).top.width, 1);
+      expect(container.border, isNull);
+      expect(border.top.color, tokens.tableBorder);
+      expect(border.top.width, 1);
+      expect(spec.container.spec.padding, const EdgeInsets.all(1));
+      expect(foreground.borderRadius, container.borderRadius);
       expect(spec.container.spec.clipBehavior, Clip.antiAlias);
       expect(_color(spec.headerRow), tokens.grayA2);
     });

--- a/packages/remix_fortal/test/public_api_test.dart
+++ b/packages/remix_fortal/test/public_api_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mix_chart/mix_chart.dart';
 import 'package:remix/remix.dart';

--- a/packages/remix_fortal/test/public_api_test.dart
+++ b/packages/remix_fortal/test/public_api_test.dart
@@ -6,6 +6,17 @@ import 'package:remix_fortal/remix_fortal.dart';
 import 'helpers/test_helpers.dart';
 
 void main() {
+  test('the Fortal surface frame helper is public', () {
+    final frame = fortalSurfaceFrame(
+      fillColor: const Color(0xFFFFFFFF),
+      borderColor: const Color(0xFF000000),
+      borderWidth: 1,
+      radius: const Radius.circular(8),
+    );
+
+    expect(frame, isA<BoxStyler>());
+  });
+
   test('new Fortal controls expose generated public wrappers', () {
     const segmented = FortalSegmentedControl<String>.classic(
       items: [RemixSegmentedControlItem(value: 'one', label: 'One')],


### PR DESCRIPTION
## Description

Refactors the shared Remix box-effects path so ordinary surfaces stay on real Mix `Box` and Flex widgets, while advanced paint and CSS-style negative margins use focused internal renderers. Descendant state and focus now survive renderer-route changes, Flex defaults and validation come from Mix, and negative-margin semantic bounds exclude visual-only paint overflow.

Also moves existing composite components onto the shared adapters and introduces `fortalSurfaceFrame` so reusable Fortal panels paint their frame above edge-to-edge child backgrounds. This PR contains no Disclosure component code and is intended to land before #164.

## Related Issues

None.

## Validation

- `fvm flutter test test/rendering/remix_box_effects_test.dart test/rendering/remix_box_effects_pixel_test.dart test/components/checkbox/checkbox_group_widget_test.dart test/components/link/link_focus_ring_test.dart test/components/slider/slider_widget_test.dart` — passed, 170 tests
- Focused Fortal accordion, checkbox, data-table, and public API tests — passed, 48 tests
- `fvm flutter analyze --fatal-infos` in `packages/remix` and `packages/remix_fortal` — passed
- `fvm dart run melos run ci` — passed; Remix 2697, Fortal 390, demo 30, dashboard 56 tests, plus toolchain, generation, docs, material-independence, and parity checks

---

## Checklist

**Note**: Updating the `pubspec.yaml` and `CHANGELOG.md` is not required. These are handled automatically during the release process.

- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors.
- [x] I have updated or added relevant documentation (doc comments with `///`).
- [ ] I am prepared to follow up on review comments in a timely manner.

## Breaking Change

Does this PR require users of the package to manually update their code?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.
